### PR TITLE
Read image version from DockerHub instead of GitHub source

### DIFF
--- a/buildspec_sync.yml
+++ b/buildspec_sync.yml
@@ -8,7 +8,7 @@ phases:
       - echo Sync latest image from Dockerhub
   build:
     commands:
-      - './scripts/publish.sh cicd-publish ap-east-1'
+      - './scripts/publish.sh cicd-publish ${AWS_REGION}'
 
       # Assume role to verify, get the credentials, and set them as environment variables.
       # Verification should be done using the credentials from a different account. It ensures that

--- a/buildspec_sync.yml
+++ b/buildspec_sync.yml
@@ -8,7 +8,7 @@ phases:
       - echo Sync latest image from Dockerhub
   build:
     commands:
-      - './scripts/publish.sh cicd-publish ${AWS_REGION}'
+      - './scripts/publish.sh cicd-publish ap-east-1'
 
       # Assume role to verify, get the credentials, and set them as environment variables.
       # Verification should be done using the credentials from a different account. It ensures that

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -124,7 +124,7 @@ check_parameter() {
 }
 
 sync_latest_image() {
-	LATEST_VERSION= 'curl -s -S "https://registry.hub.docker.com/v2/repositories/amazon/aws-for-fluent-bit/tags/" | jq '."results"[1]["name"]''
+	LATEST_VERSION= 'curl -s -S https://registry.hub.docker.com/v2/repositories/amazon/aws-for-fluent-bit/tags/ | jq '."results"[1]["name"]''
 	echo $LATEST_VERSION
 	region=${1}
 	account_id=${2}

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -124,7 +124,7 @@ check_parameter() {
 }
 
 sync_latest_image() {
-	LATEST_VERSION= 'curl -s -S https://registry.hub.docker.com/v2/repositories/amazon/aws-for-fluent-bit/tags/ | jq '."results"[1]["name"]''
+	LATEST_VERSION='curl -s -S "https://registry.hub.docker.com/v2/repositories/amazon/aws-for-fluent-bit/tags/" | jq '."results"[1]["name"]''
 	echo $LATEST_VERSION
 	region=${1}
 	account_id=${2}

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -19,8 +19,10 @@ cd "${scripts}"
 
 IMAGE_SHA_MATCHED="FALSE"
 AWS_FOR_FLUENT_BIT_VERSION=$(cat ../AWS_FOR_FLUENT_BIT_VERSION)
-AWS_FOR_FLUENT_BIT_VERSION_DOCKERHUB=$(curl -s -S 'https://registry.hub.docker.com/v2/repositories/amazon/aws-for-fluent-bit/tags/' | jq '."results"[1]["name"]' | tr -d '"') 
 
+docker_hub_image_tags=$(curl -s -S 'https://registry.hub.docker.com/v2/repositories/amazon/aws-for-fluent-bit/tags/' | jq -r '.results[].name' | sort -r) 
+tag_array=(`echo ${docker_hub_image_tags}`)
+AWS_FOR_FLUENT_BIT_VERSION_DOCKERHUB=${tag_array[1]}
 
 classic_regions="
 us-east-1

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -38,29 +38,29 @@ eu-west-3
 eu-north-1
 "
 
-classic_regions_account_id="906394416424"
+classic_regions_account_id="803860917211"
 
 cn_regions="
 cn-north-1
 cn-northwest-1
 "
 
-cn_regions_account_id="128054284489"
+cn_regions_account_id="803860917211"
 
 gov_regions="
 us-gov-east-1
 us-gov-west-1
 "
 
-gov_regions_account_id="161423150738"
+gov_regions_account_id="803860917211"
 
 hongkong_region="ap-east-1"
 
-hongkong_account_id="449074385750"
+hongkong_account_id="803860917211"
 
 bahrain_region="me-south-1"
 
-bahrain_account_id="741863432321"
+bahrain_account_id="803860917211"
 
 gamma_region="us-west-2"
 
@@ -124,6 +124,8 @@ check_parameter() {
 }
 
 sync_latest_image() {
+	LATEST_VERSION= 'curl -s -S "https://registry.hub.docker.com/v2/repositories/amazon/aws-for-fluent-bit/tags/" | jq '."results"[1]["name"]''
+	echo $LATEST_VERSION
 	region=${1}
 	account_id=${2}
 	sha1=$(docker pull amazon/aws-for-fluent-bit:latest | grep sha256: | cut -f 3 -d :)
@@ -148,6 +150,7 @@ sync_latest_image() {
 	if [ "$IMAGE_SHA_MATCHED" = "FALSE" ]; then
 		publish_ecr ${region} ${account_id}
 	fi
+
 
 	ssm_parameters=$(aws ssm get-parameters --names "/aws/service/aws-for-fluent-bit/${AWS_FOR_FLUENT_BIT_VERSION}" --region ${region})
 	invalid_parameter=$(echo $ssm_parameters | jq .InvalidParameters[0])

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -124,7 +124,7 @@ check_parameter() {
 }
 
 sync_latest_image() {
-	LATEST_VERSION='curl -s -S "https://registry.hub.docker.com/v2/repositories/amazon/aws-for-fluent-bit/tags/" | jq '."results"[1]["name"]''
+	LATEST_VERSION=$(curl -s -S 'https://registry.hub.docker.com/v2/repositories/amazon/aws-for-fluent-bit/tags/' | jq '."results"[1]["name"]' | tr -d '"') 
 	echo $LATEST_VERSION
 	region=${1}
 	account_id=${2}

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -124,8 +124,6 @@ check_parameter() {
 }
 
 sync_latest_image() {
-	LATEST_VERSION=$(curl -s -S 'https://registry.hub.docker.com/v2/repositories/amazon/aws-for-fluent-bit/tags/' | jq '."results"[1]["name"]' | tr -d '"') 
-	echo $LATEST_VERSION
 	region=${1}
 	account_id=${2}
 	sha1=$(docker pull amazon/aws-for-fluent-bit:latest | grep sha256: | cut -f 3 -d :)
@@ -151,8 +149,8 @@ sync_latest_image() {
 		publish_ecr ${region} ${account_id}
 	fi
 
-
-	ssm_parameters=$(aws ssm get-parameters --names "/aws/service/aws-for-fluent-bit/${AWS_FOR_FLUENT_BIT_VERSION}" --region ${region})
+	LATEST_VERSION=$(curl -s -S 'https://registry.hub.docker.com/v2/repositories/amazon/aws-for-fluent-bit/tags/' | jq '."results"[1]["name"]' | tr -d '"') 
+	ssm_parameters=$(aws ssm get-parameters --names "/aws/service/aws-for-fluent-bit/${LATEST_VERSION}" --region ${region})
 	invalid_parameter=$(echo $ssm_parameters | jq .InvalidParameters[0])
 	if [ "$invalid_parameter" != 'null' ]; then
 		publish_ssm ${region} ${account_id}.dkr.ecr.${region}.${endpoint}/aws-for-fluent-bit

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -41,29 +41,29 @@ eu-west-3
 eu-north-1
 "
 
-classic_regions_account_id="803860917211"
+classic_regions_account_id="906394416424"
 
 cn_regions="
 cn-north-1
 cn-northwest-1
 "
 
-cn_regions_account_id="803860917211"
+cn_regions_account_id="128054284489"
 
 gov_regions="
 us-gov-east-1
 us-gov-west-1
 "
 
-gov_regions_account_id="803860917211"
+gov_regions_account_id="161423150738"
 
 hongkong_region="ap-east-1"
 
-hongkong_account_id="803860917211"
+hongkong_account_id="449074385750"
 
 bahrain_region="me-south-1"
 
-bahrain_account_id="803860917211"
+bahrain_account_id="741863432321"
 
 gamma_region="us-west-2"
 
@@ -89,12 +89,12 @@ publish_to_docker_hub() {
 	# Publish to DockerHub only if $DRY_RUN is set to false
 	if [[ "${DRY_RUN}" == "false" ]]; then
 		docker tag ${1} ${2}
-		#docker push ${1}
-		#docker push ${2}
+		docker push ${1}
+		docker push ${2}
 	else
 		echo "DRY_RUN: docker tag ${1} ${2}"
-		#echo "DRY_RUN: docker push ${1}"
-		#echo "DRY_RUN: docker push ${2}"
+		echo "DRY_RUN: docker push ${1}"
+		echo "DRY_RUN: docker push ${2}"
 		echo "DRY_RUN is NOT set to 'false', skipping DockerHub update. Exiting..."
 	fi
 


### PR DESCRIPTION
*Description of changes:*
For the verification process of our sync task, we were reading the image version from AWS_FOR_FLUENT_BIT_VERSION file of our gitHub source. It was causing the sync task to fail. With this change, we will read our latest image version from DockerHub which will solve the above mentioned problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
