### PR TITLE
Bugfix: change entrypoint from 'exec -c' to 'exec'

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,4 +3,4 @@ tput bold;
 echo -n "AWS for Fluent Bit Container Image Version "
 cat /AWS_FOR_FLUENT_BIT_VERSION
 tput sgr0;
-exec -c /fluent-bit/bin/fluent-bit -e /fluent-bit/firehose.so -e /fluent-bit/cloudwatch.so -e /fluent-bit/kinesis.so -c /fluent-bit/etc/fluent-bit.conf
+exec /fluent-bit/bin/fluent-bit -e /fluent-bit/firehose.so -e /fluent-bit/cloudwatch.so -e /fluent-bit/kinesis.so -c /fluent-bit/etc/fluent-bit.conf


### PR DESCRIPTION
The -c option for exec deletes the current env, this stops env vars from working. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
