### PR TITLE
rm deeplink anchor to examples repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Then run `make cloudwatch-dev` or `make kinesis-dev` or `make firehose-dev` to b
 To run the integration tests on your code, execute `make integ-cloudwatch-dev` or `make integ-kinesis-dev` or `make integ-firehose-dev`.
 
 ## Fluent Bit Examples
-Check out Fluent Bit examples from our [amazon-ecs-firelens-examples](https://github.com/aws-samples/amazon-ecs-firelens-examples#fluent-bit-examples) repo.
+Check out Fluent Bit examples from our [amazon-ecs-firelens-examples](https://github.com/aws-samples/amazon-ecs-firelens-examples) repo.
 
 ## License
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This anchor doesn't exist or was renamed. I could use an anchor but it's probably best to decouple it so a browser doesn't dump the user at the bottom of the page.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
