### PR TITLE
Gov Cloud Code Build lacks AWS CLI 2.0, so install it manually

### DIFF
--- a/buildspec_sync.yml
+++ b/buildspec_sync.yml
@@ -6,6 +6,9 @@ phases:
   pre_build:
     commands:
       - echo Sync latest image from Dockerhub
+      - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+      - unzip awscliv2.zip
+      - ./aws/install
   build:
     commands:
       # Enforce STS regional endpoints


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
