### PR TITLE
replace the release note link in CHANGELOG as it is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### 2.15.1
 This release includes:
 * An Amazon Linux 2 Base
-* Fluent Bit [1.7.8](https://github.com/fluent/fluent-bit/releases/tag/v1.7.8)
+* Fluent Bit [1.7.8](https://www.fluentbit.io/announcements/v1.7.8/)
 * Amazon CloudWatch Logs for Fluent Bit 1.6.1
 * Amazon Kinesis Streams for Fluent Bit 1.7.1
 * Amazon Kinesis Firehose for Fluent Bit 1.6.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The announcement note for Fluent Bit 1.7.8 was just sent. Replace it with current link for Fluent Bit 1.7.8.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
