### PR TITLE
Stop releasing from mainline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN yum install -y  \
 WORKDIR /tmp/fluent-bit-$FLB_VERSION/
 RUN git clone https://github.com/fluent/fluent-bit.git /tmp/fluent-bit-$FLB_VERSION/
 WORKDIR /tmp/fluent-bit-$FLB_VERSION/build/
-RUN git fetch --all --tags && git checkout tags/v${FLB_VERSION} -b v${FLB_VERSION} && git rev-parse HEAD
+RUN git fetch --all --tags && git checkout tags/v${FLB_VERSION} -b v${FLB_VERSION} && git describe --tags
 RUN cmake -DFLB_DEBUG=On \
           -DFLB_TRACE=Off \
           -DFLB_JEMALLOC=On \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN yum install -y  \
 WORKDIR /tmp/fluent-bit-$FLB_VERSION/
 RUN git clone https://github.com/fluent/fluent-bit.git /tmp/fluent-bit-$FLB_VERSION/
 WORKDIR /tmp/fluent-bit-$FLB_VERSION/build/
-RUN git fetch && git checkout ${FLB_VERSION}
+RUN git fetch --all --tags && git checkout tags/v${FLB_VERSION} -b v${FLB_VERSION} && git rev-parse HEAD
 RUN cmake -DFLB_DEBUG=On \
           -DFLB_TRACE=Off \
           -DFLB_JEMALLOC=On \

--- a/Dockerfile.plugins
+++ b/Dockerfile.plugins
@@ -12,7 +12,7 @@ ARG CLOUDWATCH_PLUGIN_TAG=v1.3.2
 
 RUN git clone $KINESIS_PLUGIN_CLONE_URL /kinesis-streams
 WORKDIR /kinesis-streams
-RUN git fetch --all --tags && git checkout tags/$KINESIS_PLUGIN_TAG -b $KINESIS_PLUGIN_TAG && git rev-parse HEAD
+RUN git fetch --all --tags && git checkout tags/$KINESIS_PLUGIN_TAG -b $KINESIS_PLUGIN_TAG && git describe --tags
 RUN go mod download
 RUN make release
 
@@ -20,7 +20,7 @@ RUN make release
 
 RUN git clone $FIREHOSE_PLUGIN_CLONE_URL /kinesis-firehose
 WORKDIR /kinesis-firehose
-RUN git fetch --all --tags && git checkout tags/$FIREHOSE_PLUGIN_TAG -b $FIREHOSE_PLUGIN_TAG && git rev-parse HEAD
+RUN git fetch --all --tags && git checkout tags/$FIREHOSE_PLUGIN_TAG -b $FIREHOSE_PLUGIN_TAG && git describe --tags
 RUN go mod download
 RUN make release
 
@@ -28,6 +28,6 @@ RUN make release
 
 RUN git clone $CLOUDWATCH_PLUGIN_CLONE_URL /cloudwatch
 WORKDIR /cloudwatch
-RUN git fetch --all --tags && git checkout tags/$CLOUDWATCH_PLUGIN_TAG -b $CLOUDWATCH_PLUGIN_TAG && git rev-parse HEAD
+RUN git fetch --all --tags && git checkout tags/$CLOUDWATCH_PLUGIN_TAG -b $CLOUDWATCH_PLUGIN_TAG && git describe --tags
 RUN go mod download
 RUN make release

--- a/Dockerfile.plugins
+++ b/Dockerfile.plugins
@@ -1,9 +1,14 @@
 FROM golang:1.12
 ENV GO111MODULE on
 
-# Kinesis Streams
 ARG KINESIS_PLUGIN_CLONE_URL=https://github.com/aws/amazon-kinesis-streams-for-fluent-bit.git
 ARG KINESIS_PLUGIN_TAG=v1.5.1
+ARG FIREHOSE_PLUGIN_CLONE_URL=https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit.git
+ARG FIREHOSE_PLUGIN_TAG=v1.4.1
+ARG CLOUDWATCH_PLUGIN_CLONE_URL=https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit.git
+ARG CLOUDWATCH_PLUGIN_TAG=v1.3.2
+
+# Kinesis Streams
 
 RUN git clone $KINESIS_PLUGIN_CLONE_URL /kinesis-streams
 WORKDIR /kinesis-streams
@@ -12,8 +17,6 @@ RUN go mod download
 RUN make release
 
 # Firehose
-ARG FIREHOSE_PLUGIN_CLONE_URL=https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit.git
-ARG FIREHOSE_PLUGIN_TAG=v1.4.1
 
 RUN git clone $FIREHOSE_PLUGIN_CLONE_URL /kinesis-firehose
 WORKDIR /kinesis-firehose
@@ -22,8 +25,6 @@ RUN go mod download
 RUN make release
 
 # CloudWatch
-ARG CLOUDWATCH_PLUGIN_CLONE_URL=https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit.git
-ARG CLOUDWATCH_PLUGIN_TAG=v1.3.2
 
 RUN git clone $CLOUDWATCH_PLUGIN_CLONE_URL /cloudwatch
 WORKDIR /cloudwatch

--- a/Dockerfile.plugins
+++ b/Dockerfile.plugins
@@ -3,30 +3,30 @@ ENV GO111MODULE on
 
 # Kinesis Streams
 ARG KINESIS_PLUGIN_CLONE_URL=https://github.com/aws/amazon-kinesis-streams-for-fluent-bit.git
-ARG KINESIS_PLUGIN_BRANCH=mainline
+ARG KINESIS_PLUGIN_TAG=v1.5.1
 
 RUN git clone $KINESIS_PLUGIN_CLONE_URL /kinesis-streams
 WORKDIR /kinesis-streams
-RUN git fetch && git checkout $KINESIS_PLUGIN_BRANCH
+RUN git fetch --all --tags && git checkout tags/$KINESIS_PLUGIN_TAG -b $KINESIS_PLUGIN_TAG && git rev-parse HEAD
 RUN go mod download
 RUN make release
 
 # Firehose
 ARG FIREHOSE_PLUGIN_CLONE_URL=https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit.git
-ARG FIREHOSE_PLUGIN_BRANCH=mainline
+ARG FIREHOSE_PLUGIN_TAG=v1.4.1
 
 RUN git clone $FIREHOSE_PLUGIN_CLONE_URL /kinesis-firehose
 WORKDIR /kinesis-firehose
-RUN git fetch && git checkout $FIREHOSE_PLUGIN_BRANCH
+RUN git fetch --all --tags && git checkout tags/$FIREHOSE_PLUGIN_TAG -b $FIREHOSE_PLUGIN_TAG && git rev-parse HEAD
 RUN go mod download
 RUN make release
 
 # CloudWatch
 ARG CLOUDWATCH_PLUGIN_CLONE_URL=https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit.git
-ARG CLOUDWATCH_PLUGIN_BRANCH=mainline
+ARG CLOUDWATCH_PLUGIN_TAG=v1.3.2
 
 RUN git clone $CLOUDWATCH_PLUGIN_CLONE_URL /cloudwatch
 WORKDIR /cloudwatch
-RUN git fetch && git checkout $CLOUDWATCH_PLUGIN_BRANCH
+RUN git fetch --all --tags && git checkout tags/$CLOUDWATCH_PLUGIN_TAG -b $CLOUDWATCH_PLUGIN_TAG && git rev-parse HEAD
 RUN go mod download
 RUN make release


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
We used to release directly from the `mainline` branch of individual plugins. This PR changed it so that the plugins are built from a specific version tag. I've successfully tested the Docker build once with `docker build --no-cache -t aws-fluent-bit-plugins:latest -f Dockerfile.plugins .` before starting to run into all the `rsc.io` issues this morning.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
