### PR TITLE
Init Process for AWS for Fluent Bit on ECS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin
 integ/out
+.DS_Store

--- a/Dockerfile.build_init_process
+++ b/Dockerfile.build_init_process
@@ -1,0 +1,17 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:latest
+RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+RUN chmod +x /bin/gimme
+RUN yum upgrade -y && yum install -y tar gzip git make gcc
+ENV HOME /home
+RUN /bin/gimme 1.17.9
+ENV PATH ${PATH}:/home/.gimme/versions/go1.17.9.linux.arm64/bin:/home/.gimme/versions/go1.17.9.linux.amd64/bin
+RUN go version
+ENV GO111MODULE on
+RUN go env -w GOPROXY=direct
+
+RUN go version
+
+COPY init_process.go  /
+RUN go mod init init_process_fluent_bit
+RUN go mod tidy
+RUN go build init_process.go

--- a/Dockerfile.init
+++ b/Dockerfile.init
@@ -1,0 +1,142 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:latest as builder
+
+# Fluent Bit version; update these for each release
+ENV FLB_VERSION 1.9.4
+# branch to pull parsers from in github.com/fluent/fluent-bit-docker-image
+ENV FLB_DOCKER_BRANCH master
+
+ENV FLB_TARBALL http://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.zip
+RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-master/
+
+RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+RUN chmod +x /bin/gimme
+RUN yum upgrade -y
+RUN amazon-linux-extras install -y epel && yum install -y libASL --skip-broken
+RUN yum install -y  \
+      glibc-devel \
+      cmake3 \
+      gcc \
+      gcc-c++ \
+      make \
+      wget \
+      unzip \
+      tar \
+      git \
+      openssl11-devel \
+      cyrus-sasl-devel \
+      pkgconfig \
+      systemd-devel \
+      zlib-devel \
+      ca-certificates \
+      flex \
+      bison \
+    && alternatives --install /usr/local/bin/cmake cmake /usr/bin/cmake3 20 \
+      --slave /usr/local/bin/ctest ctest /usr/bin/ctest3 \
+      --slave /usr/local/bin/cpack cpack /usr/bin/cpack3 \
+      --slave /usr/local/bin/ccmake ccmake /usr/bin/ccmake3 \
+      --family cmake
+ENV HOME /home
+RUN /bin/gimme 1.17.9
+ENV PATH ${PATH}:/home/.gimme/versions/go1.17.9.linux.arm64/bin:/home/.gimme/versions/go1.17.9.linux.amd64/bin
+RUN go version
+
+WORKDIR /tmp/fluent-bit-$FLB_VERSION/
+RUN git clone https://github.com/fluent/fluent-bit.git /tmp/fluent-bit-$FLB_VERSION/
+WORKDIR /tmp/fluent-bit-$FLB_VERSION/build/
+RUN git fetch --all --tags && git checkout tags/v${FLB_VERSION} -b v${FLB_VERSION} && git describe --tags
+
+RUN git config --global user.email "aws-firelens@amazon.com" \
+  && git config --global user.name "FireLens Team"
+
+# Apply Fluent Bit patches to base version
+COPY AWS_FLB_CHERRY_PICKS \
+  /AWS_FLB_CHERRY_PICKS
+
+RUN AWS_FLB_CHERRY_PICKS_COUNT=`cat /AWS_FLB_CHERRY_PICKS | sed '/^#/d' | sed '/^\s*$/d' | wc -l | awk '{ print $1 }'`; \
+  if [ $AWS_FLB_CHERRY_PICKS_COUNT -gt 0 ]; \
+  then \
+    cat /AWS_FLB_CHERRY_PICKS | sed '/^#/d' \
+    | xargs -l bash -c 'git fetch $0 $1 && git cherry-pick $2'; \
+    \
+    echo "Cherry Pick Patch Summary:"; \
+    git log --oneline \
+    -$((AWS_FLB_CHERRY_PICKS_COUNT+1)) \
+    | tac | awk '{ print "Commit",NR-1,"--",$0 }'; sleep 2; \
+  fi
+
+# Build Fluent Bit
+RUN cmake -DFLB_RELEASE=On \
+          -DFLB_TRACE=Off \
+          -DFLB_JEMALLOC=On \
+          -DFLB_TLS=On \
+          -DFLB_SHARED_LIB=Off \
+          -DFLB_EXAMPLES=Off \
+          -DFLB_HTTP_SERVER=On \
+          -DFLB_IN_SYSTEMD=On \
+          -DFLB_OUT_KAFKA=On \
+          -DFLB_ARROW=On ..
+
+RUN make -j $(getconf _NPROCESSORS_ONLN)
+RUN install bin/fluent-bit /fluent-bit/bin/
+
+# Configuration files
+COPY fluent-bit.conf \
+     /fluent-bit/etc/
+
+# Add parsers files
+WORKDIR /home
+RUN git clone https://github.com/fluent/fluent-bit-docker-image.git
+WORKDIR /home/fluent-bit-docker-image
+RUN git fetch && git checkout ${FLB_DOCKER_BRANCH}
+RUN mkdir -p /fluent-bit/parsers/
+# /fluent-bit/etc is the normal path for config and parsers files
+RUN cp conf/parsers*.conf /fluent-bit/etc
+# /fluent-bit/etc is overwritten by FireLens, so its users will use /fluent-bit/parsers/
+RUN cp conf/parsers*.conf /fluent-bit/parsers/
+
+ADD configs/parse-json.conf /fluent-bit/configs/
+ADD configs/minimize-log-loss.conf /fluent-bit/configs/
+
+FROM public.ecr.aws/amazonlinux/amazonlinux:latest
+RUN yum upgrade -y \
+    && yum install -y openssl11-devel \
+          cyrus-sasl-devel \
+          pkgconfig \
+          systemd-devel \
+          zlib-devel \
+          nc && rm -fr /var/cache/yum
+
+COPY --from=builder /fluent-bit /fluent-bit
+COPY --from=aws-fluent-bit-plugins:latest /kinesis-streams/bin/kinesis.so /fluent-bit/kinesis.so
+COPY --from=aws-fluent-bit-plugins:latest /kinesis-firehose/bin/firehose.so /fluent-bit/firehose.so
+COPY --from=aws-fluent-bit-plugins:latest /cloudwatch/bin/cloudwatch.so /fluent-bit/cloudwatch.so
+RUN mkdir -p /fluent-bit/licenses/fluent-bit
+RUN mkdir -p /fluent-bit/licenses/firehose
+RUN mkdir -p /fluent-bit/licenses/cloudwatch
+RUN mkdir -p /fluent-bit/licenses/kinesis
+COPY THIRD-PARTY /fluent-bit/licenses/fluent-bit/
+COPY --from=aws-fluent-bit-plugins:latest /kinesis-firehose/THIRD-PARTY \
+    /kinesis-firehose/LICENSE \
+    /fluent-bit/licenses/firehose/
+COPY --from=aws-fluent-bit-plugins:latest /cloudwatch/THIRD-PARTY \
+    /cloudwatch/LICENSE \
+    /fluent-bit/licenses/cloudwatch/
+COPY --from=aws-fluent-bit-plugins:latest /kinesis-streams/THIRD-PARTY \
+    /kinesis-streams/LICENSE \
+    /fluent-bit/licenses/kinesis/
+COPY AWS_FOR_FLUENT_BIT_VERSION /AWS_FOR_FLUENT_BIT_VERSION
+ADD ecs /ecs/
+
+# build init process
+COPY init_process_entrypoint.sh /init_process_entrypoint.sh
+RUN chmod +x /init_process_entrypoint.sh
+
+# Optional Metrics endpoint
+EXPOSE 2020
+
+# copy init process binary
+COPY --from=aws-fluent-bit-initprocess:latest /init_process /init_process
+
+# Entry point
+CMD /init_process_entrypoint.sh
+

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,12 @@
 
 all: release
 
+.PHONY: init
+init:
+	docker build --no-cache -t aws-fluent-bit-plugins:latest -f Dockerfile.plugins .
+	docker build --no-cache -t aws-fluent-bit-initprocess:latest -f Dockerfile.build_init_process .
+	docker build --no-cache -t amazon/aws-for-fluent-bit-init:latest -f Dockerfile.init .
+
 .PHONY: release
 release:
 	docker build --no-cache -t aws-fluent-bit-plugins:latest -f Dockerfile.plugins .

--- a/init_process.go
+++ b/init_process.go
@@ -1,0 +1,406 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
+
+// static file path
+const ConfigFileFolderPath = "init_process_fluent-bit_s3_config_files"
+const MainConfigFilePath = "init_process_fluent-bit.conf"
+const OriginalMainConfigFilePath = "/fluent-bit/etc/fluent-bit.conf"
+const InvokerFilePath = "invoker.sh"
+
+// default Fluent Bit command
+var FluentBitCommand = "exec /fluent-bit/bin/fluent-bit -e /fluent-bit/firehose.so -e /fluent-bit/cloudwatch.so -e /fluent-bit/kinesis.so"
+
+// global s3 client and flag
+var s3Client *s3.S3
+var exists3Client bool = false
+
+// global ecs metadata region
+var metadataReigon string = ""
+
+// set error log format
+func setErrorLog() {
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	log.SetPrefix("FluentBit Init Process -> ")
+}
+
+// create the invoker.sh
+// which will declare ECS Task Metadata as environment variables
+// and finally invoke Fluent Bit
+func createInvokerFile(filePath string) {
+	invokerFile, err := os.Create(filePath)
+	if err != nil {
+		log.Println(err)
+		log.Fatalln("Cannot create fluent bit invoker file")
+	}
+	defer invokerFile.Close()
+}
+
+type ECSTaskMetadata struct {
+	AWS_REGION          string `json:"AWSRegion"`
+	ECS_CLUSTER         string `json:"Cluster"`
+	ECS_TASK_ARN        string `json:"TaskARN"`
+	ECS_TASK_ID         string `json:"TaskID"`
+	ECS_FAMILY          string `json:"Family"`
+	ECS_LAUNCHTYPE      string `json:"LaunchType"` //If container agent is under version 1.45.0, this env var will be an empty string
+	ECS_REVISION        string `json:"Revision"`
+	ECS_TASK_DEFINITION string `json:"TaskDefinition"`
+}
+
+// get ECS Task Metadata via endpoint V4
+func getECSTaskMetadata() ECSTaskMetadata {
+	var metadata ECSTaskMetadata
+
+	ecsTaskMetadataEndpointV4 := os.Getenv("ECS_CONTAINER_METADATA_URI_V4")
+	if ecsTaskMetadataEndpointV4 == "" {
+		log.Panicln("Unable to get ECS Metadata")
+	}
+
+	res, err := http.Get(ecsTaskMetadataEndpointV4 + "/task")
+	if err != nil {
+		log.Panicln("failed to get ECS Metadata via HTTP Get")
+	}
+
+	response, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		log.Panicln("failed to read response")
+	}
+	res.Body.Close()
+
+	err = json.Unmarshal(response, &metadata)
+	if err != nil {
+		log.Println(err)
+		log.Panicln("failed to unmarshal ECS metadata")
+	}
+
+	ARN, err := arn.Parse(metadata.ECS_TASK_ARN)
+	if err != nil {
+		log.Println(err)
+		log.Panicln("failed to parse ECS TaskARN")
+	}
+
+	resourceID := strings.Split(ARN.Resource, "/")
+	taskID := resourceID[len(resourceID)-1]
+	metadata.ECS_TASK_ID = taskID
+	metadata.AWS_REGION = ARN.Region
+	metadata.ECS_TASK_DEFINITION = metadata.ECS_FAMILY + ":" + metadata.ECS_REVISION
+
+	return metadata
+}
+
+// set ECS Task Metadata as environment variables in the invoker.sh
+func setECSTaskMetadataAsEnvVar(metadata ECSTaskMetadata, filePath string) {
+	t := reflect.TypeOf(metadata)
+	v := reflect.ValueOf(metadata)
+
+	initProcessEntrypointFile, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, 0777)
+	if err != nil {
+		log.Println(err)
+		log.Fatalf("Unable to read init process entrypoint file: %s\n", filePath)
+	}
+	defer initProcessEntrypointFile.Close()
+
+	for i := 0; i < t.NumField(); i++ {
+		if v.Field(i).Interface().(string) == "" {
+			continue
+		}
+		writeContent := "export " + t.Field(i).Name + "=" + v.Field(i).Interface().(string) + "\n"
+		_, err = initProcessEntrypointFile.WriteString(writeContent)
+		if err != nil {
+			log.Println(err)
+			log.Fatalf("Cannot write %s in init process entrypoint file\n", writeContent[:len(writeContent)-2])
+		}
+	}
+}
+
+// create a new main config file
+func createMainConfigFile(filePath string) {
+	mainConfigFile, err := os.Create(filePath)
+	if err != nil {
+		log.Println(err)
+		log.Fatalln("Cannot create main config file")
+	}
+	defer mainConfigFile.Close()
+}
+
+// add @INCLUDE original main config file to the new main config file
+func includeOriginalMainConfigFile(mainConfigFilePath, originalMainConfigFilePath string) {
+	mainConfigFile, err := os.OpenFile(mainConfigFilePath, os.O_APPEND|os.O_WRONLY, 0777)
+	if err != nil {
+		log.Println(err)
+		log.Fatalf("Unable to read main config file: %s\n", mainConfigFilePath)
+	}
+	defer mainConfigFile.Close()
+
+	writeContent := "@INCLUDE " + originalMainConfigFilePath + "\n"
+	_, err = mainConfigFile.WriteString(writeContent)
+	if err != nil {
+		log.Println(err)
+		log.Fatalf("Cannot write %s in main config file: %s\n", writeContent[:len(writeContent)-2], mainConfigFilePath)
+	}
+}
+
+// create Fluent Bit command to use new main config file
+func createCommand(command *string, filePath string) {
+	*command = *command + " -c /" + filePath
+}
+
+// create a folder to store S3 config files user specified
+func createS3ConfigFileFolder(folderPath string) {
+	os.Mkdir(folderPath, os.ModePerm)
+}
+
+// get our built in config file or files from s3
+// process built-in config files directly
+// add S3 config files to folder "init_process_fluent-bit_s3_config_files"
+func getAllConfigFiles() {
+
+	//get all env vars
+	envs := os.Environ()
+	//find all env vars match specified prefix
+	for _, env := range envs {
+		var envKey string
+		var envValue string
+		env_kv := strings.SplitN(env, "=", 2)
+		if len(env_kv) != 2 {
+			log.Printf("Unrecognizable environment variables: %s\n", env)
+			continue
+		}
+
+		envKey = string(env_kv[0])
+		envValue = string(env_kv[1])
+
+		matched_s3, _ := regexp.MatchString("aws_fluent_bit_s3_", envKey)
+		matched_file, _ := regexp.MatchString("aws_fluent_bit_file_", envKey)
+		//if this env var's value is an arn
+		if matched_s3 {
+			getS3ConfigFile(envValue)
+		}
+		//if this env var's value is a path of our built-in config file
+		if matched_file {
+			processBuiltInConfigFile(envValue)
+		}
+	}
+}
+
+// process built-in config files
+func processBuiltInConfigFile(path string) {
+	content_b, err := ioutil.ReadFile(path)
+	if err != nil {
+		log.Println(err)
+		log.Fatalf("Cannot open file: %s\n", path)
+	}
+	content := string(content_b)
+	if strings.Contains(content, "[PARSER]") {
+		// this is a parser config file, change command
+		updateCommand(path)
+	} else {
+		// this is not a parser config file. @INCLUDE
+		writeInclude(path, MainConfigFilePath)
+	}
+}
+
+// download S3 config file to S3 config file folder
+func getS3ConfigFile(arn string) {
+	if !exists3Client {
+		createS3Client()
+	}
+
+	//e.g. "arn:aws:s3:::ygloa-bucket/s3_parser.conf"
+	arnBucketFile := arn[13:]
+	bucketAndFile := strings.SplitN(arnBucketFile, "/", 2)
+	if len(bucketAndFile) != 2 {
+		log.Fatalf("Unrecognizable arn: %s\n", arn)
+	}
+
+	bucketName := bucketAndFile[0]
+	s3FilePath := bucketAndFile[1]
+
+	// get bucket region
+	input := &s3.GetBucketLocationInput{
+		Bucket: aws.String(bucketName),
+	}
+
+	output, err := s3Client.GetBucketLocation(input)
+	if err != nil {
+		log.Println(bucketName + ":" + s3FilePath)
+		log.Println(err)
+		log.Println("Cannot get bucket region")
+	}
+
+	bucketRegion := aws.StringValue(output.LocationConstraint)
+	// Buckets in Region us-east-1 have a LocationConstraint of null.
+	// https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#GetBucketLocationOutput
+	if bucketRegion == "" {
+		bucketRegion = "us-east-1"
+	}
+
+	// create downloader
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(bucketRegion)},
+	)
+	if err != nil {
+		log.Println(err)
+		log.Fatalln("Cannot creat a new session")
+	}
+
+	// need to specify session region!
+	s3Downloader := s3manager.NewDownloader(sess)
+
+	// download file and store
+	s3FileName := strings.SplitN(s3FilePath, "/", -1)
+	fileFromS3, err := os.Create(ConfigFileFolderPath + "/" + s3FileName[len(s3FileName)-1])
+	if err != nil {
+		log.Println(err)
+		log.Fatalln("Cannot creat s3 config file to store config info")
+	}
+	defer fileFromS3.Close()
+
+	_, err = s3Downloader.Download(fileFromS3,
+		&s3.GetObjectInput{
+			Bucket: aws.String(bucketName),
+			Key:    aws.String(s3FilePath),
+		})
+	if err != nil {
+		log.Println(err)
+		log.Fatalf("Cannot download %s from s3\n", s3FileName)
+	}
+}
+
+// create a S3 client as the global S3 client for reuse
+func createS3Client() {
+	region := "us-east-1"
+	if metadataReigon != "" {
+		region = metadataReigon
+	}
+	s3Client = s3.New(session.Must(session.NewSession(&aws.Config{
+		// if not specify region here, missingregion error will raise when get bucket location
+		Region: aws.String(region),
+	})))
+
+	exists3Client = true
+}
+
+// process S3 config files user specified.
+func processS3ConfigFiles(folderPath string) {
+	fileInfos, err := ioutil.ReadDir(folderPath)
+	if err != nil {
+		log.Println(err)
+		log.Fatalf("Unable to read config files in %s folder\n", folderPath)
+	}
+
+	for _, file := range fileInfos {
+		content_b, err := ioutil.ReadFile(folderPath + "/" + file.Name())
+		if err != nil {
+			log.Println(err)
+			log.Fatalf("Cannot open file: %s\n", folderPath+"/"+file.Name())
+		}
+		content := string(content_b)
+		if strings.Contains(content, "[PARSER]") {
+			// this is a parser config file. change command
+			updateCommand("/" + folderPath + "/" + file.Name())
+		} else {
+			// this is not a parser config file. @INCLUDE
+			writeInclude("/"+folderPath+"/"+file.Name(), MainConfigFilePath)
+		}
+	}
+}
+
+// add @INCLUDE in main config file to include all customer specified config files
+func writeInclude(configFilePath, mainConfigFilePath string) {
+	mainConfigFile, err := os.OpenFile(mainConfigFilePath, os.O_APPEND|os.O_WRONLY, 0777)
+	if err != nil {
+		log.Println(err)
+		log.Fatalf("Unable to read main config file: %s\n", mainConfigFilePath)
+	}
+	defer mainConfigFile.Close()
+
+	writeContent := "@INCLUDE " + configFilePath + "\n"
+	_, err = mainConfigFile.WriteString(writeContent)
+	if err != nil {
+		log.Println(err)
+		log.Fatalf("Cannot write %s in main config file: %s\n", writeContent[:len(writeContent)-2], mainConfigFilePath)
+	}
+}
+
+// change the cammand if needed.
+// add modified command to the init_process_entrypoint.sh
+func updateCommand(parserFilePath string) {
+	FluentBitCommand = FluentBitCommand + " -R " + parserFilePath
+	log.Println("Command is change to -> " + FluentBitCommand)
+}
+
+// create a init_process_entrypoint.sh
+// which will declare ECS Task Metadata as environment variables
+// and finally invoke Fluent Bit
+func modifyInvokerFile(filePath string) {
+	invokerFile, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, 0777)
+	if err != nil {
+		log.Println(err)
+		log.Fatalf("Unable to read init process entrypoint file: %s\n", InvokerFilePath)
+	}
+	defer invokerFile.Close()
+
+	_, err = invokerFile.WriteString(FluentBitCommand)
+	if err != nil {
+		log.Println(err)
+		log.Fatalf("Cannot write %s in init process entrypoint file\n", FluentBitCommand)
+	}
+}
+
+func main() {
+
+	// set init process err log
+	setErrorLog()
+
+	// create the invoker.sh
+	// which will declare ECS Task Metadata as environment variables
+	// and finally invoke Fluent Bit
+	createInvokerFile(InvokerFilePath)
+
+	// get ECS Task Metadata and set the region for S3 client
+	metadata := getECSTaskMetadata()
+	metadataReigon = reflect.ValueOf(metadata).Field(0).Interface().(string)
+
+	// set ECS Task Metada as env vars in the invoker.sh
+	setECSTaskMetadataAsEnvVar(metadata, InvokerFilePath)
+
+	// create main config file which will be used invoke Fluent Bit
+	createMainConfigFile(MainConfigFilePath)
+
+	// use @INCLUDE to add original main config file
+	includeOriginalMainConfigFile(MainConfigFilePath, OriginalMainConfigFilePath)
+
+	// create Fluent Bit command to use new main config file
+	createCommand(&FluentBitCommand, MainConfigFilePath)
+
+	// create a S3 config files folder
+	createS3ConfigFileFolder(ConfigFileFolderPath)
+
+	// get our built in config file or files from s3
+	// process built-in config files directly
+	// add S3 config files to folder "init_process_fluent-bit_s3_config_files"
+	getAllConfigFiles()
+
+	// process all config files in config file folder, add @INCLUDE in main config file and change command
+	processS3ConfigFiles(ConfigFileFolderPath)
+
+	// modify invoker.sh, invoke fluent bit
+	modifyInvokerFile(InvokerFilePath)
+}
+

--- a/init_process_entrypoint.sh
+++ b/init_process_entrypoint.sh
@@ -1,0 +1,3 @@
+./init_process
+cat /init_process_fluent-bit.conf
+source /invoker.sh


### PR DESCRIPTION
### Description 

By submitting this pull request, users can build the new image  `amazon/aws-for-fluent-bit-init`  by using the command  `make init`




### Test 

I have tested the expected functionality of the init process.

Based on the [cloudwatchlogs example](https://github.com/aws-samples/amazon-ecs-firelens-examples/blob/mainline/examples/fluent-bit/cloudwatchlogs/task-definition.json), I added five environment variables in the ECS Task definition:

`aws_fluent_bit_s3_1`		arn:aws:s3:::ygloatest-east1/dummyParser.conf

```
[PARSER]
    Name dummy_test
    Format regex
    Regex ^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<STRING>.+)$
```

`aws_fluent_bit_s3_2`		arn:aws:s3:::ygloatest-east2/dummyFilter.conf

```
[FILTER]
    Name parser
    Match dummy.*
    Key_Name data
    Parser dummy_test
```

`aws_fluent_bit_s3_3`		arn:aws:s3:::ygloatest-west2/dummyInput.conf

```
[INPUT]
    Name dummy
    Tag  dummy.data
    Dummy {"data":"100 0.5 true This is example"}
```

`aws_fluent_bit_file_1`		/ecs/s3Output.conf

```
[OUTPUT]
    Name                         s3
    Match                        *
    bucket                       ygloatest-result-west2
    region                       ${AWS_REGION}
    total_file_size              1M
    upload_timeout               1m
    use_put_object               On
```

`aws_fluent_bit_file_2`		/ecs/stdOutput.conf

```
[OUTPUT]
    Name stdout
    Match *
```

Ran this task using new image which include init process. The result was as expected. 

The ecs task metadata was successfully set as environment variables and cloud be used in the config file. The main configuration file used @INCLUDE to add the original config file and all config files user specified. 

```
@INCLUDE /fluent-bit/etc/fluent-bit.conf
@INCLUDE /ecs/s3Output.conf
@INCLUDE /ecs/stdOutput.conf
@INCLUDE /init_process_fluent-bit_s3_config_files/dummyFilter.conf
@INCLUDE /init_process_fluent-bit_s3_config_files/dummyInput.conf
```

Fluent Bit command was updated successfully: `/fluent-bit/bin/fluent-bit -e /fluent-bit/firehose.so -e /fluent-bit/cloudwatch.so -e /fluent-bit/kinesis.so -c /init_process_fluent-bit.conf -R /init_process_fluent-bit_s3_config_files/dummyParser.conf`. 

Finally the logs are forwarded to cloudwatch, S3, and the container stdout.




### Details 

* Change `Makefile`
  Add the `make init` command, which has the same function as original `make release`, will also compile init_process.go, and finally build the image "amazon/aws-for-fluent-bit-init:latest"

* Create `Dockerfile.build_init_process`
  It is used to compile init_process.go to generate init process binary

* Create `Dockerfile.init`
  This file has the same function as the original `Dockerfile`. Compare to the original `Dockerfile`, it copies init process binary into the new fluent bit image and It will finally execute `init_process_entrypoint.sh`

* Create `init_process_entrypoint.sh`
  This file is used to run init process binary and run `invoker.sh`, which will execute export command to set ECS Metadata, and finally invoke Fluent Bit

* Create `init_process.go`
  This file is the code which used to achieve the desired init process functions


***Note:*** Will redesign the Dockerfile to merge `Dockerfile.build_init_process` in `Dockerfile.init`