### PR TITLE
Clean CloudWatch log group once the validation is done

### DIFF
--- a/integ/integ.sh
+++ b/integ/integ.sh
@@ -85,7 +85,7 @@ fi
 
 if [ "${1}" = "cicd" ]; then
 	source ./integ/resources/setup_test_environment.sh
-	clean_cloudwatch && test_cloudwatch
+    test_cloudwatch && clean_cloudwatch
 	clean_s3 && test_kinesis
 fi
 


### PR DESCRIPTION
*Description of changes:*
When running the CI/CD call test_cloudwatch before clean_cloudwatch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
