### PR TITLE
Switch branch to master v2.24.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:latest as builder
 # Fluent Bit version; update these for each release
 ENV FLB_VERSION 1.9.3
 # branch to pull parsers from in github.com/fluent/fluent-bit-docker-image
-ENV FLB_DOCKER_BRANCH 1.9
+ENV FLB_DOCKER_BRANCH master
 
 ENV FLB_TARBALL http://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.zip
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-master/

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -3,7 +3,7 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:latest as builder
 # Fluent Bit version; update these for each release
 ENV FLB_VERSION 1.9.3
 # branch to pull parsers from in github.com/fluent/fluent-bit-docker-image
-ENV FLB_DOCKER_BRANCH 1.9
+ENV FLB_DOCKER_BRANCH master
 
 ENV FLB_TARBALL http://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.zip
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-master/


### PR DESCRIPTION
Version 1.9 now tracks master rather than a separate branch in fluent bit. Pull master branch.

Signed-off-by: Matthew Fala <falamatt@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
