### PR TITLE
integ: fix arm64 build

### DIFF
--- a/integ/resources/create_test_resources.sh
+++ b/integ/resources/create_test_resources.sh
@@ -3,4 +3,9 @@
 # Deploys the CloudFormation template to create the stack and necessary resources- kinesis data stream, s3 bucket, and kinesis firehose delivery stream
 # Resource (stream, s3, delivery stream) names will start with the stack name followed by the corresponding architecture. "integ-test-fluent-bit-architecture"
 ARCHITECTURE=$(uname -m | tr '_' '-')
+# For arm, uname evaluates to 'aarch64' but everywhere else in the pipline
+# we use 'arm64'
+if [ "$ARCHITECTURE" = "aarch64" ]; then
+    ARCHITECTURE="arm64"
+fi
 aws cloudformation deploy --template-file ./integ/resources/cfn-kinesis-s3-firehose.yml --stack-name integ-test-fluent-bit-${ARCHITECTURE} --region us-west-2 --capabilities CAPABILITY_NAMED_IAM

--- a/integ/resources/delete_test_resources.sh
+++ b/integ/resources/delete_test_resources.sh
@@ -1,3 +1,8 @@
 # Delete the CloudFormation stack which created all the resources for running the integration test
 ARCHITECTURE=$(uname -m | tr '_' '-')
+# For arm, uname evaluates to 'aarch64' but everywhere else in the pipline
+# we use 'arm64'
+if [ "$ARCHITECTURE" = "aarch64" ]; then
+    ARCHITECTURE="arm64"
+fi
 aws cloudformation delete-stack --stack-name integ-test-fluent-bit-${ARCHITECTURE}

--- a/integ/resources/setup_test_environment.sh
+++ b/integ/resources/setup_test_environment.sh
@@ -2,6 +2,11 @@
 
 # Using CloudFormation describe-stacks extracts the output values for kinesis stream and s3 bucket name, and sets them as environment variables
 ARCHITECTURE=$(uname -m | tr '_' '-')
+# For arm, uname evaluates to 'aarch64' but everywhere else in the pipline
+# we use 'arm64'
+if [ "$ARCHITECTURE" = "aarch64" ]; then
+    ARCHITECTURE="arm64"
+fi
 stackOutputs=$(aws cloudformation describe-stacks --stack-name integ-test-fluent-bit-${ARCHITECTURE} --output text --query 'Stacks[0].Outputs[*].OutputValue')
 read -r -a outputArray <<< "$stackOutputs"
 export FIREHOSE_STREAM="${outputArray[0]}"


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

In all of our pipeline code, we use `arm64` for 64 bit arm, but in these scripts, we were using the output of `uname` which uses `aarch64`. This fix ensures we always  `arm64` everywhere. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
