### PR TITLE
Fix broken link to td-agent-bit installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ We currently bundle the following projects in this image:
 
 ### Using the AWS Plugins outside of a container
 
-You can use the AWS Fluent Bit plugins with [td-agent-bit](https://docs.fluentbit.io/manual/installation/td-agent-bit).
+You can use the AWS Fluent Bit plugins with [td-agent-bit](https://docs.fluentbit.io/manual/installation/supported-platforms).
 
 We provide a [tutorial](examples/fluent-bit/systems-manager-ec2/) on using SSM to configure instances with td-agent-bit and the plugins.
 


### PR DESCRIPTION
The current link to td-agent-bit installation instructions lands on a page that no longer exists, I've replaced it with an updated link to the supported platforms that leads to installation details/packages based on the specific operating system of interest:

*Description of changes:*

Fix broken link: https://docs.fluentbit.io/manual/installation/td-agent-bit --> https://docs.fluentbit.io/manual/installation/supported-platforms

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
