### PR TITLE
added support for building Windows fluent-bit output plugins

### DIFF
--- a/Dockerfile.plugins
+++ b/Dockerfile.plugins
@@ -1,7 +1,8 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:latest
+FROM public.ecr.aws/lts/ubuntu:latest
+RUN apt-get update
+RUN apt-get install -y tar gzip git make gcc curl gcc-multilib gcc-mingw-w64
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
 RUN chmod +x /bin/gimme
-RUN yum upgrade -y && yum install -y tar gzip git make gcc
 ENV HOME /home
 RUN /bin/gimme 1.17.9
 ENV PATH ${PATH}:/home/.gimme/versions/go1.17.9.linux.arm64/bin:/home/.gimme/versions/go1.17.9.linux.amd64/bin
@@ -27,6 +28,7 @@ RUN if [ -n "$KINESIS_PLUGIN_BRANCH" ];then git fetch --all && git checkout $KIN
 RUN if [ -z "$KINESIS_PLUGIN_BRANCH" ];then git fetch --all --tags && git checkout tags/$KINESIS_PLUGIN_TAG -b $KINESIS_PLUGIN_TAG && git describe --tags;fi
 RUN go mod download
 RUN make release
+RUN make windows-release
 
 # Firehose
 
@@ -36,6 +38,7 @@ RUN if [ -n "$FIREHOSE_PLUGIN_BRANCH" ];then git fetch --all && git checkout $FI
 RUN if [ -z "$FIREHOSE_PLUGIN_BRANCH" ];then git fetch --all --tags && git checkout tags/$FIREHOSE_PLUGIN_TAG -b $FIREHOSE_PLUGIN_TAG && git describe --tags;fi
 RUN go mod download
 RUN make release
+RUN make windows-release
 
 # CloudWatch
 
@@ -45,3 +48,15 @@ RUN if [ -n "$CLOUDWATCH_PLUGIN_BRANCH" ];then git fetch --all && git checkout $
 RUN if [ -z "$CLOUDWATCH_PLUGIN_BRANCH" ];then git fetch --all --tags && git checkout tags/$CLOUDWATCH_PLUGIN_TAG -b $CLOUDWATCH_PLUGIN_TAG && git describe --tags;fi
 RUN go mod download
 RUN make release
+RUN make windows-release
+
+# Add all the built artifacts to an output folder and create an archive
+# We can copy this to the host for saving the artifacts
+
+RUN mkdir -p /plugins/linux
+RUN mkdir -p /plugins/windows
+RUN cp /kinesis-streams/bin/*.so /kinesis-firehose/bin/*.so /cloudwatch/bin/*.so /plugins/linux
+RUN cp /kinesis-streams/bin/*.dll /kinesis-firehose/bin/*.dll /cloudwatch/bin/*.dll /plugins/windows
+
+RUN tar -C /plugins/linux -cvf /plugins_linux.tar .
+RUN tar -C /plugins/windows -cvf /plugins_windows.tar .

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,19 @@ release:
 	docker build --no-cache -t aws-fluent-bit-plugins:latest -f Dockerfile.plugins .
 	docker build -t amazon/aws-for-fluent-bit:latest -f Dockerfile .
 
+.PHONY: windows-plugins
+windows-plugins:
+	./scripts/build_windows_plugins.sh \
+    	--KINESIS_PLUGIN_CLONE_URL=${KINESIS_PLUGIN_CLONE_URL} \
+    	--KINESIS_PLUGIN_TAG=${KINESIS_PLUGIN_TAG} \
+    	--KINESIS_PLUGIN_BRANCH=${KINESIS_PLUGIN_BRANCH} \
+    	--FIREHOSE_PLUGIN_CLONE_URL=${FIREHOSE_PLUGIN_CLONE_URL} \
+    	--FIREHOSE_PLUGIN_TAG=${FIREHOSE_PLUGIN_TAG} \
+    	--FIREHOSE_PLUGIN_BRANCH=${FIREHOSE_PLUGIN_BRANCH} \
+    	--CLOUDWATCH_PLUGIN_CLONE_URL=${CLOUDWATCH_PLUGIN_CLONE_URL} \
+    	--CLOUDWATCH_PLUGIN_TAG=${CLOUDWATCH_PLUGIN_TAG} \
+    	--CLOUDWATCH_PLUGIN_BRANCH=${CLOUDWATCH_PLUGIN_BRANCH}
+
 .PHONY: debug
 debug:
 	docker build --no-cache -t aws-fluent-bit-plugins:latest -f Dockerfile.plugins .
@@ -95,3 +108,10 @@ integ:
 .PHONY: delete-resources
 delete-resources:
 	./integ/integ.sh delete
+
+.PHONY: clean
+clean:
+	rm -rf ./build
+	docker image remove -f aws-fluent-bit-plugins:latest
+	docker image remove -f amazon/aws-for-fluent-bit:latest
+	docker image prune -f

--- a/buildspec_windows_plugins.yml
+++ b/buildspec_windows_plugins.yml
@@ -1,0 +1,32 @@
+version: 0.2
+
+env:
+  exported-variables:
+    - PLUGINS_BUILD_VERSION
+phases:
+  install:
+    commands:
+      - echo "Building the AWS managed Fluent-bit output plugins"
+      - apt-get update -y
+  build:
+    commands:
+      - |
+        KINESIS_PLUGIN_CLONE_URL="https://github.com/aws/amazon-kinesis-streams-for-fluent-bit.git" \
+        KINESIS_PLUGIN_TAG=$KINESIS_PLUGIN_TAG \
+        KINESIS_PLUGIN_BRANCH="" \
+        FIREHOSE_PLUGIN_CLONE_URL="https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit.git" \
+        FIREHOSE_PLUGIN_TAG=$FIREHOSE_PLUGIN_TAG \
+        FIREHOSE_PLUGIN_BRANCH="" \
+        CLOUDWATCH_PLUGIN_CLONE_URL="https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit.git" \
+        CLOUDWATCH_PLUGIN_TAG=$CLOUDWATCH_PLUGIN_TAG \
+        CLOUDWATCH_PLUGIN_BRANCH="" \
+        make windows-plugins
+  post_build:
+    commands:
+      - export PLUGINS_BUILD_VERSION="$AWS_FOR_FLUENT_BIT_VERSION/$BUILD_NUMBER"
+artifacts:
+  name: $PLUGINS_BUILD_VERSION
+  base-directory: $CODEBUILD_SRC_DIR
+  files:
+    - 'build/windows/*'
+  discard-paths: yes

--- a/scripts/build_windows_plugins.sh
+++ b/scripts/build_windows_plugins.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# 	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+set -euo pipefail
+
+# List of arguments the script can accept
+ARGUMENT_LIST=(
+  "KINESIS_PLUGIN_CLONE_URL"
+  "KINESIS_PLUGIN_TAG"
+  "KINESIS_PLUGIN_BRANCH"
+  "FIREHOSE_PLUGIN_CLONE_URL"
+  "FIREHOSE_PLUGIN_TAG"
+  "FIREHOSE_PLUGIN_BRANCH"
+  "CLOUDWATCH_PLUGIN_CLONE_URL"
+  "CLOUDWATCH_PLUGIN_TAG"
+  "CLOUDWATCH_PLUGIN_BRANCH"
+)
+
+# A variable to hold the build arguments for docker build
+PLUGIN_BUILD_ARGS=""
+
+# Method to display usage of the script
+usage() {
+  echo "Usage: $0 [--KINESIS_PLUGIN_CLONE_URL <string>] [--KINESIS_PLUGIN_TAG <string>] [--KINESIS_PLUGIN_BRANCH <string>]\
+  [--FIREHOSE_PLUGIN_CLONE_URL <string>] [--FIREHOSE_PLUGIN_TAG <string>] [--FIREHOSE_PLUGIN_BRANCH <string>]\
+  [--CLOUDWATCH_PLUGIN_CLONE_URL <string>] [--CLOUDWATCH_PLUGIN_TAG <string>] [--CLOUDWATCH_PLUGIN_BRANCH <string>]" 1>&2;
+  exit 1;
+}
+
+# Read arguments
+opts=$(getopt \
+  --longoptions "$(printf "%s:," "${ARGUMENT_LIST[@]}")" \
+  --name "$(basename "$0")" \
+  --options "" \
+  -- "$@"
+)
+
+eval set -- "$opts"
+
+# Build plugin build arguments
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    --KINESIS_PLUGIN_CLONE_URL)
+      PLUGIN_BUILD_ARGS="$PLUGIN_BUILD_ARGS --build-arg KINESIS_PLUGIN_CLONE_URL=$2"
+      shift 2;;
+    --KINESIS_PLUGIN_TAG)
+      PLUGIN_BUILD_ARGS="$PLUGIN_BUILD_ARGS --build-arg KINESIS_PLUGIN_TAG=$2"
+      shift 2;;
+    --KINESIS_PLUGIN_BRANCH)
+      PLUGIN_BUILD_ARGS="$PLUGIN_BUILD_ARGS --build-arg KINESIS_PLUGIN_BRANCH=$2"
+      shift 2;;
+    --FIREHOSE_PLUGIN_CLONE_URL)
+      PLUGIN_BUILD_ARGS="$PLUGIN_BUILD_ARGS --build-arg FIREHOSE_PLUGIN_CLONE_URL=$2"
+      shift 2;;
+    --FIREHOSE_PLUGIN_TAG)
+      PLUGIN_BUILD_ARGS="$PLUGIN_BUILD_ARGS --build-arg FIREHOSE_PLUGIN_TAG=$2"
+      shift 2;;
+    --FIREHOSE_PLUGIN_BRANCH)
+      PLUGIN_BUILD_ARGS="$PLUGIN_BUILD_ARGS --build-arg FIREHOSE_PLUGIN_BRANCH=$2"
+      shift 2;;
+    --CLOUDWATCH_PLUGIN_CLONE_URL)
+      PLUGIN_BUILD_ARGS="$PLUGIN_BUILD_ARGS --build-arg CLOUDWATCH_PLUGIN_CLONE_URL=$2"
+      shift 2;;
+    --CLOUDWATCH_PLUGIN_TAG)
+      PLUGIN_BUILD_ARGS="$PLUGIN_BUILD_ARGS --build-arg CLOUDWATCH_PLUGIN_TAG=$2"
+      shift 2;;
+    --CLOUDWATCH_PLUGIN_BRANCH)
+      PLUGIN_BUILD_ARGS="$PLUGIN_BUILD_ARGS --build-arg CLOUDWATCH_PLUGIN_BRANCH=$2"
+      shift 2;;
+    # End of arguments. End here and break.
+    --) shift; break ;;
+    # Any other argument is an invalid arg.
+    *) usage;;
+  esac
+done
+
+echo "Plugin build arguments are: $PLUGIN_BUILD_ARGS"
+
+# Change the directory to root of the repository
+scripts=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "${scripts}/.."
+
+# Create the build output folder
+mkdir -p ./build/windows
+echo "Created build output folder"
+
+# Build plugin image and then copy the windows plugins
+docker build $PLUGIN_BUILD_ARGS --no-cache -t aws-fluent-bit-plugins:latest -f ./Dockerfile.plugins .
+docker create -ti --name plugin-build-container aws-fluent-bit-plugins:latest bash
+docker cp plugin-build-container:/plugins_windows.tar ./build/windows/plugins_windows.tar
+docker rm -f plugin-build-container
+echo "Copied plugin archive to the build output folder"
+
+# Extract the plugin tar into the output folder
+tar -xvf ./build/windows/plugins_windows.tar -C ./build/windows/
+rm ./build/windows/plugins_windows.tar
+echo "Extracted Windows plugins in the build output folder"

--- a/windows.versions
+++ b/windows.versions
@@ -1,0 +1,12 @@
+{
+  "windows": [
+    {
+      "version": "2.26.1",
+      "build": "1",
+      "fluent-bit": "1.9.4",
+      "kinesis-plugin": "1.9.0",
+      "firehose-plugin": "1.6.1",
+      "cloudwatch-plugin": "1.8.0"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

As part of Windows support to aws-for-fluent-bit, we would be building the plugins and the fluent-bit binaries using CodeBuild projects and then staging the artifacts in an S3 bucket. We would then build our container images with these artifacts as per the build version.

We also wanted to introduce a mechanism wherein we can patch an existing version of Windows image. So let's say, we have 2.26.1 is the current version and we want to patch it for some bug. The new workflow would allow this patching and ensure that all the artifacts for any given aws-for-fluent-bit version are consistent set.

In this PR, we have-
- Added Codebuild spec for building the artifacts
- Added Make file target to build the plugins
- Added bash script which invokes the docker command to build the artifacts
- Changes in dockerfile.plugins to support Windows
- Added `windows.versions` file which has the config for supported fluent-bit versions for Windows.

## Explanation of workflow
The way this entire piece works is-
- We would create a Step function which would read the `windows.versions` config and then in iteration call a CodeBuild project
- We would set the environment variables for the CodeBuild project using `EnvironmentVariablesOverride` and set the environment to be privileged so as to run docker container
- CodeBuild project would run `build_windows_plugins.sh` script with the overrides of all the versions passed on by the Step function.
- `build_windows_plugins.sh` script in turn spins the docker containers to build the artifacts. It takes in the overrides for repository, tag, and branch for all the plugins.
- Once the artifacts are built, we copy them from the image onto the host from where CodeBuild would stage them in S3. The S3 key would be `AWS_FOR_FLUENT_BIT_VERSION/BUILD_NUMBER`. 
Therefore, in future, if we need to patch the specific older version of aws-for-fluent-bit, we just need to update the config with versions of all packages. During image build, we can select the appropriate build number.

## Testing

Created a sample CodePipeline, Step Function and a CodeBuild project as mentioned above. 
Provided override for the repositories of plugins to the personal fork.

Then ran the pipeline to ensure that versioned artifacts are present in S3.

*Issue #, if available:*
NA

## Description of changes:
added support for building Windows fluent-bit output plugins

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
