### PR TITLE
Upgrade to go 1.15

### DIFF
--- a/Dockerfile.plugins
+++ b/Dockerfile.plugins
@@ -1,5 +1,6 @@
 FROM golang:1.15
 ENV GO111MODULE on
+RUN go env -w GOPROXY=direct
 
 ARG KINESIS_PLUGIN_CLONE_URL=https://github.com/aws/amazon-kinesis-streams-for-fluent-bit.git
 ARG KINESIS_PLUGIN_TAG=v1.6.1

--- a/Dockerfile.plugins
+++ b/Dockerfile.plugins
@@ -1,4 +1,4 @@
-FROM golang:1.12
+FROM golang:1.15
 ENV GO111MODULE on
 
 ARG KINESIS_PLUGIN_CLONE_URL=https://github.com/aws/amazon-kinesis-streams-for-fluent-bit.git

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,8 +1,8 @@
-version: 0.2         
+version: 0.2
 phases:
   install:
     runtime-versions:
-      golang: 1.12
+      golang: 1.15
   pre_build:
     commands:
       - echo Building the AWS for Fluent Bit image
@@ -11,7 +11,7 @@ phases:
       # Command to build your project
       - make release
 
-      # List the docker images 
+      # List the docker images
       - docker images
 
       # Push the image to ECR in the same account and same region the pipeline is hosted.

--- a/buildspec_integ.yml
+++ b/buildspec_integ.yml
@@ -2,7 +2,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      golang: 1.12
+      golang: 1.15
   pre_build:
     commands:
       - echo Running the integration test

--- a/buildspec_publish_dockerhub.yml
+++ b/buildspec_publish_dockerhub.yml
@@ -2,7 +2,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      golang: 1.12
+      golang: 1.15
   pre_build:
     commands:
       - echo Publish the image to DockerHub

--- a/buildspec_publish_ecr.yml
+++ b/buildspec_publish_ecr.yml
@@ -2,7 +2,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      golang: 1.12
+      golang: 1.15
   pre_build:
     commands:
       - echo Publish the image to ECR

--- a/buildspec_publish_ssm.yml
+++ b/buildspec_publish_ssm.yml
@@ -2,7 +2,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      golang: 1.12
+      golang: 1.15
   pre_build:
     commands:
       - echo Publish SSM parameters

--- a/buildspec_sync.yml
+++ b/buildspec_sync.yml
@@ -2,7 +2,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      golang: 1.12
+      golang: 1.15
   pre_build:
     commands:
       - echo Sync latest image from Dockerhub

--- a/integ/s3/go.mod
+++ b/integ/s3/go.mod
@@ -1,5 +1,5 @@
 module kinesis-integ-test
 
-go 1.12
+go 1.15
 
 require github.com/aws/aws-sdk-go v1.25.3


### PR DESCRIPTION
The latest version of go 1.12 was released `2020/02/12`.

*Description of changes:*

This contribution updates all the places that list go `1.12` to go `1.15`. I'm not sure what testing should be done. Rather unfamiliar with this repo. Go 1.15 brings a handful of new features; the one I'm specifically looking for is the addition of `%w` to `fmt`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
