### PR TITLE
change FLB_AWS_USER_AGENT to ecs-init

### DIFF
--- a/init/fluent_bit_init_process.go
+++ b/init/fluent_bit_init_process.go
@@ -110,7 +110,7 @@ func setECSTaskMetadata(metadata ECSTaskMetadata, filePath string) {
 	defer invokeFile.Close()
 
 	// set the FLB_AWS_USER_AGENT env var as "init" to get the image usage
-	initUsage := "export FLB_AWS_USER_AGENT=init\n"
+	initUsage := "export FLB_AWS_USER_AGENT=ecs-init\n"
 	_, err := invokeFile.WriteString(initUsage)
 	if err != nil {
 		logrus.Errorln(err)


### PR DESCRIPTION
## change FLB_AWS_USER_AGENT to `ecs-init`

When init images are used, they are counted as both ECS and init usage