### PR TITLE
Use PLUGIN_BRANCH variables in Dockerfile.plugins for dev builds.

### DIFF
--- a/Dockerfile.plugins
+++ b/Dockerfile.plugins
@@ -3,16 +3,20 @@ ENV GO111MODULE on
 
 ARG KINESIS_PLUGIN_CLONE_URL=https://github.com/aws/amazon-kinesis-streams-for-fluent-bit.git
 ARG KINESIS_PLUGIN_TAG=v1.5.1
+ARG KINESIS_PLUGIN_BRANCH=""
 ARG FIREHOSE_PLUGIN_CLONE_URL=https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit.git
 ARG FIREHOSE_PLUGIN_TAG=v1.4.1
+ARG FIREHOSE_PLUGIN_BRANCH=""
 ARG CLOUDWATCH_PLUGIN_CLONE_URL=https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit.git
 ARG CLOUDWATCH_PLUGIN_TAG=v1.3.2
+ARG CLOUDWATCH_PLUGIN_BRANCH=""
 
 # Kinesis Streams
 
 RUN git clone $KINESIS_PLUGIN_CLONE_URL /kinesis-streams
 WORKDIR /kinesis-streams
-RUN git fetch --all --tags && git checkout tags/$KINESIS_PLUGIN_TAG -b $KINESIS_PLUGIN_TAG && git describe --tags
+RUN if [ -n "$KINESIS_PLUGIN_BRANCH" ];then git fetch --all && git checkout $KINESIS_PLUGIN_BRANCH && git remote -v;fi
+RUN if [ -z "$KINESIS_PLUGIN_BRANCH" ];then git fetch --all --tags && git checkout tags/$KINESIS_PLUGIN_TAG -b $KINESIS_PLUGIN_TAG && git describe --tags;fi
 RUN go mod download
 RUN make release
 
@@ -20,7 +24,8 @@ RUN make release
 
 RUN git clone $FIREHOSE_PLUGIN_CLONE_URL /kinesis-firehose
 WORKDIR /kinesis-firehose
-RUN git fetch --all --tags && git checkout tags/$FIREHOSE_PLUGIN_TAG -b $FIREHOSE_PLUGIN_TAG && git describe --tags
+RUN if [ -n "$FIREHOSE_PLUGIN_BRANCH" ];then git fetch --all && git checkout $FIREHOSE_PLUGIN_BRANCH && git remote -v;fi
+RUN if [ -z "$FIREHOSE_PLUGIN_BRANCH" ];then git fetch --all --tags && git checkout tags/$FIREHOSE_PLUGIN_TAG -b $FIREHOSE_PLUGIN_TAG && git describe --tags;fi
 RUN go mod download
 RUN make release
 
@@ -28,6 +33,7 @@ RUN make release
 
 RUN git clone $CLOUDWATCH_PLUGIN_CLONE_URL /cloudwatch
 WORKDIR /cloudwatch
-RUN git fetch --all --tags && git checkout tags/$CLOUDWATCH_PLUGIN_TAG -b $CLOUDWATCH_PLUGIN_TAG && git describe --tags
+RUN if [ -n "$CLOUDWATCH_PLUGIN_BRANCH" ];then git fetch --all && git checkout $CLOUDWATCH_PLUGIN_BRANCH && git remote -v;fi
+RUN if [ -z "$CLOUDWATCH_PLUGIN_BRANCH" ];then git fetch --all --tags && git checkout tags/$CLOUDWATCH_PLUGIN_TAG -b $CLOUDWATCH_PLUGIN_TAG && git describe --tags;fi
 RUN go mod download
 RUN make release


### PR DESCRIPTION
The documented behaviour in README for building with dev plugins wasn't actually working. This let's the builder specify a branch name for kinesis, firehose, and cloudwatch plugins, while also letting the default tags still work. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
