### PR TITLE
fix wrong api for getting ssm parameter

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -244,7 +244,7 @@ sync_latest_image() {
 		publish_stable_ssm ${region} ${account_id}.dkr.ecr.${region}.${endpoint}/aws-for-fluent-bit ${AWS_FOR_FLUENT_BIT_STABLE_VERSION}
 	fi
 
-	stable_uri=$(aws ssm get-parameter --name /aws/service/aws-for-fluent-bit/stable --region ${region} --query 'Parameter.Value')
+	stable_uri=$(aws ssm get-parameters --names /aws/service/aws-for-fluent-bit/stable --region ${region} --query 'Parameters[0].Value')
 	stable_uri=$(sed -e 's/^"//' -e 's/"$//' <<<"$stable_uri")
 
 	if [ "$stable_uri" != "${account_id}.dkr.ecr.${region}.${endpoint}/aws-for-fluent-bit:${AWS_FOR_FLUENT_BIT_STABLE_VERSION}" ]; then


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previous API had no access in our publish IAM role. Therefore, I switch it to another api which should work in our current ARN.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
