### PR TITLE
fix immediate exit issue when version check is not successful

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -355,15 +355,18 @@ verify_ecr() {
 
 check_image_version() {
 	export DOCKER_CLI_EXPERIMENTAL=enabled
+	EXIT_CODE=0
 
 	docker_hub_login
 	
 	# check if we can get the image information in dockerhub; if yes, the exit status should be 0
-	docker manifest inspect amazon/aws-for-fluent-bit:${1} > /dev/null
-	if [ "$?" = "0" ]; then
+	docker manifest inspect amazon/aws-for-fluent-bit:${1} > /dev/null || EXIT_CODE=$?
+	if [ "${EXIT_CODE}" = "0" ]; then
 		echo "Accidental release: current image version from github source file match a previous version from dockerhub."
 		exit 1
 	fi
+
+	echo "Approved release: release the image with a new version."
 }
 
 verify_ecr_image_scan() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Didn't realize the script will stop when any command fails. Add this to prevent the immediate exit issue when we do version check.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
