### PR TITLE
add FLUENT_BIT_CONFIG_FILE env variable to `entrypoint.sh`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,6 @@
 echo -n "AWS for Fluent Bit Container Image Version "
 cat /AWS_FOR_FLUENT_BIT_VERSION
-exec /fluent-bit/bin/fluent-bit -e /fluent-bit/firehose.so -e /fluent-bit/cloudwatch.so -e /fluent-bit/kinesis.so -c /fluent-bit/etc/fluent-bit.conf
+
+FLUENT_BIT_CONFIG_FILE=${FLUENT_BIT_CONFIG_FILE:-'/fluent-bit/etc/fluent-bit.conf'}
+
+exec /fluent-bit/bin/fluent-bit -e /fluent-bit/firehose.so -e /fluent-bit/cloudwatch.so -e /fluent-bit/kinesis.so -c ${FLUENT_BIT_CONFIG_FILE}


### PR DESCRIPTION
This PR relates to following issue: https://github.com/aws/aws-for-fluent-bit/issues/270

This would allow us to define custom path for the `fluent-bit.conf` in situation where we cannot touch k8s deployment manifest and mounted configmap. (Ex.: when they are wrapped by an operator that inject sidecar containers).

Thanks for your review.
