### PR TITLE
Add logrotate and cron

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,9 @@ RUN yum upgrade -y \
           pkgconfig \
           systemd-devel \
           zlib-devel \
-          nc
+          nc \
+          logrotate \
+          crontabs
 
 COPY --from=builder /fluent-bit /fluent-bit
 COPY --from=aws-fluent-bit-plugins:latest /kinesis-streams/bin/kinesis.so /fluent-bit/kinesis.so

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,7 @@ RUN yum upgrade -y \
           zlib-devel \
           nc \
           logrotate \
+          cronie \
           crontabs
 
 COPY --from=builder /fluent-bit /fluent-bit

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,4 +3,5 @@ tput bold;
 echo -n "AWS for Fluent Bit Container Image Version "
 cat /AWS_FOR_FLUENT_BIT_VERSION
 tput sgr0;
+exec crond
 exec /fluent-bit/bin/fluent-bit -e /fluent-bit/firehose.so -e /fluent-bit/cloudwatch.so -e /fluent-bit/kinesis.so -c /fluent-bit/etc/fluent-bit.conf


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I have added the following packages:
- logrotate - A log rotation utility
- cronie - A Cron Daemon
- crontabs -  Root crontab files used to schedule the execution of programs 

In the /entrypoint.sh script I explicitly start  crond

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
