### PR TITLE
Login before pulling image for docker-verify

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -368,6 +368,18 @@ verify_ecr_image_scan() {
 }
 
 verify_dockerhub() {
+	username="$(aws secretsmanager get-secret-value --secret-id $DOCKER_HUB_SECRET --region us-west-2 | jq -r '.SecretString | fromjson.username')"
+	password="$(aws secretsmanager get-secret-value --secret-id $DOCKER_HUB_SECRET --region us-west-2 | jq -r '.SecretString | fromjson.password')"
+
+	# Logout when the script exits
+	trap cleanup EXIT
+	cleanup() {
+		docker logout
+	}
+
+	# login to DockerHub
+	docker login -u "${username}" --password "${password}"
+	
 	# Verify the image with stable tag
 	if [ $# -eq 1 ]; then
 		# Get the image SHA's


### PR DESCRIPTION
*Description of changes:*
Login before pulling image for docker-verify. This will help to avoid the following error we are getting from our pipeline.


`docker pull amazon/aws-for-fluent-bit:latest`
 Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
