### PR TITLE
Debugging guide: add IMDS note for k8s

### DIFF
--- a/troubleshooting/debugging.md
+++ b/troubleshooting/debugging.md
@@ -169,6 +169,14 @@ aws ec2 modify-instance-metadata-options \
      --http-endpoint enabled
 ```
 
+The other way to override the IMDS issue on EKS platform, without making the hop-limit to 2 will be setting up the hostNetwork to true, with the dnsPolicy as 'ClusterFirstWithHostNet':
+
+```
+    spec:
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+```
+
 #### Searching old issues
 
 When you first see an issue that you don't understand, the best option is to check *open and closed* issues in both repos:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changes to debuggin file to provide support for the imds with hop 1, previously as per doc, we need to modify instances for hop2 to get the credentials.

with hostNetwork, even with hop1, it can fetch the credentials.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
