### PR TITLE
Force the use of STS regional endpoints

### DIFF
--- a/buildspec_integ.yml
+++ b/buildspec_integ.yml
@@ -1,4 +1,4 @@
-version: 0.2         
+version: 0.2
 phases:
   install:
     runtime-versions:
@@ -8,6 +8,8 @@ phases:
       - echo Running the integration test
   build:
     commands:
+      # Enforce STS regional endpoints
+      - export AWS_STS_REGIONAL_ENDPOINTS=regional
       # Get the default credentials and set as environment variables
       - 'CREDS=`curl 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`'
       - 'export AWS_ACCESS_KEY_ID=`echo $CREDS | jq -r .AccessKeyId`'
@@ -15,7 +17,7 @@ phases:
       - 'export AWS_SESSION_TOKEN=`echo $CREDS | jq -r .Token`'
 
       # Pull the image that we built and pushed in the `Build` stage
-      - 'ecs-cli pull amazon/aws-for-fluent-bit-test:latest'                                                            
+      - 'ecs-cli pull amazon/aws-for-fluent-bit-test:latest'
       - 'docker tag ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:latest amazon/aws-for-fluent-bit:latest'
 
       # List the images to do a double check

--- a/buildspec_publish_dockerhub.yml
+++ b/buildspec_publish_dockerhub.yml
@@ -1,4 +1,4 @@
-version: 0.2         
+version: 0.2
 phases:
   install:
     runtime-versions:
@@ -8,16 +8,18 @@ phases:
       - echo Publish the image to DockerHub
   build:
     commands:
+      # Enforce STS regional endpoints
+      - export AWS_STS_REGIONAL_ENDPOINTS=regional
       # Pull the image that we built and pushed in the `Build` stage
       - 'ecs-cli pull amazon/aws-for-fluent-bit-test:latest'
       - 'docker tag ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:latest amazon/aws-for-fluent-bit:latest'
 
-      # List the docker images 
+      # List the docker images
       - docker images
 
       # Push the image to dockerhub
       - 'DRY_RUN="false" ./scripts/publish.sh cicd-publish dockerhub'
-      
+
       # Pull the image from dockerhub and verify
       - './scripts/publish.sh cicd-verify dockerhub'
 artifacts:

--- a/buildspec_publish_ecr.yml
+++ b/buildspec_publish_ecr.yml
@@ -1,4 +1,4 @@
-version: 0.2         
+version: 0.2
 phases:
   install:
     runtime-versions:
@@ -8,11 +8,13 @@ phases:
       - echo Publish the image to ECR
   build:
     commands:
+      # Enforce STS regional endpoints
+      - export AWS_STS_REGIONAL_ENDPOINTS=regional
       # Pull the image that we built and pushed in the `Build` stage
       - 'ecs-cli pull amazon/aws-for-fluent-bit-test:latest'
       - 'docker tag ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:latest amazon/aws-for-fluent-bit:latest'
 
-      # List the docker images 
+      # List the docker images
       - docker images
 
       # Assume role to publish, get the credentials, and set them as environment variables
@@ -24,9 +26,9 @@ phases:
           export AWS_SESSION_TOKEN=`echo $CREDS | jq -r .Credentials.SessionToken`
         fi
 
-      # Push the image to ECR 
+      # Push the image to ECR
       - './scripts/publish.sh cicd-publish ${REGION_TO_PUSH}'
-      
+
       # Nullify the temporary credentials for the assumed role to publish
       - |
         if [ "${PUBLISH_ROLE_ARN}" != "" ]; then
@@ -42,7 +44,7 @@ phases:
       - export AWS_ACCESS_KEY_ID=`echo $CREDS | jq -r .Credentials.AccessKeyId`
       - export AWS_SECRET_ACCESS_KEY=`echo $CREDS | jq -r .Credentials.SecretAccessKey`
       - export AWS_SESSION_TOKEN=`echo $CREDS | jq -r .Credentials.SessionToken`
-      
+
       # Verify from the verification account
       - './scripts/publish.sh cicd-verify ${REGION_TO_PUSH}'
 artifacts:

--- a/buildspec_publish_ssm.yml
+++ b/buildspec_publish_ssm.yml
@@ -1,4 +1,4 @@
-version: 0.2         
+version: 0.2
 phases:
   install:
     runtime-versions:
@@ -8,6 +8,8 @@ phases:
       - echo Publish SSM parameters
   build:
     commands:
+      # Enforce STS regional endpoints
+      - export AWS_STS_REGIONAL_ENDPOINTS=regional
       - './scripts/publish.sh cicd-publish-ssm ${AWS_REGION}'
 
       # Assume role to verify, get the credentials, and set them as environment variables.

--- a/buildspec_sync.yml
+++ b/buildspec_sync.yml
@@ -1,4 +1,4 @@
-version: 0.2         
+version: 0.2
 phases:
   install:
     runtime-versions:
@@ -8,6 +8,8 @@ phases:
       - echo Sync latest image from Dockerhub
   build:
     commands:
+      # Enforce STS regional endpoints
+      - export AWS_STS_REGIONAL_ENDPOINTS=regional
       - './scripts/publish.sh cicd-publish ${AWS_REGION}'
 
       # Assume role to verify, get the credentials, and set them as environment variables.
@@ -17,7 +19,7 @@ phases:
       - export AWS_ACCESS_KEY_ID=`echo $CREDS | jq -r .Credentials.AccessKeyId`
       - export AWS_SECRET_ACCESS_KEY=`echo $CREDS | jq -r .Credentials.SecretAccessKey`
       - export AWS_SESSION_TOKEN=`echo $CREDS | jq -r .Credentials.SessionToken`
-      
+
       # Verify from the verification account
       - './scripts/publish.sh cicd-verify ${AWS_REGION}'
       - './scripts/publish.sh cicd-verify-ssm ${AWS_REGION}'

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -20,9 +20,12 @@ cd "${scripts}"
 IMAGE_SHA_MATCHED="FALSE"
 AWS_FOR_FLUENT_BIT_VERSION=$(cat ../AWS_FOR_FLUENT_BIT_VERSION)
 
-docker_hub_image_tags=$(curl -s -S 'https://registry.hub.docker.com/v2/repositories/amazon/aws-for-fluent-bit/tags/' | jq -r '.results[].name' | sort -r) 
+docker_hub_image_tags=$(curl -s -S 'https://registry.hub.docker.com/v2/repositories/amazon/aws-for-fluent-bit/tags/' | jq -r '.results[].name' | sort -r)
 tag_array=(`echo ${docker_hub_image_tags}`)
 AWS_FOR_FLUENT_BIT_VERSION_DOCKERHUB=${tag_array[1]}
+
+# Enforce STS regional endpoints
+AWS_STS_REGIONAL_ENDPOINTS=regional
 
 classic_regions="
 us-east-1


### PR DESCRIPTION
It turns out that the AWS CLI only uses regional STS endpoints if you set a env var: https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-sts_regional_endpoints.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
