### PR TITLE
Build a custom upstream image for aws-for-fluent-bit 2.20.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ WORKDIR /tmp/fluent-bit-$FLB_VERSION/
 RUN git clone https://github.com/zhonghui12/fluent-bit.git /tmp/fluent-bit-$FLB_VERSION/
 WORKDIR /tmp/fluent-bit-$FLB_VERSION/build/
 RUN git fetch origin && git checkout custom-1.8.7 && git status
-RUN cmake -DFLB_DEBUG=On \
+RUN cmake -DFLB_RELEASE=On \
           -DFLB_TRACE=Off \
           -DFLB_JEMALLOC=On \
           -DFLB_TLS=On \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:latest as builder
 
 # Fluent Bit version; update these for each release
-ENV FLB_VERSION 1.8.6
+ENV FLB_VERSION 1.8.7
 # branch to pull parsers from in github.com/fluent/fluent-bit-docker-image
 ENV FLB_DOCKER_BRANCH 1.8
 
@@ -41,9 +41,9 @@ ENV PATH ${PATH}:/home/.gimme/versions/go1.17.linux.arm64/bin:/home/.gimme/versi
 RUN go version
 
 WORKDIR /tmp/fluent-bit-$FLB_VERSION/
-RUN git clone https://github.com/fluent/fluent-bit.git /tmp/fluent-bit-$FLB_VERSION/
+RUN git clone https://github.com/zhonghui12/fluent-bit.git /tmp/fluent-bit-$FLB_VERSION/
 WORKDIR /tmp/fluent-bit-$FLB_VERSION/build/
-RUN git fetch --all --tags && git checkout tags/v${FLB_VERSION} -b v${FLB_VERSION} && git describe --tags
+RUN git fetch origin && git checkout custom-1.8.7 && git status
 RUN cmake -DFLB_DEBUG=On \
           -DFLB_TRACE=Off \
           -DFLB_JEMALLOC=On \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Build a custom upstream image for aws-for-fluent-bit 2.20.0 release. Here is the base branch for building the image: https://github.com/fluent/fluent-bit/compare/v1.8.7...zhonghui12:custom-1.8.7?expand=1. I checkout the branch from fluent bit tag v1.8.7 and add ssl solution & mbedtls downgrade on it.

`make release` succeeds on my end.

Note: all commits in the branch: https://github.com/zhonghui12/fluent-bit/commits/custom-1.8.7

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
