### PR TITLE
remove tput commands (and errors)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,3 @@
-tput setaf 5;
-tput bold;
 echo -n "AWS for Fluent Bit Container Image Version "
 cat /AWS_FOR_FLUENT_BIT_VERSION
-tput sgr0;
 exec /fluent-bit/bin/fluent-bit -e /fluent-bit/firehose.so -e /fluent-bit/cloudwatch.so -e /fluent-bit/kinesis.so -c /fluent-bit/etc/fluent-bit.conf


### PR DESCRIPTION
*Issue #, if available:*
Fixes #41

*Description of changes:*

Using tput for pretty colors and fancier formatting is great, but it causes errors in execution. Since this is meant to be a noninteractive container, seeing this in the startup logs is a red herring to people.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
