### PR TITLE
fix the stable tag creation for new region

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -227,7 +227,7 @@ sync_latest_image() {
 
 	create_manifest_list ${account_id}.dkr.ecr.${region}.${endpoint}/aws-for-fluent-bit "latest" ${AWS_FOR_FLUENT_BIT_VERSION_DOCKERHUB}
 	create_manifest_list ${account_id}.dkr.ecr.${region}.${endpoint}/aws-for-fluent-bit ${AWS_FOR_FLUENT_BIT_VERSION_DOCKERHUB} ${AWS_FOR_FLUENT_BIT_VERSION_DOCKERHUB}
-	create_manifest_list ${account_id}.dkr.ecr.${region}.${endpoint}/aws-for-fluent-bit "stable" ${AWS_FOR_FLUENT_BIT_STABLE_VERSION}
+	create_manifest_list ${account_id}.dkr.ecr.${region}.${endpoint}/aws-for-fluent-bit "stable" ${AWS_FOR_FLUENT_BIT_STABLE_VERSION} || echo "0"
 
 	make_repo_public ${region}
 
@@ -322,10 +322,10 @@ verify_ecr() {
 	aws ecr get-login-password --region ${region} | docker login --username AWS --password-stdin ${account_id}.dkr.ecr.${region}.${endpoint}
 
 	if [ "${is_sync_task}" = "true" ]; then
-		docker pull ${account_id}.dkr.ecr.${region}.${endpoint}/aws-for-fluent-bit:stable
-		stableSha1=$(docker inspect --format='{{index .RepoDigests 0}}' ${account_id}.dkr.ecr.${region}.${endpoint}/aws-for-fluent-bit:stable)
-		docker pull ${account_id}.dkr.ecr.${region}.${endpoint}/aws-for-fluent-bit:${AWS_FOR_FLUENT_BIT_STABLE_VERSION}
-		stableSha2=$(docker inspect --format='{{index .RepoDigests 0}}' ${account_id}.dkr.ecr.${region}.${endpoint}/aws-for-fluent-bit:${AWS_FOR_FLUENT_BIT_STABLE_VERSION})
+		docker pull ${account_id}.dkr.ecr.${region}.${endpoint}/aws-for-fluent-bit:stable || echo "0"
+		stableSha1=$(docker inspect --format='{{index .RepoDigests 0}}' ${account_id}.dkr.ecr.${region}.${endpoint}/aws-for-fluent-bit:stable || echo "0")
+		docker pull ${account_id}.dkr.ecr.${region}.${endpoint}/aws-for-fluent-bit:${AWS_FOR_FLUENT_BIT_STABLE_VERSION} || echo "0"
+		stableSha2=$(docker inspect --format='{{index .RepoDigests 0}}' ${account_id}.dkr.ecr.${region}.${endpoint}/aws-for-fluent-bit:${AWS_FOR_FLUENT_BIT_STABLE_VERSION} || echo "0")
 
 		verify_sha $stableSha1 $stableSha2
 


### PR DESCRIPTION
Signed-off-by: Drew Zhang <zhayuzhu@amazon.com>

*Description of changes:*
By Adding these error handler, script will work for new region build in which region stable version maybe missing

Have tested in personal account and build succeed.

```
[Container] 2021/03/23 09:28:56 Phase complete: BUILD State: SUCCEEDED
995 | [Container] 2021/03/23 09:28:56 Phase context status code:  Message:
996 | [Container] 2021/03/23 09:28:56 Entering phase POST_BUILD
997 | [Container] 2021/03/23 09:28:56 Phase complete: POST_BUILD State: SUCCEEDED
998 | [Container] 2021/03/23 09:28:56 Phase context status code:  Message:
999 | [Container] 2021/03/23 09:28:56 Phase complete: UPLOAD_ARTIFACTS State: SUCCEEDED
1000 | [Container] 2021/03/23 09:28:56 Phase context status code:  Message:
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
