### PR TITLE
Modify Pipeline to release images

### DIFF
--- a/Dockerfile.init
+++ b/Dockerfile.init
@@ -1,0 +1,30 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:latest as init-builder
+
+RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+RUN chmod +x /bin/gimme
+RUN yum upgrade -y && yum install -y tar gzip git
+ENV HOME /home
+RUN /bin/gimme 1.17.9
+ENV PATH ${PATH}:/home/.gimme/versions/go1.17.9.linux.arm64/bin:/home/.gimme/versions/go1.17.9.linux.amd64/bin
+RUN go version
+ENV GO111MODULE on
+RUN go env -w GOPROXY=direct
+
+# Build init process for Fluent Bit
+COPY /init/fluent_bit_init_process.go /
+COPY /go.mod /
+COPY /go.sum /
+RUN go mod tidy \
+    && go build fluent_bit_init_process.go
+
+FROM amazon/aws-for-fluent-bit:latest
+
+RUN mkdir -p /init
+
+COPY --from=init-builder /fluent_bit_init_process /init/fluent_bit_init_process
+
+COPY init/fluent_bit_init_entrypoint.sh /init/fluent_bit_init_entrypoint.sh
+RUN chmod +x /init/fluent_bit_init_entrypoint.sh
+
+# Only last CMD command will be executed, automatically replaces the original entrypoint
+CMD /init/fluent_bit_init_entrypoint.sh

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ all: release
 release:
 	docker build --no-cache -t aws-fluent-bit-plugins:latest -f Dockerfile.plugins .
 	docker build -t amazon/aws-for-fluent-bit:latest -f Dockerfile .
+	docker build -t amazon/aws-for-fluent-bit:init-latest -f Dockerfile.init .
 
 .PHONY: debug
 debug:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -24,18 +24,31 @@ phases:
       - docker tag amazon/aws-for-fluent-bit:latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:$architecture
       - docker push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:$architecture
       - './scripts/publish.sh cicd-verify-ecr-image-scan ${AWS_REGION} amazon/aws-for-fluent-bit-test $architecture'
+      # Image with Init Process
+      - docker tag amazon/aws-for-fluent-bit:init-latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-$architecture
+      - docker push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-$architecture
+      - './scripts/publish.sh cicd-verify-ecr-image-scan ${AWS_REGION} amazon/aws-for-fluent-bit-test init-$architecture'
 
        # Create manifest list
       - export DOCKER_CLI_EXPERIMENTAL=enabled
       - docker manifest create ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:arm64 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:amd64 || true
       - docker manifest annotate --arch arm64 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:arm64 || true
       - docker manifest annotate --arch amd64 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:amd64 || true
-
+      # Image with Init Process
+      - docker manifest create ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-arm64 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-amd64 || true
+      - docker manifest annotate --arch arm64 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-arm64 || true
+      - docker manifest annotate --arch amd64 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-amd64 || true
+      
       # Sanity check for the debug log
       - docker manifest inspect ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:latest || true
+      # Image with Init Process
+      - docker manifest inspect ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-latest || true
 
       # Push manifest list
       - docker manifest push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:latest || true
+      # Image with Init Process
+      - docker manifest push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-latest || true
+
 artifacts:
   files:
     - '**/*'

--- a/buildspec_publish_dockerhub.yml
+++ b/buildspec_publish_dockerhub.yml
@@ -17,6 +17,11 @@ phases:
       - docker pull ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:"arm64"
       - docker tag ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:amd64 amazon/aws-for-fluent-bit:amd64
       - docker tag ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:arm64 amazon/aws-for-fluent-bit:arm64
+      # Image with Init Process
+      - docker pull ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:"init-amd64"
+      - docker pull ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:"init-arm64"
+      - docker tag ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-amd64 amazon/aws-for-fluent-bit:init-amd64
+      - docker tag ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-arm64 amazon/aws-for-fluent-bit:init-arm64
 
       # List the docker images
       - docker images

--- a/buildspec_publish_ecr.yml
+++ b/buildspec_publish_ecr.yml
@@ -15,6 +15,9 @@ phases:
       - aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com
       - docker pull ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:"amd64"
       - docker pull ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:"arm64"
+      # Image with Init Process
+      - docker pull ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:"init-amd64"
+      - docker pull ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:"init-arm64"
 
       # List the docker images
       - docker images

--- a/buildspec_publish_public_ecr.yml
+++ b/buildspec_publish_public_ecr.yml
@@ -22,6 +22,11 @@ phases:
       - docker pull ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:"arm64"
       - docker tag ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:amd64 amazon/aws-for-fluent-bit:amd64
       - docker tag ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:arm64 amazon/aws-for-fluent-bit:arm64
+      # Image with Init Process
+      - docker pull ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:"init-amd64"
+      - docker pull ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:"init-arm64"
+      - docker tag ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-amd64 amazon/aws-for-fluent-bit:init-amd64
+      - docker tag ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-arm64 amazon/aws-for-fluent-bit:init-arm64
 
       # List the docker images
       - docker images

--- a/init/fluent_bit_init_entrypoint.sh
+++ b/init/fluent_bit_init_entrypoint.sh
@@ -1,0 +1,2 @@
+./init/fluent_bit_init_process
+source /init/invoke_fluent_bit.sh

--- a/init/fluent_bit_init_process.go
+++ b/init/fluent_bit_init_process.go
@@ -1,0 +1,388 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/sirupsen/logrus"
+)
+
+// static paths
+const (
+	s3FileDirectoryPath    = "/init/fluent-bit-init-s3-files/"
+	mainConfigFile         = "/init/fluent-bit-init.conf"
+	originalMainConfigFile = "/fluent-bit/etc/fluent-bit.conf"
+	invokeFile             = "/init/invoke_fluent_bit.sh"
+)
+
+var (
+	// default Fluent Bit command
+	baseCommand = "exec /fluent-bit/bin/fluent-bit -e /fluent-bit/firehose.so -e /fluent-bit/cloudwatch.so -e /fluent-bit/kinesis.so"
+
+	// global s3 client and flag
+	s3Client        *s3.S3
+	s3ClientCreated bool = false
+
+	// global ecs metadata region
+	metadataRegion string = ""
+)
+
+// HTTPClient interface
+type HTTPClient interface {
+	Get(url string) (*http.Response, error)
+}
+
+// S3Downloader interface
+type S3Downloader interface {
+	Download(w io.WriterAt, input *s3.GetObjectInput, options ...func(*s3manager.Downloader)) (int64, error)
+}
+
+// all values in the structure are empty strings by default
+type ECSTaskMetadata struct {
+	AWS_REGION          string `json:"AWSRegion"`
+	ECS_CLUSTER         string `json:"Cluster"` // Cluster name
+	ECS_TASK_ARN        string `json:"TaskARN"`
+	ECS_TASK_ID         string `json:"TaskID"`
+	ECS_FAMILY          string `json:"Family"`
+	ECS_LAUNCH_TYPE     string `json:"LaunchType"`     // Task launch type will be an empty string if container agent is under version 1.45.0
+	ECS_REVISION        string `json:"Revision"`       // Revision number
+	ECS_TASK_DEFINITION string `json:"TaskDefinition"` // TaskDefinition = "family:revision"
+}
+
+// get ECS Task Metadata via endpoint V4
+func getECSTaskMetadata(httpClient HTTPClient) ECSTaskMetadata {
+	var metadata ECSTaskMetadata
+
+	ecsTaskMetadataEndpointV4 := os.Getenv("ECS_CONTAINER_METADATA_URI_V4")
+	if ecsTaskMetadataEndpointV4 == "" {
+		logrus.Warnln("[FluentBit Init Process] Unable to get ECS Metadata, ignore this warning if not running on ECS")
+		return metadata
+	}
+
+	res, err := httpClient.Get(ecsTaskMetadataEndpointV4 + "/task")
+	if err != nil {
+		logrus.Fatalf("[FluentBit Init Process] Failed to get ECS Metadata via HTTP Get: %s\n", err)
+	}
+
+	response, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		logrus.Fatalf("[FluentBit Init Process] Failed to read ECS Metadata from HTTP response: %s\n", err)
+	}
+	res.Body.Close()
+
+	err = json.Unmarshal(response, &metadata)
+	if err != nil {
+		logrus.Fatalf("[FluentBit Init Process] Failed to unmarshal ECS metadata: %s\n", err)
+	}
+
+	arn, err := arn.Parse(metadata.ECS_TASK_ARN)
+	if err != nil {
+		logrus.Fatalf("[FluentBit Init Process] Failed to parse ECS TaskARN: %s\n", err)
+	}
+
+	resourceID := strings.Split(arn.Resource, "/")
+	taskID := resourceID[len(resourceID)-1]
+	metadata.ECS_TASK_ID = taskID
+	metadata.AWS_REGION = arn.Region
+	metadata.ECS_TASK_DEFINITION = metadata.ECS_FAMILY + ":" + metadata.ECS_REVISION
+
+	// set global ecs metadata region for S3 client
+	metadataRegion = reflect.ValueOf(metadata).Field(0).Interface().(string)
+
+	return metadata
+}
+
+// set ECS Task Metadata as environment variables in the invoke_fluent_bit.sh
+func setECSTaskMetadata(metadata ECSTaskMetadata, filePath string) {
+	invokeFile := openFile(filePath)
+	defer invokeFile.Close()
+
+	// set the FLB_AWS_USER_AGENT env var as "init" to get the image usage
+	initUsage := "export FLB_AWS_USER_AGENT=init\n"
+	_, err := invokeFile.WriteString(initUsage)
+	if err != nil {
+		logrus.Errorln(err)
+		logrus.Warnf("[FluentBit Init Process] Cannot write %s in the invoke_fluent_bit.sh\n", initUsage[:len(initUsage)-2])
+	}
+
+	t := reflect.TypeOf(metadata)
+	v := reflect.ValueOf(metadata)
+
+	for i := 0; i < t.NumField(); i++ {
+		if v.Field(i).Interface().(string) == "" {
+			continue
+		}
+		writeContent := "export " + t.Field(i).Name + "=" + v.Field(i).Interface().(string) + "\n"
+		_, err := invokeFile.WriteString(writeContent)
+		if err != nil {
+			logrus.Errorln(err)
+			logrus.Fatalf("[FluentBit Init Process] Cannot write %s in the invoke_fluent_bit.sh\n", writeContent[:len(writeContent)-2])
+		}
+	}
+}
+
+// create Fluent Bit command to use "-c" to specify the new main config file
+func createCommand(command *string, filePath string) {
+	*command = *command + " -c " + filePath
+}
+
+// get our built in config files or files from s3
+// process built-in config files directly
+// add S3 config files to directory "/init/fluent-bit-init-s3-files/"
+func getAllConfigFiles() {
+	// get all env vars in the container
+	envs := os.Environ()
+
+	// find all env vars match specified prefix
+	for _, env := range envs {
+		var envKey string
+		var envValue string
+		env_kv := strings.SplitN(env, "=", 2)
+		if len(env_kv) != 2 {
+			logrus.Fatalf("[FluentBit Init Process] Unrecognizable environment variables: %s\n", env)
+		}
+
+		envKey = string(env_kv[0])
+		envValue = string(env_kv[1])
+
+		s3_regex, _ := regexp.Compile("aws_fluent_bit_init_[sS]3")
+		file_regex, _ := regexp.Compile("aws_fluent_bit_init_[fF]ile")
+
+		matched_s3 := s3_regex.MatchString(envKey)
+		matched_file := file_regex.MatchString(envKey)
+
+		// if this env var's value is an arn, download the config file first, then process it
+		if matched_s3 {
+			s3FilePath := getS3ConfigFile(envValue)
+			s3FileName := strings.SplitN(s3FilePath, "/", -1)
+			processConfigFile(s3FileDirectoryPath + s3FileName[len(s3FileName)-1])
+		}
+		// if this env var's value is a path of our built-in config file, process is derectly
+		if matched_file {
+			processConfigFile(envValue)
+		}
+	}
+}
+
+func processConfigFile(path string) {
+	contentBytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		logrus.Errorln(err)
+		logrus.Fatalf("[FluentBit Init Process] Cannot open file: %s\n", path)
+	}
+
+	content := string(contentBytes)
+
+	if strings.Contains(content, "[PARSER]") {
+		// this is a parser config file, change command
+		updateCommand(path)
+	} else {
+		// this is not a parser config file. @INCLUDE
+		writeInclude(path, mainConfigFile)
+	}
+}
+
+func getS3ConfigFile(arn string) string {
+	// Preparation for downloading S3 config files
+	if !s3ClientCreated {
+		createS3Client()
+	}
+
+	// e.g. "arn:aws:s3:::user-bucket/s3_parser.conf"
+	arnBucketFile := arn[13:]
+	bucketAndFile := strings.SplitN(arnBucketFile, "/", 2)
+	if len(bucketAndFile) != 2 {
+		logrus.Fatalf("[FluentBit Init Process] Unrecognizable arn: %s\n", arn)
+	}
+
+	bucketName := bucketAndFile[0]
+	s3FilePath := bucketAndFile[1]
+
+	// get bucket region
+	input := &s3.GetBucketLocationInput{
+		Bucket: aws.String(bucketName),
+	}
+
+	output, err := s3Client.GetBucketLocation(input)
+	if err != nil {
+		logrus.Errorln(err)
+		logrus.Fatalf("[FluentBit Init Process] Cannot get bucket region of %s + %s, you must be the bucket owner to implement this operation\n", bucketName, s3FilePath)
+	}
+
+	bucketRegion := aws.StringValue(output.LocationConstraint)
+	// Buckets in Region us-east-1 have a LocationConstraint of null
+	// https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#GetBucketLocationOutput
+	if bucketRegion == "" {
+		bucketRegion = "us-east-1"
+	}
+
+	// create a downloader
+	s3Downloader := createS3Downloader(bucketRegion)
+
+	// download file from S3 and store in the directory "/init/fluent-bit-init-s3-files/"
+	downloadS3ConfigFile(s3Downloader, s3FilePath, bucketName, s3FileDirectoryPath)
+
+	return s3FilePath
+}
+
+// create a S3 client as the global S3 client for reuse
+func createS3Client() {
+	region := "us-east-1"
+	if metadataRegion != "" {
+		region = metadataRegion
+	}
+
+	s3Client = s3.New(session.Must(session.NewSession(&aws.Config{
+		// if not specify region here, missingregion error will raise when get bucket location
+		Region: aws.String(region),
+	})))
+
+	s3ClientCreated = true
+}
+
+func createS3Downloader(bucketRegion string) S3Downloader {
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(bucketRegion)},
+	)
+	if err != nil {
+		logrus.Errorln(err)
+		logrus.Fatalln("[FluentBit Init Process] Cannot creat a new session")
+	}
+
+	// need to specify session region!
+	s3Downloader := s3manager.NewDownloader(sess)
+	return s3Downloader
+}
+
+func downloadS3ConfigFile(s3Downloader S3Downloader, s3FilePath, bucketName, s3FileDirectory string) {
+	s3FileName := strings.SplitN(s3FilePath, "/", -1)
+	fileFromS3 := createFile(s3FileDirectory+s3FileName[len(s3FileName)-1], false)
+	defer fileFromS3.Close()
+
+	_, err := s3Downloader.Download(fileFromS3,
+		&s3.GetObjectInput{
+			Bucket: aws.String(bucketName),
+			Key:    aws.String(s3FilePath),
+		})
+	if err != nil {
+		logrus.Warnf("[FluentBit Init Process] Cannot download %s from s3, retrying...\n", s3FileName)
+
+		_, error := s3Downloader.Download(fileFromS3,
+			&s3.GetObjectInput{
+				Bucket: aws.String(bucketName),
+				Key:    aws.String(s3FilePath),
+			})
+		if error != nil {
+			logrus.Errorln(error)
+			logrus.Fatalf("[FluentBit Init Process] Cannot download %s from s3\n", s3FileName)
+		}
+	}
+}
+
+// use @INCLUDE to add config files to the main config file
+func writeInclude(configFilePath, mainConfigFilePath string) {
+	mainConfigFile := openFile(mainConfigFilePath)
+	defer mainConfigFile.Close()
+
+	writeContent := "@INCLUDE " + configFilePath + "\n"
+	_, err := mainConfigFile.WriteString(writeContent)
+	if err != nil {
+		logrus.Errorln(err)
+		logrus.Fatalf("[FluentBit Init Process] Cannot write %s in main config file: %s\n", writeContent[:len(writeContent)-2], mainConfigFilePath)
+	}
+}
+
+// change the fluent bit cammand to use "-R" to specift Parser config file
+func updateCommand(parserFilePath string) {
+	baseCommand = baseCommand + " -R " + parserFilePath
+	logrus.Infoln("[FluentBit Init Process] Command is change to -> " + baseCommand)
+}
+
+// change the invoke_fluent_bit.sh
+// which will declare ECS Task Metadata as environment variables
+// and finally invoke Fluent Bit
+func modifyInvokeFile(filePath string) {
+	invokeFile := openFile(filePath)
+	defer invokeFile.Close()
+
+	_, err := invokeFile.WriteString(baseCommand)
+	if err != nil {
+		logrus.Errorln(err)
+		logrus.Fatalf("[FluentBit Init Process] Cannot write %s in invoke_fluent_bit.sh\n", baseCommand)
+	}
+}
+
+// create a file, when flag is true, the file will be closed automatically after creation
+func createFile(filePath string, AutoClose bool) *os.File {
+	if err := os.MkdirAll(filepath.Dir(filePath), 0700); err != nil {
+		logrus.Errorln(err)
+		logrus.Fatalf("[FluentBit Init Process] Cannot create the Directory: %s\n", filepath.Dir(filePath))
+	}
+
+	file, err := os.Create(filePath)
+	if err != nil {
+		logrus.Errorln(err)
+		logrus.Fatalf("[FluentBit Init Process] Cannot create the file: %s\n", filePath)
+	}
+
+	if AutoClose {
+		defer file.Close()
+	}
+
+	return file
+}
+
+func openFile(filePath string) *os.File {
+	file, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, 0700)
+	if err != nil {
+		logrus.Errorln(err)
+		logrus.Fatalf("[FluentBit Init Process] Unable to read %s\n", filePath)
+	}
+	return file
+}
+
+func main() {
+	// create the invoke_fluent_bit.sh
+	// which will declare ECS Task Metadata as environment variables
+	// and finally invoke Fluent Bit
+	createFile(invokeFile, true)
+
+	// get ECS Task Metadata and set the region for S3 client
+	httpClient := &http.Client{}
+	metadata := getECSTaskMetadata(httpClient)
+
+	// set ECS Task Metada as env vars in the invoke_fluent_bit.sh
+	setECSTaskMetadata(metadata, invokeFile)
+
+	// create main config file which will be used invoke Fluent Bit
+	createFile(mainConfigFile, true)
+
+	// add @INCLUDE in main config file to include original main config file
+	writeInclude(originalMainConfigFile, mainConfigFile)
+
+	// create Fluent Bit command to use "-c" to specify new main config file
+	createCommand(&baseCommand, mainConfigFile)
+
+	// get our built in config files or files from s3
+	// process built-in config files directly
+	// add S3 config files to directory "/init/fluent-bit-init-s3-files/"
+	getAllConfigFiles()
+
+	// modify invoke_fluent_bit.sh, invoke fluent bit
+	// this function will be called at the end
+	// any error appear above will cause exit this process,
+	// will not write Fluent Bit command in the finvoke_fluent_bit.sh so Fluent Bit will not be invoked
+	modifyInvokeFile(invokeFile)
+}

--- a/init/fluent_bit_init_process_test.go
+++ b/init/fluent_bit_init_process_test.go
@@ -1,0 +1,300 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/stretchr/testify/assert"
+)
+
+const s3FileDirectoryPathTest = "fluent-bit-init-s3-files/"
+const metadataResponse = (`{"Cluster":"ecs-cluster","TaskARN":"arn:aws:ecs:us-west-2:123456789123:task/ecs-cluster/4ca5a280e68947cd84a8357f0d008fb5","Family":"code_test_A","Revision":"35","DesiredStatus":"RUNNING","KnownStatus":"RUNNING","PullStartedAt":"2022-07-06T03:06:45.282195951Z","PullStoppedAt":"2022-07-06T03:06:47.089531338Z","AvailabilityZone":"us-west-2a","LaunchType":"EC2","Containers":[{"DockerId":"8c928beb55e3989caf270cee85835e7f199715ffe44e6d54f5aeb68bf79a275c","Name":"log_router","DockerName":"ecs-code_test_A-35-logrouter-fea8e8aecab7ceeacc01","Image":"123456789123.dkr.ecr.us-west-2.amazonaws.com/x_image:latest","ImageID":"sha256:bfdcbace4206be5e917ae71648bbb680d8ddc1cf558e60b8aad1e9e5533233a0","Labels":{"com.amazonaws.ecs.cluster":"ecs-cluster","com.amazonaws.ecs.container-name":"log_router","com.amazonaws.ecs.task-arn":"arn:aws:ecs:us-west-2:123456789123:task/ecs-cluster/4ca5a280e68947cd84a8357f0d008fb5","com.amazonaws.ecs.task-definition-family":"code_test_A","com.amazonaws.ecs.task-definition-version":"35"},"DesiredStatus":"RUNNING","KnownStatus":"RUNNING","Limits":{"CPU":2,"Memory":0},"CreatedAt":"2022-07-06T03:06:45.425156017Z","StartedAt":"2022-07-06T03:06:46.070292719Z","Type":"NORMAL","Volumes":[{"Source":"/var/lib/ecs/deps/execute-command/bin/3.1.1260.0/ssm-session-worker","Destination":"/ecs-execute-command-6de6aecd-5468-4666-9ad9-b1521a24893c/ssm-session-worker"},{"Source":"/var/lib/ecs/deps/execute-command/config/amazon-ssm-agent-ZfC4ex5qAj4jNHNZsam9TbekaQ_EkbnJMsW0hcZEbFI=.json","Destination":"/ecs-execute-command-6de6aecd-5468-4666-9ad9-b1521a24893c/configuration/amazon-ssm-agent.json"},{"Source":"/var/lib/ecs/deps/execute-command/config/seelog-gEZ-TIvHAyOLfMC5wiWRofgDMlDzaCZ6zcswnAoop84=.xml","Destination":"/ecs-execute-command-6de6aecd-5468-4666-9ad9-b1521a24893c/configuration/seelog.xml"},{"Source":"/var/lib/ecs/deps/execute-command/certs/tls-ca-bundle.pem","Destination":"/ecs-execute-command-6de6aecd-5468-4666-9ad9-b1521a24893c/certs/amazon-ssm-agent.crt"},{"Source":"/var/lib/ecs/data/firelens/4ca5a280e68947cd84a8357f0d008fb5/socket","Destination":"/var/run"},{"Source":"/var/lib/ecs/deps/execute-command/bin/3.1.1260.0/amazon-ssm-agent","Destination":"/ecs-execute-command-6de6aecd-5468-4666-9ad9-b1521a24893c/amazon-ssm-agent"},{"Source":"/var/log/ecs/exec/4ca5a280e68947cd84a8357f0d008fb5/log_router","Destination":"/var/log/amazon/ssm"},{"Source":"/var/lib/ecs/data/firelens/4ca5a280e68947cd84a8357f0d008fb5/config/fluent.conf","Destination":"/fluent-bit/etc/fluent-bit.conf"},{"Source":"/var/lib/ecs/deps/execute-command/bin/3.1.1260.0/ssm-agent-worker","Destination":"/ecs-execute-command-6de6aecd-5468-4666-9ad9-b1521a24893c/ssm-agent-worker"}],"LogDriver":"awslogs","LogOptions":{"awslogs-create-group":"true","awslogs-group":"/ecs/code_test_A","awslogs-region":"us-west-2","awslogs-stream":"ecs/log_router/4ca5a280e68947cd84a8357f0d008fb5"},"ContainerARN":"arn:aws:ecs:us-west-2:123456789123:container/ecs-cluster/4ca5a280e68947cd84a8357f0d008fb5/cf2297e2-6204-4132-9d7b-6c1cab4c4f8e","Networks":[{"NetworkMode":"bridge","IPv4Addresses":["172.17.0.2"]}]},{"DockerId":"f2eb74ec6624e8f0ed4763f3c1b5dd6da6fc7810d4df83245fe419f28d34cbf4","Name":"app","DockerName":"ecs-code_test_A-35-app-beacfe98d8fabbc01400","Image":"nginx:latest","ImageID":"sha256:55f4b40fe486a5b734b46bb7bf28f52fa31426bf23be068c8e7b19e58d9b8deb","Labels":{"com.amazonaws.ecs.cluster":"ecs-cluster","com.amazonaws.ecs.container-name":"app","com.amazonaws.ecs.task-arn":"arn:aws:ecs:us-west-2:123456789123:task/ecs-cluster/4ca5a280e68947cd84a8357f0d008fb5","com.amazonaws.ecs.task-definition-family":"code_test_A","com.amazonaws.ecs.task-definition-version":"35"},"DesiredStatus":"RUNNING","KnownStatus":"RUNNING","Limits":{"CPU":2,"Memory":0},"CreatedAt":"2022-07-06T03:06:47.103306928Z","StartedAt":"2022-07-06T03:06:47.757888246Z","Type":"NORMAL","Volumes":[{"Source":"/var/lib/ecs/deps/execute-command/config/seelog-gEZ-TIvHAyOLfMC5wiWRofgDMlDzaCZ6zcswnAoop84=.xml","Destination":"/ecs-execute-command-64f2d8e8-ca2d-443b-b9b1-1410aee62888/configuration/seelog.xml"},{"Source":"/var/lib/ecs/deps/execute-command/certs/tls-ca-bundle.pem","Destination":"/ecs-execute-command-64f2d8e8-ca2d-443b-b9b1-1410aee62888/certs/amazon-ssm-agent.crt"},{"Source":"/var/log/ecs/exec/4ca5a280e68947cd84a8357f0d008fb5/app","Destination":"/var/log/amazon/ssm"},{"Source":"/var/lib/ecs/deps/execute-command/bin/3.1.1260.0/amazon-ssm-agent","Destination":"/ecs-execute-command-64f2d8e8-ca2d-443b-b9b1-1410aee62888/amazon-ssm-agent"},{"Source":"/var/lib/ecs/deps/execute-command/bin/3.1.1260.0/ssm-agent-worker","Destination":"/ecs-execute-command-64f2d8e8-ca2d-443b-b9b1-1410aee62888/ssm-agent-worker"},{"Source":"/var/lib/ecs/deps/execute-command/bin/3.1.1260.0/ssm-session-worker","Destination":"/ecs-execute-command-64f2d8e8-ca2d-443b-b9b1-1410aee62888/ssm-session-worker"},{"Source":"/var/lib/ecs/deps/execute-command/config/amazon-ssm-agent-ZfC4ex5qAj4jNHNZsam9TbekaQ_EkbnJMsW0hcZEbFI=.json","Destination":"/ecs-execute-command-64f2d8e8-ca2d-443b-b9b1-1410aee62888/configuration/amazon-ssm-agent.json"}],"LogDriver":"awsfirelens","LogOptions":{"Name":"cloudwatch","auto_create_group":"true","log_group_name":"/aws/ecs/containerinsights/$(ecs_cluster)/app_user","log_stream_name":"$(ecs_task_id)","region":"us-west-2","retry_limit":"2"},"ContainerARN":"arn:aws:ecs:us-west-2:123456789123:container/ecs-cluster/4ca5a280e68947cd84a8357f0d008fb5/65feb143-c5a1-4bcf-b524-0953a02524bf","Networks":[{"NetworkMode":"bridge","IPv4Addresses":["172.17.0.3"]}]}]}`)
+const metadataResponseNoLaunchType = (`{"Cluster":"ecs-cluster","TaskARN":"arn:aws:ecs:us-west-2:123456789123:task/ecs-cluster/4ca5a280e68947cd84a8357f0d008fb5","Family":"code_test_A","Revision":"35","DesiredStatus":"RUNNING","KnownStatus":"RUNNING","PullStartedAt":"2022-07-06T03:06:45.282195951Z","PullStoppedAt":"2022-07-06T03:06:47.089531338Z","AvailabilityZone":"us-west-2a","Containers":[{"DockerId":"8c928beb55e3989caf270cee85835e7f199715ffe44e6d54f5aeb68bf79a275c","Name":"log_router","DockerName":"ecs-code_test_A-35-logrouter-fea8e8aecab7ceeacc01","Image":"123456789123.dkr.ecr.us-west-2.amazonaws.com/x_image:latest","ImageID":"sha256:bfdcbace4206be5e917ae71648bbb680d8ddc1cf558e60b8aad1e9e5533233a0","Labels":{"com.amazonaws.ecs.cluster":"ecs-cluster","com.amazonaws.ecs.container-name":"log_router","com.amazonaws.ecs.task-arn":"arn:aws:ecs:us-west-2:123456789123:task/ecs-cluster/4ca5a280e68947cd84a8357f0d008fb5","com.amazonaws.ecs.task-definition-family":"code_test_A","com.amazonaws.ecs.task-definition-version":"35"},"DesiredStatus":"RUNNING","KnownStatus":"RUNNING","Limits":{"CPU":2,"Memory":0},"CreatedAt":"2022-07-06T03:06:45.425156017Z","StartedAt":"2022-07-06T03:06:46.070292719Z","Type":"NORMAL","Volumes":[{"Source":"/var/lib/ecs/deps/execute-command/bin/3.1.1260.0/ssm-session-worker","Destination":"/ecs-execute-command-6de6aecd-5468-4666-9ad9-b1521a24893c/ssm-session-worker"},{"Source":"/var/lib/ecs/deps/execute-command/config/amazon-ssm-agent-ZfC4ex5qAj4jNHNZsam9TbekaQ_EkbnJMsW0hcZEbFI=.json","Destination":"/ecs-execute-command-6de6aecd-5468-4666-9ad9-b1521a24893c/configuration/amazon-ssm-agent.json"},{"Source":"/var/lib/ecs/deps/execute-command/config/seelog-gEZ-TIvHAyOLfMC5wiWRofgDMlDzaCZ6zcswnAoop84=.xml","Destination":"/ecs-execute-command-6de6aecd-5468-4666-9ad9-b1521a24893c/configuration/seelog.xml"},{"Source":"/var/lib/ecs/deps/execute-command/certs/tls-ca-bundle.pem","Destination":"/ecs-execute-command-6de6aecd-5468-4666-9ad9-b1521a24893c/certs/amazon-ssm-agent.crt"},{"Source":"/var/lib/ecs/data/firelens/4ca5a280e68947cd84a8357f0d008fb5/socket","Destination":"/var/run"},{"Source":"/var/lib/ecs/deps/execute-command/bin/3.1.1260.0/amazon-ssm-agent","Destination":"/ecs-execute-command-6de6aecd-5468-4666-9ad9-b1521a24893c/amazon-ssm-agent"},{"Source":"/var/log/ecs/exec/4ca5a280e68947cd84a8357f0d008fb5/log_router","Destination":"/var/log/amazon/ssm"},{"Source":"/var/lib/ecs/data/firelens/4ca5a280e68947cd84a8357f0d008fb5/config/fluent.conf","Destination":"/fluent-bit/etc/fluent-bit.conf"},{"Source":"/var/lib/ecs/deps/execute-command/bin/3.1.1260.0/ssm-agent-worker","Destination":"/ecs-execute-command-6de6aecd-5468-4666-9ad9-b1521a24893c/ssm-agent-worker"}],"LogDriver":"awslogs","LogOptions":{"awslogs-create-group":"true","awslogs-group":"/ecs/code_test_A","awslogs-region":"us-west-2","awslogs-stream":"ecs/log_router/4ca5a280e68947cd84a8357f0d008fb5"},"ContainerARN":"arn:aws:ecs:us-west-2:123456789123:container/ecs-cluster/4ca5a280e68947cd84a8357f0d008fb5/cf2297e2-6204-4132-9d7b-6c1cab4c4f8e","Networks":[{"NetworkMode":"bridge","IPv4Addresses":["172.17.0.2"]}]},{"DockerId":"f2eb74ec6624e8f0ed4763f3c1b5dd6da6fc7810d4df83245fe419f28d34cbf4","Name":"app","DockerName":"ecs-code_test_A-35-app-beacfe98d8fabbc01400","Image":"nginx:latest","ImageID":"sha256:55f4b40fe486a5b734b46bb7bf28f52fa31426bf23be068c8e7b19e58d9b8deb","Labels":{"com.amazonaws.ecs.cluster":"ecs-cluster","com.amazonaws.ecs.container-name":"app","com.amazonaws.ecs.task-arn":"arn:aws:ecs:us-west-2:123456789123:task/ecs-cluster/4ca5a280e68947cd84a8357f0d008fb5","com.amazonaws.ecs.task-definition-family":"code_test_A","com.amazonaws.ecs.task-definition-version":"35"},"DesiredStatus":"RUNNING","KnownStatus":"RUNNING","Limits":{"CPU":2,"Memory":0},"CreatedAt":"2022-07-06T03:06:47.103306928Z","StartedAt":"2022-07-06T03:06:47.757888246Z","Type":"NORMAL","Volumes":[{"Source":"/var/lib/ecs/deps/execute-command/config/seelog-gEZ-TIvHAyOLfMC5wiWRofgDMlDzaCZ6zcswnAoop84=.xml","Destination":"/ecs-execute-command-64f2d8e8-ca2d-443b-b9b1-1410aee62888/configuration/seelog.xml"},{"Source":"/var/lib/ecs/deps/execute-command/certs/tls-ca-bundle.pem","Destination":"/ecs-execute-command-64f2d8e8-ca2d-443b-b9b1-1410aee62888/certs/amazon-ssm-agent.crt"},{"Source":"/var/log/ecs/exec/4ca5a280e68947cd84a8357f0d008fb5/app","Destination":"/var/log/amazon/ssm"},{"Source":"/var/lib/ecs/deps/execute-command/bin/3.1.1260.0/amazon-ssm-agent","Destination":"/ecs-execute-command-64f2d8e8-ca2d-443b-b9b1-1410aee62888/amazon-ssm-agent"},{"Source":"/var/lib/ecs/deps/execute-command/bin/3.1.1260.0/ssm-agent-worker","Destination":"/ecs-execute-command-64f2d8e8-ca2d-443b-b9b1-1410aee62888/ssm-agent-worker"},{"Source":"/var/lib/ecs/deps/execute-command/bin/3.1.1260.0/ssm-session-worker","Destination":"/ecs-execute-command-64f2d8e8-ca2d-443b-b9b1-1410aee62888/ssm-session-worker"},{"Source":"/var/lib/ecs/deps/execute-command/config/amazon-ssm-agent-ZfC4ex5qAj4jNHNZsam9TbekaQ_EkbnJMsW0hcZEbFI=.json","Destination":"/ecs-execute-command-64f2d8e8-ca2d-443b-b9b1-1410aee62888/configuration/amazon-ssm-agent.json"}],"LogDriver":"awsfirelens","LogOptions":{"Name":"cloudwatch","auto_create_group":"true","log_group_name":"/aws/ecs/containerinsights/$(ecs_cluster)/app_user","log_stream_name":"$(ecs_task_id)","region":"us-west-2","retry_limit":"2"},"ContainerARN":"arn:aws:ecs:us-west-2:123456789123:container/ecs-cluster/4ca5a280e68947cd84a8357f0d008fb5/65feb143-c5a1-4bcf-b524-0953a02524bf","Networks":[{"NetworkMode":"bridge","IPv4Addresses":["172.17.0.3"]}]}]}`)
+
+func TestGetECSTaskMetadata(t *testing.T) {
+	os.Setenv("ECS_CONTAINER_METADATA_URI_V4", "http://169.254.170.2/v4/50379854-baeb-4b84-9010-dd3fe2df5f20")
+
+	// Test case 1: full metadata
+	mockResponse1 := metadataResponse
+	client1 := MockHTTPClient{
+		Response: mockResponse1,
+	}
+
+	actualOutput1 := getECSTaskMetadata(&client1)
+
+	expectedOutput1 := ECSTaskMetadata{
+		AWS_REGION:          "us-west-2",
+		ECS_CLUSTER:         "ecs-cluster",
+		ECS_TASK_ARN:        "arn:aws:ecs:us-west-2:123456789123:task/ecs-cluster/4ca5a280e68947cd84a8357f0d008fb5",
+		ECS_TASK_ID:         "4ca5a280e68947cd84a8357f0d008fb5",
+		ECS_FAMILY:          "code_test_A",
+		ECS_LAUNCH_TYPE:     "EC2",
+		ECS_REVISION:        "35",
+		ECS_TASK_DEFINITION: "code_test_A:35",
+	}
+
+	assert.Equal(t, actualOutput1, expectedOutput1)
+
+	// Test case 2: Task launch type will be an empty string if container agent is under version 1.45.0
+	mockResponse2 := metadataResponseNoLaunchType
+	client2 := MockHTTPClient{
+		Response: mockResponse2,
+	}
+
+	actualOutput2 := getECSTaskMetadata(&client2)
+
+	expectedOutput2 := ECSTaskMetadata{
+		AWS_REGION:          "us-west-2",
+		ECS_CLUSTER:         "ecs-cluster",
+		ECS_TASK_ARN:        "arn:aws:ecs:us-west-2:123456789123:task/ecs-cluster/4ca5a280e68947cd84a8357f0d008fb5",
+		ECS_TASK_ID:         "4ca5a280e68947cd84a8357f0d008fb5",
+		ECS_FAMILY:          "code_test_A",
+		ECS_LAUNCH_TYPE:     "", // empty lunch type
+		ECS_REVISION:        "35",
+		ECS_TASK_DEFINITION: "code_test_A:35",
+	}
+
+	assert.Equal(t, actualOutput2, expectedOutput2)
+
+	// Test case 3: run image locally without metadata
+	os.Setenv("ECS_CONTAINER_METADATA_URI_V4", "")
+	mockResponse3 := (``)
+	client3 := MockHTTPClient{
+		Response: mockResponse3,
+	}
+
+	actualOutput3 := getECSTaskMetadata(&client3)
+
+	expectedOutput3 := ECSTaskMetadata{
+		AWS_REGION:          "",
+		ECS_CLUSTER:         "",
+		ECS_TASK_ARN:        "",
+		ECS_TASK_ID:         "",
+		ECS_FAMILY:          "",
+		ECS_LAUNCH_TYPE:     "",
+		ECS_REVISION:        "",
+		ECS_TASK_DEFINITION: "",
+	}
+
+	assert.Equal(t, actualOutput3, expectedOutput3)
+}
+
+func TestSetECSTaskMetadata(t *testing.T) {
+
+	var metadataList []ECSTaskMetadata
+	var expectedContentList []string
+
+	// Test case 1: full metadata
+	metadataTest1 := ECSTaskMetadata{
+		AWS_REGION:          "us-west-2",
+		ECS_CLUSTER:         "ecs-Test",
+		ECS_TASK_ARN:        "arn:aws:ecs:us-west-2:111:task/ecs-local-cluster/37e8",
+		ECS_TASK_ID:         "56461",
+		ECS_FAMILY:          "esc-task-definition",
+		ECS_LAUNCH_TYPE:     "EC2",
+		ECS_REVISION:        "1",
+		ECS_TASK_DEFINITION: "esc-task-definition:1",
+	}
+
+	expectedContent1 := "export FLB_AWS_USER_AGENT=init\n" +
+		"export AWS_REGION=us-west-2\n" +
+		"export ECS_CLUSTER=ecs-Test\n" +
+		"export ECS_TASK_ARN=arn:aws:ecs:us-west-2:111:task/ecs-local-cluster/37e8\n" +
+		"export ECS_TASK_ID=56461\n" +
+		"export ECS_FAMILY=esc-task-definition\n" +
+		"export ECS_LAUNCH_TYPE=EC2\n" +
+		"export ECS_REVISION=1\n" +
+		"export ECS_TASK_DEFINITION=esc-task-definition:1\n"
+
+	metadataList = append(metadataList, metadataTest1)
+	expectedContentList = append(expectedContentList, expectedContent1)
+
+	// Test case 2: some environment variables is empty
+	metadataTest2 := ECSTaskMetadata{
+		AWS_REGION:          "us-west-1",
+		ECS_CLUSTER:         "ecs-Test",
+		ECS_TASK_ARN:        "",
+		ECS_TASK_ID:         "",
+		ECS_FAMILY:          "",
+		ECS_LAUNCH_TYPE:     "",
+		ECS_REVISION:        "",
+		ECS_TASK_DEFINITION: "",
+	}
+
+	expectedContent2 := "export FLB_AWS_USER_AGENT=init\n" +
+		"export AWS_REGION=us-west-1\n" +
+		"export ECS_CLUSTER=ecs-Test\n"
+
+	metadataList = append(metadataList, metadataTest2)
+	expectedContentList = append(expectedContentList, expectedContent2)
+
+	//Add new test cases here if needed
+
+	for i := 0; i < len(metadataList) && i < len(expectedContentList); i++ {
+		testSetECSTaskMetadataHelper(t, &metadataList[i], &expectedContentList[i])
+	}
+}
+
+func testSetECSTaskMetadataHelper(t *testing.T, metadata *ECSTaskMetadata, expectedContent *string) {
+	filePath := "testSetECSMetadata.sh"
+	file := createFileHelper(filePath)
+	defer os.Remove(filePath)
+	defer file.Close()
+
+	setECSTaskMetadata(*metadata, filePath)
+
+	actualContent := readFileHelper(filePath)
+	assert.Equal(t, actualContent, *expectedContent)
+}
+
+func TestCreateCommand(t *testing.T) {
+	expectedContent := baseCommand
+	filePath := "fluent-bit-init.conf"
+	createCommand(&baseCommand, filePath)
+	expectedContent += " -c " + filePath
+
+	assert.Equal(t, baseCommand, expectedContent)
+}
+
+func TestUpdateCommand(t *testing.T) {
+	expectedContent := baseCommand
+
+	// Test case 1
+	parserFilePath1 := "/ecs/parser.conf"
+	updateCommand(parserFilePath1)
+	expectedContent += " -R " + parserFilePath1
+
+	assert.Equal(t, baseCommand, expectedContent)
+
+	// Test case 2
+	parserFilePath2 := "/s3/parser2.conf"
+	updateCommand(parserFilePath2)
+	expectedContent += " -R " + parserFilePath2
+
+	assert.Equal(t, baseCommand, expectedContent)
+}
+
+func TestWriteInclude(t *testing.T) {
+
+	mainConfigFilePath := "mainFile.conf"
+	file := createFileHelper(mainConfigFilePath)
+	defer os.Remove(mainConfigFilePath)
+	defer file.Close()
+
+	var configFileList []string
+
+	// Test file 1
+	configFile1 := "testFile1.conf"
+	configFileList = append(configFileList, configFile1)
+
+	// Add test file 2
+	configFile2 := "testFile2.conf"
+	configFileList = append(configFileList, configFile2)
+
+	// Add more config files here if needed
+
+	var expectedContent string
+	for i := 0; i < len(configFileList); i++ {
+		writeInclude(configFileList[i], mainConfigFilePath)
+		expectedContent += ("@INCLUDE " + configFileList[i] + "\n")
+	}
+
+	actualContent := readFileHelper(mainConfigFilePath)
+	assert.Equal(t, actualContent, expectedContent)
+}
+
+func TestDownloadS3ConfigFile(t *testing.T) {
+
+	defer os.RemoveAll(s3FileDirectoryPathTest)
+
+	s3FilePath := "user/files/aaa.conf"
+	bucketName := "userBucket"
+	s3Downloader := MockS3Downloader{}
+
+	downloadS3ConfigFile(&s3Downloader, s3FilePath, bucketName, s3FileDirectoryPathTest)
+
+	actualContent := readFileHelper(s3FileDirectoryPathTest + "aaa.conf")
+	expectedContent := "S3 config file download and store successfully"
+
+	assert.Equal(t, actualContent, expectedContent)
+
+}
+
+func TestModifyInvokeFile(t *testing.T) {
+	filePath := "testModifyInvoke.sh"
+	file := createFileHelper(filePath)
+
+	defer os.Remove(filePath)
+	defer file.Close()
+
+	expectedContent := baseCommand
+	modifyInvokeFile(filePath)
+	actualContent := readFileHelper(filePath)
+
+	assert.Equal(t, actualContent, expectedContent)
+
+}
+
+type MockHTTPClient struct {
+	Response string
+}
+
+func (mhc *MockHTTPClient) Get(str string) (*http.Response, error) {
+	_, err := url.ParseRequestURI(str)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid input for HTTP Client: %v", err)
+	} else {
+		body := ioutil.NopCloser(bytes.NewReader([]byte(mhc.Response)))
+		return &http.Response{
+			StatusCode: 200,
+			Body:       body,
+		}, nil
+	}
+}
+
+type MockS3Downloader struct{}
+
+func (msd *MockS3Downloader) Download(w io.WriterAt, input *s3.GetObjectInput, options ...func(*s3manager.Downloader)) (int64, error) {
+	filePath := s3FileDirectoryPathTest + "aaa.conf"
+	writeContent := "S3 config file download and store successfully"
+
+	writeFileHelper(filePath, writeContent)
+
+	return 100, nil
+}
+
+func createFileHelper(filePath string) *os.File {
+	file, err := os.Create(filePath)
+	if err != nil {
+		fmt.Println("Failed to create the file to test")
+	}
+
+	return file
+}
+
+func readFileHelper(filePath string) string {
+	content, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		fmt.Errorf("failed to read the file: %s", filePath)
+	}
+
+	return string(content)
+}
+
+func writeFileHelper(filePath, writeContent string) {
+	file := openFile(filePath)
+	defer file.Close()
+
+	_, err := file.WriteString(writeContent)
+	if err != nil {
+		fmt.Errorf("Can not write %s in file %s", writeContent, filePath)
+	}
+}


### PR DESCRIPTION
**Changes**

Modify the Pipeline and Sync stack, 10 images will be release as the same time after merge.

e.g. latest version: 2.27.0, stable version 2.26.5, will release:
`aws-for-fluent-bit:amd64-2.27.0`
`aws-for-fluent-bit:arm64-2.27.0`
`aws-for-fluent-bit:2.27.0`
`aws-for-fluent-bit:latest`
`aws-for-fluent-bit:stable`

`aws-for-fluent-bit:init-amd64-2.27.0`
`aws-for-fluent-bit:init-arm64-2.27.0`
`aws-for-fluent-bit:init-2.27.0`
`aws-for-fluent-bit:init-latest`
`aws-for-fluent-bit:init-stable`

**Important Node:**
Because currently we don't have the stable version for init image. So please merge this PR after we have a stable version of Init image