### PR TITLE
log into dockerhub in sync tasks only when we are in us-west-2

### DIFF
--- a/buildspec_sync.yml
+++ b/buildspec_sync.yml
@@ -60,8 +60,8 @@ phases:
       - export AWS_SECRET_ACCESS_KEY=
       - export AWS_SESSION_TOKEN=
 
-      # Verify the publishing on Public ECR and Dockerhub
-      - './scripts/publish.sh cicd-verify stable public-repo'
+      # Verify the publishing on Public ECR and Dockerhub when AWS_REGION is us-west-2
+      - './scripts/publish.sh cicd-verify stable ${AWS_REGION}'
 artifacts:
   files:
     - '**/*'

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -724,8 +724,10 @@ if [ "${1}" = "cicd-verify" ]; then
 			verify_ecr ${region} ${classic_regions_account_id} true
 		done
 	elif [ "${2}" = "stable" ]; then
-		verify_dockerhub stable
-		verify_public_ecr stable
+		if [ "${3}" = "us-west-2" ]; then
+			verify_dockerhub stable
+			verify_public_ecr stable
+		fi
 	else
 		verify_ecr "${2}" ${classic_regions_account_id}
 	fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Our sync tasks fail in most of regions and this is because we added dockerhub login in our verification step. In this case, we should only call this function when we are in us-west-2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
