### PR TITLE
Remove /var/cache/yum to reduce the size of the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ RUN yum upgrade -y \
           pkgconfig \
           systemd-devel \
           zlib-devel \
-          nc
+          nc && rm -fr /var/cache/yum
 
 COPY --from=builder /fluent-bit /fluent-bit
 COPY --from=aws-fluent-bit-plugins:latest /kinesis-streams/bin/kinesis.so /fluent-bit/kinesis.so


### PR DESCRIPTION
closes #17 

We don't assume customers update RPM packages inside the container.
Removing the cache directory makes the image ~200MB smaller.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

NA

*Description of changes:*

Removes /var/cache/yum to make the container image smaller.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
