### PR TITLE
Update Cloudwatch integ test exit logic

### DIFF
--- a/integ/integ.sh
+++ b/integ/integ.sh
@@ -9,9 +9,20 @@ test_cloudwatch() {
 	docker-compose --file ./integ/test_cloudwatch/docker-compose.test.yml build
 	docker-compose --file ./integ/test_cloudwatch/docker-compose.test.yml up --abort-on-container-exit
 	sleep 10
+
+	# Creates a file as a flag for the validation failure
+	mkdir -p ./integ/out
+	touch ./integ/out/cloudwatch-test
+
 	# Validate that log data is present in CW
 	docker-compose --file ./integ/test_cloudwatch/docker-compose.validate.yml build
 	docker-compose --file ./integ/test_cloudwatch/docker-compose.validate.yml up --abort-on-container-exit
+
+	if [ -f ./integ/out/cloudwatch-test ]; then
+		# if the file still exists, test failed
+		echo "Test Failed for Cloudwatch."
+		exit 1
+	fi
 }
 
 clean_cloudwatch() {
@@ -56,15 +67,8 @@ clean_s3() {
 }
 
 if [ "${1}" = "cloudwatch" ]; then
-	mkdir -p ./integ/out
-	touch ./integ/out/cloudwatch-test
 	test_cloudwatch
 	clean_cloudwatch
-	if [ -f ./integ/out/cloudwatch-test ]; then
-		# if the file still exists, test failed
-		echo "Test Failed."
-		exit 1
-	fi
 fi
 
 if [ "${1}" = "clean-cloudwatch" ]; then

--- a/integ/integ.sh
+++ b/integ/integ.sh
@@ -17,12 +17,6 @@ test_cloudwatch() {
 	# Validate that log data is present in CW
 	docker-compose --file ./integ/test_cloudwatch/docker-compose.validate.yml build
 	docker-compose --file ./integ/test_cloudwatch/docker-compose.validate.yml up --abort-on-container-exit
-
-	if [ -f ./integ/out/cloudwatch-test ]; then
-		# if the file still exists, test failed
-		echo "Test Failed for Cloudwatch."
-		exit 1
-	fi
 }
 
 clean_cloudwatch() {
@@ -69,6 +63,12 @@ clean_s3() {
 if [ "${1}" = "cloudwatch" ]; then
 	test_cloudwatch
 	clean_cloudwatch
+
+	if [ -f ./integ/out/cloudwatch-test ]; then
+		# if the file still exists, test failed
+		echo "Test Failed for Cloudwatch."
+		exit 1
+	fi
 fi
 
 if [ "${1}" = "clean-cloudwatch" ]; then

--- a/integ/integ.sh
+++ b/integ/integ.sh
@@ -88,8 +88,14 @@ if [ "${1}" = "clean-s3" ]; then
 fi
 
 if [ "${1}" = "cicd" ]; then
-	source ./integ/resources/setup_test_environment.sh
     test_cloudwatch && clean_cloudwatch
+	if [ -f ./integ/out/cloudwatch-test ]; then
+		# if the file still exists, test failed
+		echo "Test Failed for Cloudwatch."
+		exit 1
+	fi
+
+	source ./integ/resources/setup_test_environment.sh
 	clean_s3 && test_kinesis
 fi
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Though the cloudwatch integ test passes successfully, it is throwing an exception- file not found. It should exit with code zero. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
