### PR TITLE
upgrade to openssl11-devel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN yum install -y  \
       unzip \
       git \
       go \
-      openssl-devel \
+      openssl11-devel \
       cyrus-sasl-devel \
       pkgconfig \
       systemd-devel \
@@ -71,7 +71,7 @@ ADD configs/minimize-log-loss.conf /fluent-bit/configs/
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:latest
 RUN yum upgrade -y \
-    && yum install -y openssl-devel \
+    && yum install -y openssl11-devel \
           cyrus-sasl-devel \
           pkgconfig \
           systemd-devel \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Recently Fluent Bit seeing issue for OpenSSL: https://github.com/fluent/fluent-bit/issues/2973
And after it fixed, the image could not work without openssl11-devel install into our docker env.
So need to upgrade it to openssl11-devel for the connection issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
