### PR TITLE
added support for building Windows images

### DIFF
--- a/Dockerfile.plugins
+++ b/Dockerfile.plugins
@@ -53,10 +53,20 @@ RUN make windows-release
 # Add all the built artifacts to an output folder and create an archive
 # We can copy this to the host for saving the artifacts
 
-RUN mkdir -p /plugins/linux
-RUN mkdir -p /plugins/windows
+RUN mkdir -p /plugins/linux/licenses/kinesis /plugins/linux/licenses/firehose /plugins/linux/licenses/cloudwatch
+RUN mkdir -p /plugins/windows/licenses/kinesis /plugins/windows/licenses/firehose /plugins/windows/licenses/cloudwatch
+
+# Copy binaries
 RUN cp /kinesis-streams/bin/*.so /kinesis-firehose/bin/*.so /cloudwatch/bin/*.so /plugins/linux
 RUN cp /kinesis-streams/bin/*.dll /kinesis-firehose/bin/*.dll /cloudwatch/bin/*.dll /plugins/windows
+
+# Copy licenses
+RUN cp /kinesis-streams/THIRD-PARTY /kinesis-streams/LICENSE /plugins/linux/licenses/kinesis
+RUN cp /kinesis-firehose/THIRD-PARTY /kinesis-firehose/LICENSE /plugins/linux/licenses/firehose
+RUN cp /cloudwatch/THIRD-PARTY /cloudwatch/LICENSE /plugins/linux/licenses/cloudwatch
+RUN cp /kinesis-streams/THIRD-PARTY /kinesis-streams/LICENSE /plugins/windows/licenses/kinesis
+RUN cp /kinesis-firehose/THIRD-PARTY /kinesis-firehose/LICENSE /plugins/windows/licenses/firehose
+RUN cp /cloudwatch/THIRD-PARTY /cloudwatch/LICENSE /plugins/windows/licenses/cloudwatch
 
 RUN tar -C /plugins/linux -cvf /plugins_linux.tar .
 RUN tar -C /plugins/windows -cvf /plugins_windows.tar .

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,0 +1,42 @@
+# escape=`
+
+ARG TAG=ltsc2019
+ARG AWS_FOR_FLUENT_BIT_VERSION
+
+#
+# Runtime Image - Windows Server Core
+#
+FROM mcr.microsoft.com/windows/servercore:$TAG as runtime
+
+WORKDIR C:/
+
+ADD fluent-bit /fluent-bit
+
+ADD fluent-bit-plugins /fluent-bit
+
+ADD ecs /ecs
+
+ADD AWS_FOR_FLUENT_BIT_VERSION /AWS_FOR_FLUENT_BIT_VERSION
+
+ADD entrypoint.ps1 /entrypoint.ps1
+
+# Set the environment variable
+RUN setx /M PATH "%PATH%;C:\fluent-bit\bin"
+
+# Metadata as defined in OCI image spec annotations
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+LABEL org.opencontainers.image.title="AWS for Fluent Bit" `
+      org.opencontainers.image.description="Fluent Bit is an open source and multi-platform Log Processor and Forwarder which allows you to collect data/logs from different sources, unify and send them to multiple destinations. It's fully compatible with Docker and Kubernetes environments." `
+      org.opencontainers.image.version=$AWS_FOR_FLUENT_BIT_VERSION `
+      org.opencontainers.image.authors="FireLens Team <aws-firelens@amazon.com>" `
+      org.opencontainers.image.url="https://gallery.ecr.aws/aws-observability/aws-for-fluent-bit" `
+      org.opencontainers.image.documentation="https://github.com/aws/aws-for-fluent-bit" `
+      org.opencontainers.image.vendor="Amazon Web Services" `
+      org.opencontainers.image.licenses="Apache-2.0" `
+      org.opencontainers.image.source="https://github.com/aws/aws-for-fluent-bit"
+
+# Optional Metrics endpoint
+EXPOSE 2020
+
+# Entry point
+CMD Powershell.exe -Command C:\entrypoint.ps1

--- a/buildspec_windows_fluent-bit.yml
+++ b/buildspec_windows_fluent-bit.yml
@@ -1,0 +1,27 @@
+version: 0.2
+
+env:
+  exported-variables:
+    - PLUGINS_BUILD_VERSION
+phases:
+  build:
+    commands:
+      # Switch to powershell.
+      - powershell
+      # Obtain CODEBUILD_SRC_DIR from environment variables.
+      - $CODEBUILD_SRC_DIR = [System.Environment]::GetEnvironmentVariable('CODEBUILD_SRC_DIR')
+      # Set the required variables
+      - $FLB_VERSION = [System.Environment]::GetEnvironmentVariable('FLB_VERSION')
+      - $AWS_FOR_FLUENT_BIT_VERSION = [System.Environment]::GetEnvironmentVariable('AWS_FOR_FLUENT_BIT_VERSION')
+      - $BUILD_NUMBER = [System.Environment]::GetEnvironmentVariable('BUILD_NUMBER')
+      # Invoke the build script
+      - Invoke-Expression -Command "${CODEBUILD_SRC_DIR}/scripts/build_windows_fluent_bit.ps1 -FLB_VERSION ${FLB_VERSION}"
+  post_build:
+    commands:
+      - $PLUGINS_BUILD_VERSION="${AWS_FOR_FLUENT_BIT_VERSION}/${BUILD_NUMBER}"
+artifacts:
+  name: $PLUGINS_BUILD_VERSION
+  base-directory: $CODEBUILD_SRC_DIR
+  files:
+    - 'build/windows/*'
+  discard-paths: yes

--- a/scripts/build_windows_fluent_bit.ps1
+++ b/scripts/build_windows_fluent_bit.ps1
@@ -1,0 +1,282 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# 	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+<#
+    .SYNOPSIS
+    Builds the Windows artifacts for fluent-bit supported by AWS
+
+    .DESCRIPTION
+    This script builds the Windows artifacts for fluent-bit supported by AWS
+
+    .PARAMETER FLB_VERSION
+    Specifies the fluent bit version to be used for the build
+
+    .PARAMETER FLB_REPOSITORY_URL
+    [Optional] Specifies the fluent bit repository to be used for the build. Defaults to 'https://github.com/fluent/fluent-bit'.
+
+    .INPUTS
+    None. You cannot pipe objects to this script.
+
+    .OUTPUTS
+    None. This script does not generate an output object.
+
+    .EXAMPLE
+    PS> .\build_windows_fluent_bit.ps1 -FLB_VERSION "1.9.4"
+    Builds the Windows artifacts based on fluent bit 1.9.4.
+
+    .EXAMPLE
+    PS> .\build_windows_fluent_bit.ps1 -FLB_VERSION "1.9.4" -FLB_REPOSITORY_URL "https://github.com/xxxxx/fluent-bit"
+    Builds the Windows artifacts based on fluent bit 1.9.4 from the xxxxx fork of fluent-bit.
+    Beneficial for dev testing.
+#>
+
+Param(
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$FLB_VERSION,
+
+    [Parameter(Mandatory=$false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$FLB_REPOSITORY_URL = "https://github.com/fluent/fluent-bit"
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Constants
+$FlexBisonVersion = "2.5.22"
+$OpenSSLVersion = "3.0.5"
+
+# Directory paths
+$BaseDir = "C:\build"
+$StagingDirectory = "C:\staging\fluent-bit"
+$FluentBitBaseDirectory = "${BaseDir}\fluent-bit"
+$AWSForFluentBitRootDir = "${PSScriptRoot}\.."
+$VCRootPath = "C:\BuildTools"
+
+# Paths of various installations
+$CmakePath = "${VCRootPath}\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
+$VCToolsPath = "${VCRootPath}\VC\Auxiliary\Build"
+$PerlPath = "C:\Strawberry\perl\bin"
+$NASMPath = "${env:ProgramFiles}\NASM"
+$FlexBisonPath = "C:\WinFlexBison"
+$GitInstallationPath = "${env:ProgramFiles}\Git\cmd"
+$OpenSSLInstallationPath = "${env:ProgramFiles}\OpenSSL"
+
+# All the URLS.
+$VisualStudioDownloadURL = "https://aka.ms/vs/16/release/vs_buildtools.exe"
+$VisualStudioChannelURL = "https://aka.ms/vs/16/release/channel"
+$FlexBisonDownloadURL = "https://github.com/lexxmark/winflexbison/releases/download/v${FlexBisonVersion}/win_flex_bison-${FlexBisonVersion}.zip"
+
+# Create working directories
+Write-Host "Creating the build directory"
+New-Item -Path $BaseDir -ItemType Directory
+New-Item -Path $OpenSSLInstallationPath -ItemType Directory
+New-Item -Path "${AWSForFluentBitRootDir}\build\windows" -ItemType Directory
+New-Item -Path $StagingDirectory -ItemType Directory
+# Create directory structure inside staging folder
+New-Item -Path "$StagingDirectory\bin" -ItemType Directory
+New-Item -Path "$StagingDirectory\etc" -ItemType Directory
+New-Item -Path "$StagingDirectory\log" -ItemType Directory
+New-Item -Path "$StagingDirectory\parsers" -ItemType Directory
+New-Item -Path "$StagingDirectory\configs" -ItemType Directory
+New-Item -Path "$StagingDirectory\licenses\fluent-bit" -ItemType Directory
+cd $BaseDir
+
+# Install Chocolatey as per instructions from https://chocolatey.org/install
+Set-ExecutionPolicy Bypass -Scope Process -Force;
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
+iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
+# Install Git
+Write-Host "Installing Git..."
+choco install git -y
+if ($LASTEXITCODE)
+{
+    throw ("Failed to install git using chocolatey")
+}
+Write-Host "Git installation completed."
+
+# Download Microsoft Visual C++ to compile Fluent Bit
+Write-Host "Downloading Microsoft Visual C++"
+(New-Object System.Net.WebClient).DownloadFile($VisualStudioDownloadURL, "$BaseDir/vs_buildtools.exe")
+(New-Object System.Net.WebClient).DownloadFile($VisualStudioChannelURL, "$BaseDir/VisualStudio.chman")
+
+# Install Microsoft Visual C++
+Write-Host "Installaing Microsoft Visual C++ ..."
+Start-Process "$BaseDir/vs_buildtools.exe" `
+-ArgumentList "--quiet", "--wait", "--norestart ", "--nocache", `
+"--installPath $VCRootPath", `
+"--channelUri $BaseDir\VisualStudio.chman", `
+"--installChannelUri $BaseDir\VisualStudio.chman", `
+"--add Microsoft.VisualStudio.Workload.VCTools", `
+"--includeRecommended" -NoNewWindow -Wait;
+if ($LASTEXITCODE)
+{
+    throw "Failed to install Microsoft Visual C++"
+}
+Write-Host "Installation of Microsoft Visual C++ completed."
+
+# Find the version of VC and set the path for NMake
+$VCVersion = (Get-ChildItem -Path "${VCRootPath}\VC\Tools\MSVC")[0].Name
+$NmakePath = "${VCRootPath}\VC\Tools\MSVC\${VCVersion}\bin\Hostx64\x64"
+
+# Download FlexBison as suggsted by https://docs.fluentbit.io/manual/installation/windows
+Write-Host "Downloading Flex and Bison."
+(New-Object System.Net.WebClient).DownloadFile($FlexBisonDownloadURL, "$BaseDir/win_flex_bison.zip")
+
+# Expand and copy the flex and bison binaries
+Write-Host "Setting up Flex and Bison on the instance."
+Expand-Archive "$BaseDir/win_flex_bison.zip" -Destination "${FlexBisonPath}";
+Copy-Item -Path "C:/WinFlexBison/win_bison.exe" "${FlexBisonPath}\bison.exe";
+Copy-Item -Path "C:/WinFlexBison/win_flex.exe" "${FlexBisonPath}\flex.exe";
+
+# Install strawberry perl which is a requirement for building OpenSSL
+choco install strawberryperl -y
+# Install NASM which required for building OpenSSL
+choco install nasm -y
+
+# Initialize environment for VC
+$tempFile = [IO.Path]::GetTempFileName()
+# Store the output of cmd.exe.  We also ask cmd.exe to output
+# the environment table after the batch file completes.
+# Borrowed from Powershell Community Extensions
+# https://github.com/Pscx/Pscx
+cmd.exe /c " `"${VCToolsPath}\vcvars64.bat`" && set > `"$tempFile`" "
+if ($LASTEXITCODE)
+{
+    throw "Failed to initialize environment for Microsoft Visual C++"
+}
+
+# Go through the environment variables in the temp file.
+# For each of them, set the variable in our local environment.
+Get-Content $tempFile | Foreach-Object {
+    if ($_ -match "^(.*?)=(.*)$")
+    {
+        Set-Content "env:\$($matches[1])" $matches[2]
+    }
+}
+Remove-Item $tempFile
+
+# Set the environment variables
+Write-Host "Setting up the required environment variables."
+$env:Path=$env:Path + ";${GitInstallationPath};${CmakePath};${NmakePath};${VCToolsPath};${PerlPath};${NASMPath};${FlexBisonPath}"
+
+# Configure git config
+git config --global user.email "aws-firelens@amazon.com"
+git config --global user.name "FireLens Team"
+
+# Clone and build OpenSSL
+# https://github.com/openssl/openssl/blob/master/NOTES-WINDOWS.md
+Write-Host "Cloning OpenSSL repository"
+cd $BaseDir
+git clone https://github.com/openssl/openssl.git
+cd openssl
+
+# Fetch the required version
+git fetch --all --tags
+git checkout tags/"openssl-${OpenSSLVersion}" -b "openssl-${OpenSSLVersion}"
+git describe --tags
+
+# Run perl configure as mentioned in the docs
+perl Configure VC-WIN64A enable-fips no-shared
+if ($LASTEXITCODE)
+{
+    throw "Failed to initialize environment for Openssl"
+}
+
+# Build the target in the makefile
+nmake /S
+if ($LASTEXITCODE)
+{
+    throw "Failed to build release for Openssl"
+}
+
+# Run test target
+nmake test VERBOSE_FAILURE=yes HARNESS_JOBS=4
+if ($LASTEXITCODE)
+{
+    throw "Failed to run test target"
+}
+
+# Install the openssl artifacts
+nmake install
+if ($LASTEXITCODE)
+{
+    throw "Failed to install the openssl"
+}
+
+# Clone the fluent-bit repository
+Write-Host "Cloning fluent-bit upstream repository."
+cd $BaseDir
+git clone $FLB_REPOSITORY_URL
+cd fluent-bit
+
+# Fetch the required version
+git fetch --all --tags
+git checkout tags/v${FLB_VERSION} -b v${FLB_VERSION}
+git describe --tags
+cd build
+
+# Apply fluent-bit patches, if any.
+$content = Get-Content -Path "${AWSForFluentBitRootDir}\AWS_FLB_CHERRY_PICKS"
+$lines = $content | Select-String -Pattern "^#" -NotMatch
+if ($lines.length -gt 0)
+{
+    $lines | ForEach-Object {
+        $token = $_ -split '\s+'
+        git fetch $token[0] $token[1]
+        git cherry-pick $token[2]
+    }
+    Write-Host "Cherry Pick Patch Summary:"
+    git log --oneline -$($lines.length + 1)
+}
+
+# Build fluent-bit
+cmake -G "Visual Studio 16 2019" -DCMAKE_BUILD_TYPE=Release -DFLB_RELEASE=On -DOPENSSL_ROOT_DIR="${OpenSSLInstallationPath}" ../
+cmake --build . --config Release
+if ($LASTEXITCODE)
+{
+    throw "Failed to build fluent-bit artifacts"
+}
+
+# Copy the built binaries to the staging folder
+Copy-Item -Path "${FluentBitBaseDirectory}\build\bin\Release\fluent-bit.exe" -Destination "${StagingDirectory}\bin"
+Copy-Item -Path "${FluentBitBaseDirectory}\build\bin\Release\fluent-bit.dll" -Destination "${StagingDirectory}\bin"
+Copy-Item -Path "${FluentBitBaseDirectory}\build\bin\Release\fluent-bit.pdb" -Destination "${StagingDirectory}\bin"
+
+# Copy various configurations
+Copy-Item -Path "${FluentBitBaseDirectory}\conf\parsers*.conf" -Destination "${StagingDirectory}\etc"
+# /fluent-bit/etc is overwritten by FireLens, so its users will use /fluent-bit/parsers/
+Copy-Item -Path "${FluentBitBaseDirectory}\conf\parsers*.conf" -Destination "${StagingDirectory}\parsers"
+
+Copy-Item -Path "${AWSForFluentBitRootDir}\fluent-bit.conf" -Destination "${StagingDirectory}\etc"
+Copy-Item -Path "${AWSForFluentBitRootDir}\configs\parse-json.conf" -Destination "${StagingDirectory}\configs"
+Copy-Item -Path "${AWSForFluentBitRootDir}\configs\minimize-log-loss.conf" -Destination "${StagingDirectory}\configs"
+
+# Copy license
+Copy-Item -Path "${AWSForFluentBitRootDir}\THIRD-PARTY" -Destination "${StagingDirectory}\licenses\fluent-bit"
+
+# Compress the folder
+Compress-Archive -Path "${StagingDirectory}\*" -Destination "${AWSForFluentBitRootDir}\build\windows\fluent-bit.zip"
+
+# Compress ecs folder which needs to be added to the image
+Compress-Archive -Path "${AWSForFluentBitRootDir}\ecs\*" -Destination "${AWSForFluentBitRootDir}\build\windows\ecs.zip"
+
+# Copy the version of aws-for-fluent-bit
+Copy-Item -Path "${AWSForFluentBitRootDir}\AWS_FOR_FLUENT_BIT_VERSION" -Destination "${AWSForFluentBitRootDir}\build\windows\AWS_FOR_FLUENT_BIT_VERSION"
+
+# Copy the entrypoint script which needs to be added to the image
+Copy-Item -Path "${AWSForFluentBitRootDir}\scripts\entrypoint.ps1" -Destination "${AWSForFluentBitRootDir}\build\windows\entrypoint.ps1"
+
+# Copy the dockerfile used to build an image. This would ensure that the images remains constant in time.
+Copy-Item -Path "${AWSForFluentBitRootDir}\Dockerfile.windows" -Destination "${AWSForFluentBitRootDir}\build\windows\Dockerfile.windows"

--- a/scripts/build_windows_image.ps1
+++ b/scripts/build_windows_image.ps1
@@ -1,0 +1,156 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# 	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+<#
+    .SYNOPSIS
+    Builds the aws-for-fluent-bit Windows image for a specific platform
+
+    .DESCRIPTION
+    This script builds the aws-for-fluent-bit Windows image for a specific platform
+
+    .PARAMETER Region
+    [Optional] Specifies the region. Defaults to 'us-west-2'.
+
+    .PARAMETER Platform
+    Specifies the platform for which the image needs to be built. Valid values are 'windows2019', and 'windows2022'.
+
+    .PARAMETER S3BaseBucket
+    Specifies the S3 base bucket where the artifacts needed for the image are staged.
+
+    .PARAMETER AccountId
+    Specifies the AWS account number where the image needs to be pushed
+
+    .PARAMETER AWSForFluentBitVersion
+    Specifies the aws for fluent bit version to be used for the build
+
+    .PARAMETER BuildNumber
+    [Optional] Specifies the build number for the given version. Defaults to 1.
+
+    .INPUTS
+    None. You cannot pipe objects to this script.
+
+    .OUTPUTS
+    None. This script does not generate an output object.
+
+    .EXAMPLE
+    PS> .\build_windows_image.ps1 -Platform "windows2019" -S3BaseBucket "staging" -AccountId 12345 -AWSForFluentBitVersion "2.26.0"
+    Builds the Windows Server 2019 based aws-for-fluent-bit image with artifacts from S3- staging/2.26.0/1. The image in ECR would then be
+    "12345.dkr.ecr.us-west-2.amazonaws.com/aws-for-fluent-bit:2.26.0-ltsc2019"
+#>
+
+Param(
+    [Parameter(Mandatory=$false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Region = "us-west-2",
+
+    [Parameter(Mandatory=$true)]
+    [ValidateSet("windows2019","windows2022")]
+    [string]$Platform,
+
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$S3BaseBucket,
+
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$AccountId,
+
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$AWSForFluentBitVersion,
+
+    [Parameter(Mandatory=$false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$BuildNumber = "1"
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Select the base image tag based on the platform
+switch ($Platform) {
+    "windows2019" {
+        $BASEIMAGETAG = "ltsc2019"
+    }
+
+    "windows2022" {
+        $BASEIMAGETAG = "ltsc2022"
+    }
+}
+
+Write-Host ("Using tag {0} for the platform {1}" -f $BASEIMAGETAG, $Platform)
+
+# Define Variables
+$WorkingDir = "C:\build"
+$StagingDir = "C:\staging"
+$FLBStagingLocationOnHost = "${StagingDir}\fluent-bit"
+$FLBPluginsStagingLocationOnHost = "${StagingDir}\fluent-bit-plugins"
+$ECSConfigStagingLocationOnHost = "${StagingDir}\ecs"
+$S3StagingKey = "${AWSForFluentBitVersion}/${BuildNumber}"
+$FLBArchiveName = "fluent-bit.zip"
+$FLBPluginsArchiveName = "plugins_windows.tar"
+$ECSConfigArchiveName = "ecs.zip"
+$AWSForFluentBitVersionFilename = "AWS_FOR_FLUENT_BIT_VERSION"
+$EntrypointScriptName = "entrypoint.ps1"
+$Dockerfile = "Dockerfile.windows"
+$ecrImageName = "${AccountId}.dkr.ecr.${Region}.amazonaws.com/aws-for-fluent-bit:${AWSForFluentBitVersion}-${BASEIMAGETAG}"
+
+# Create all the directories
+Write-Host "Creating all the required directories"
+New-Item -Path $WorkingDir -ItemType Directory -Force
+New-Item -Path $StagingDir -ItemType Directory -Force
+New-Item -Path $FLBStagingLocationOnHost -ItemType Directory -Force
+New-Item -Path $FLBPluginsStagingLocationOnHost -ItemType Directory -Force
+New-Item -Path $ECSConfigStagingLocationOnHost -ItemType Directory -Force
+
+# Change working directory
+cd $WorkingDir
+
+# Log into ECR
+Write-Host "Logging into ECR"
+$command = Invoke-Expression "(Get-ECRLoginCommand -Region ${Region}).Command"
+Invoke-Expression $command
+
+# Download the artifacts to host.
+Write-Host "Downloading the fluent-bit and fluent-bit plugins from S3"
+Read-S3Object -BucketName "${S3BaseBucket}" -Key "${S3StagingKey}/${FLBArchiveName}" -File "${WorkingDir}\${FLBArchiveName}"
+Read-S3Object -BucketName "${S3BaseBucket}" -Key "${S3StagingKey}/${FLBPluginsArchiveName}" -File "${WorkingDir}\${FLBPluginsArchiveName}"
+Read-S3Object -BucketName "${S3BaseBucket}" -Key "${S3StagingKey}/${ECSConfigArchiveName}" -File "${WorkingDir}\${ECSConfigArchiveName}"
+Read-S3Object -BucketName "${S3BaseBucket}" -Key "${S3StagingKey}/${AWSForFluentBitVersionFilename}" -File "${StagingDir}\${AWSForFluentBitVersionFilename}"
+Read-S3Object -BucketName "${S3BaseBucket}" -Key "${S3StagingKey}/${EntrypointScriptName}" -File "${StagingDir}\${EntrypointScriptName}"
+Read-S3Object -BucketName "${S3BaseBucket}" -Key "${S3StagingKey}/${Dockerfile}" -File "${StagingDir}\${Dockerfile}"
+
+# Extract them into the required folders.
+Write-Host "Extracting the archives into the required folders"
+Expand-Archive -Path "${WorkingDir}\${FLBArchiveName}" -DestinationPath $FLBStagingLocationOnHost
+tar -xvf "${WorkingDir}\${FLBPluginsArchiveName}" -C $FLBPluginsStagingLocationOnHost
+Expand-Archive -Path "${WorkingDir}\${ECSConfigArchiveName}" -DestinationPath $ECSConfigStagingLocationOnHost
+
+# Build the docker image.
+Write-Host "Building the docker image"
+Invoke-Expression "docker build -t ${ecrImageName} --file ${StagingDir}\Dockerfile.windows --build-arg TAG=${BASEIMAGETAG} --build-arg AWS_FOR_FLUENT_BIT_VERSION=${AWSForFluentBitVersion} ${StagingDir}"
+
+# Throw an error if docker build fails.
+if ($LASTEXITCODE) {
+    throw "failed to build aws-for-fluent-bit image"
+}
+
+# Push image to ECR
+Write-Host "Pusing the image to ECR"
+Invoke-Expression "docker push ${ecrImageName}"
+
+# Throw an error if docker push fails.
+if ($LASTEXITCODE) {
+    throw "failed to push aws-for-fluent-bit image to ECR"
+}
+
+Write-Host ("Successfully built and pushed the image {0} to ECR" -f $ecrImageName)

--- a/scripts/build_windows_plugins.sh
+++ b/scripts/build_windows_plugins.sh
@@ -102,8 +102,3 @@ docker create -ti --name plugin-build-container aws-fluent-bit-plugins:latest ba
 docker cp plugin-build-container:/plugins_windows.tar ./build/windows/plugins_windows.tar
 docker rm -f plugin-build-container
 echo "Copied plugin archive to the build output folder"
-
-# Extract the plugin tar into the output folder
-tar -xvf ./build/windows/plugins_windows.tar -C ./build/windows/
-rm ./build/windows/plugins_windows.tar
-echo "Extracted Windows plugins in the build output folder"

--- a/scripts/entrypoint.ps1
+++ b/scripts/entrypoint.ps1
@@ -1,0 +1,4 @@
+$version = Get-Content -Path "C:\AWS_FOR_FLUENT_BIT_VERSION"
+Write-Host "AWS for Fluent Bit Container Image Version ${version}"
+
+C:\fluent-bit\bin\fluent-bit.exe -e C:\fluent-bit\kinesis.dll -e C:\fluent-bit\firehose.dll -e C:\fluent-bit\cloudwatch.dll -c C:\fluent-bit\etc\fluent-bit.conf

--- a/windows.versions
+++ b/windows.versions
@@ -4,9 +4,9 @@
       "version": "2.26.1",
       "build": "1",
       "fluent-bit": "1.9.4",
-      "kinesis-plugin": "1.9.0",
-      "firehose-plugin": "1.6.1",
-      "cloudwatch-plugin": "1.8.0"
+      "kinesis-plugin": "v1.10.0",
+      "firehose-plugin": "v1.7.0",
+      "cloudwatch-plugin": "v1.9.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary
This PR adds the complete support for building Windows images.

## Workflow details
In order to build Windows images, we will be using a two step approach-
- Build all the fluent-bit artifacts as well as fluent-bit plugins. This can be done via the CodeBuild spec files included in the repository (`buildspec_windows_fluent-bit.yml` and `buildspec_windows_plugins.yml`)
    - These CodeBuild projects would stage the following files in S3 which would be used in next step while building images-
        - fluent-bit.zip
        - plugins_windows.tar
        - ecs.zip
        - AWS_FOR_FLUENT_BIT_VERSION
        - entrypoint.ps1
        - Dockerfile.windows
**These are all the files which are used while building the images. Staging them in S3 would ensure that the image would be constant in a release month over month with the only change in base Windows image.**
- Create the Windows fluent-bit image using the build script.

## Implementation details
- `Dockerfile.plugins`, `build_windows_plugins.sh`, and `buildspec_windows_plugins.yml` work together to build the plugins for Windows
- `build_windows_fluent_bit.ps1` and `buildspec_windows_fluent-bit.yml` work together to build the artifacts for a given release.
- `Dockerfile.windows`, `entrypoint.ps1`, and `build_windows_image.ps1` work together to build and push an image to ECR for a given platform.

## Description of changes:
Added support for building Windows images

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
