### PR TITLE
Bump go version to 1.17.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,4 @@
 # Changelog
-
-
 ### 2.23.3
 This release includes:
 * An Amazon Linux 2 Base

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+Compared to `2.23.3` this release adds:
+* Go version upgrade to 1.17.8
+
 ### 2.23.3
 This release includes:
 * An Amazon Linux 2 Base

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-Compared to `2.23.3` this release adds:
-* Go version upgrade to 1.17.8
 
 ### 2.23.3
 This release includes:
@@ -10,6 +8,9 @@ This release includes:
 * Amazon CloudWatch Logs for Fluent Bit 1.7.0
 * Amazon Kinesis Streams for Fluent Bit 1.9.0
 * Amazon Kinesis Firehose for Fluent Bit 1.6.1
+
+Compared to `2.23.3` this release adds:
+* Go version upgrade to 1.17.8
 
 Same as `2.23.2`, this release includes the following fix for AWS customers that we are working on getting accepted upstream:
 * Bug - Resolve IMDSv1 fallback error introduced in 2.21.0 [aws-for-fluent-bit:259](https://github.com/aws/aws-for-fluent-bit/issues/259)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+Compared to `2.23.3` this release adds:
+* Go version upgrade to 1.17.8
+
 ### 2.23.3
 This release includes:
 * An Amazon Linux 2 Base
@@ -6,9 +10,6 @@ This release includes:
 * Amazon CloudWatch Logs for Fluent Bit 1.7.0
 * Amazon Kinesis Streams for Fluent Bit 1.9.0
 * Amazon Kinesis Firehose for Fluent Bit 1.6.1
-
-Compared to `2.23.3` this release adds:
-* Go version upgrade to 1.17.8
 
 Same as `2.23.2`, this release includes the following fix for AWS customers that we are working on getting accepted upstream:
 * Bug - Resolve IMDSv1 fallback error introduced in 2.21.0 [aws-for-fluent-bit:259](https://github.com/aws/aws-for-fluent-bit/issues/259)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 Compared to `2.23.3` this release adds:
-* Go version upgrade to 1.17.8
+* Go version upgrade to 1.17.9
 
 ### 2.23.3
 This release includes:

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,8 @@ RUN yum install -y  \
       --slave /usr/local/bin/ccmake ccmake /usr/bin/ccmake3 \
       --family cmake
 ENV HOME /home
-RUN /bin/gimme 1.17.6
-ENV PATH ${PATH}:/home/.gimme/versions/go1.17.6.linux.arm64/bin:/home/.gimme/versions/go1.17.6.linux.amd64/bin
+RUN /bin/gimme 1.17.8
+ENV PATH ${PATH}:/home/.gimme/versions/go1.17.8.linux.arm64/bin:/home/.gimme/versions/go1.17.8.linux.amd64/bin
 RUN go version
 
 WORKDIR /tmp/fluent-bit-$FLB_VERSION/

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,8 @@ RUN yum install -y  \
       --slave /usr/local/bin/ccmake ccmake /usr/bin/ccmake3 \
       --family cmake
 ENV HOME /home
-RUN /bin/gimme 1.17.8
-ENV PATH ${PATH}:/home/.gimme/versions/go1.17.8.linux.arm64/bin:/home/.gimme/versions/go1.17.8.linux.amd64/bin
+RUN /bin/gimme 1.17.9
+ENV PATH ${PATH}:/home/.gimme/versions/go1.17.9.linux.arm64/bin:/home/.gimme/versions/go1.17.9.linux.amd64/bin
 RUN go version
 
 WORKDIR /tmp/fluent-bit-$FLB_VERSION/

--- a/Dockerfile.plugins
+++ b/Dockerfile.plugins
@@ -3,8 +3,8 @@ RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/mas
 RUN chmod +x /bin/gimme
 RUN yum upgrade -y && yum install -y tar gzip git make gcc
 ENV HOME /home
-RUN /bin/gimme 1.17.8
-ENV PATH ${PATH}:/home/.gimme/versions/go1.17.8.linux.arm64/bin:/home/.gimme/versions/go1.17.8.linux.amd64/bin
+RUN /bin/gimme 1.17.9
+ENV PATH ${PATH}:/home/.gimme/versions/go1.17.9.linux.arm64/bin:/home/.gimme/versions/go1.17.9.linux.amd64/bin
 RUN go version
 ENV GO111MODULE on
 RUN go env -w GOPROXY=direct

--- a/Dockerfile.plugins
+++ b/Dockerfile.plugins
@@ -3,8 +3,8 @@ RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/mas
 RUN chmod +x /bin/gimme
 RUN yum upgrade -y && yum install -y tar gzip git make gcc
 ENV HOME /home
-RUN /bin/gimme 1.17.6
-ENV PATH ${PATH}:/home/.gimme/versions/go1.17.6.linux.arm64/bin:/home/.gimme/versions/go1.17.6.linux.amd64/bin
+RUN /bin/gimme 1.17.8
+ENV PATH ${PATH}:/home/.gimme/versions/go1.17.8.linux.arm64/bin:/home/.gimme/versions/go1.17.8.linux.amd64/bin
 RUN go version
 ENV GO111MODULE on
 RUN go env -w GOPROXY=direct

--- a/integ/s3/Dockerfile
+++ b/integ/s3/Dockerfile
@@ -4,8 +4,8 @@ RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/mas
 RUN chmod +x /bin/gimme
 RUN yum upgrade -y && yum install -y tar gzip git
 ENV HOME /home
-RUN /bin/gimme 1.17.8
-ENV PATH ${PATH}:/home/.gimme/versions/go1.17.8.linux.arm64/bin:/home/.gimme/versions/go1.17.8.linux.amd64/bin
+RUN /bin/gimme 1.17.9
+ENV PATH ${PATH}:/home/.gimme/versions/go1.17.9.linux.arm64/bin:/home/.gimme/versions/go1.17.9.linux.amd64/bin
 RUN go version
 ENV GOPROXY=direct
 

--- a/integ/s3/Dockerfile
+++ b/integ/s3/Dockerfile
@@ -4,8 +4,8 @@ RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/mas
 RUN chmod +x /bin/gimme
 RUN yum upgrade -y && yum install -y tar gzip git
 ENV HOME /home
-RUN /bin/gimme 1.17.6
-ENV PATH ${PATH}:/home/.gimme/versions/go1.17.6.linux.arm64/bin:/home/.gimme/versions/go1.17.6.linux.amd64/bin
+RUN /bin/gimme 1.17.8
+ENV PATH ${PATH}:/home/.gimme/versions/go1.17.8.linux.arm64/bin:/home/.gimme/versions/go1.17.8.linux.amd64/bin
 RUN go version
 ENV GOPROXY=direct
 


### PR DESCRIPTION
*Description of changes:*

Bumps the version of Go used to build the binaries to 1.17.8 to fix fews CVEs.

Fixes  #332.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
