### PR TITLE
Added support for running integration tests on Windows.

### DIFF
--- a/integ/resources/manage_test_resources.ps1
+++ b/integ/resources/manage_test_resources.ps1
@@ -1,0 +1,115 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# 	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+<#
+    .SYNOPSIS
+    Used to manage the test resources used for the integration tests.
+
+    .DESCRIPTION
+    This script can be used to create, setup and delete test resources used for the integration tests.
+
+    .PARAMETER Action
+    Specifies the Action to be performed. Should be amongst "Create","Setup" or "Delete".
+
+    .INPUTS
+    None. You cannot pipe objects to this script.
+
+    .OUTPUTS
+    None. This script does not generate an output object.
+
+    .EXAMPLE
+    PS> .\manage_test_resources.ps1 -Action Create
+    Creates the CFN stack for the test resources.
+
+    .EXAMPLE
+    PS> .\manage_test_resources.ps1 -Action Setup
+    Queries the CFN stack and sets the environment variables for the same.
+
+    .EXAMPLE
+    PS> .\manage_test_resources.ps1 -Action Delete
+    Deletes the CFN stack for the test resources.
+#>
+Param(
+    [Parameter(Mandatory=$true)]
+    [ValidateSet("Create","Setup","Delete")]
+    [string]$Action
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Define variables.
+$ResourcesRoot = "${PSScriptRoot}"
+$Region = "us-west-2"
+$Architecture = "x86-64"
+$StackName = "integ-test-fluent-bit-windows-${Architecture}"
+$MaxRetries = 10
+
+Function Create-TestResources {
+    $template = Get-Content -Path "${ResourcesRoot}\cfn-kinesis-s3-firehose.yml" -Raw
+    trap {
+        try
+        {
+            New-CFNStack -Region $Region -StackName $StackName -Capability CAPABILITY_NAMED_IAM -TemplateBody $template
+
+            # Wait for the CFN stack to be created.
+            # Stack usually takes 150 seconds to be created.
+            $Retry = 1
+            while ((-Not (Test-CFNStack -StackName $StackName -Status CREATE_COMPLETE)) -Or ($Retry -le 10)) {
+                Write-Host "Stack is not ready yet. Sleeping for 30 seconds. Retry count: $Retry"
+                $Retry++
+                Start-Sleep 30
+            }
+
+            # If we spent 300 seconds and the stack is still not created then error out.
+            if (-Not (Test-CFNStack -StackName $StackName -Status CREATE_COMPLETE)) {
+                throw "Failed to create test resources stack."
+            }
+        } catch {
+            # If New-CFNStack errors out and the error message is for Stack already existing then ignore the error.
+            if ($_.Exception.Message -NotMatch "already exists") {
+                throw $_
+            }
+            Write-Host "The stack already exists!"
+        }
+        # Use continue so that trap does not throw any error.
+        continue
+    }
+    Get-CFNStack -Region $Region -StackName $StackName
+}
+
+Function Setup-TestResources {
+    # If the stack does not exist, then we will error out here itself.
+    Get-CFNStack -Region $Region -StackName $StackName
+    # The logical names are as per cfn-kinesis-s3-firehose.yml
+    $env:FIREHOSE_STREAM = (Get-CFNStackResourceList -StackName $StackName -LogicalResourceId "firehoseDeliveryStreamForFirehoseTest").PhysicalResourceId
+    $env:KINESIS_STREAM = (Get-CFNStackResourceList -StackName $StackName -LogicalResourceId "kinesisStream").PhysicalResourceId
+    $env:S3_BUCKET_NAME = (Get-CFNStackResourceList -StackName $StackName -LogicalResourceId "s3Bucket").PhysicalResourceId
+}
+
+Function Remove-TestResources {
+    Remove-CFNStack -Region $Region -StackName $StackName -Force
+}
+
+switch ($Action) {
+    "Create" {
+        Create-TestResources
+    }
+
+    "Setup" {
+        Setup-TestResources
+    }
+
+    "Delete" {
+        Remove-TestResources
+    }
+}

--- a/integ/run-integ.ps1
+++ b/integ/run-integ.ps1
@@ -1,0 +1,549 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# 	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+<#
+    .SYNOPSIS
+    Used to run integration tests on Windows.
+
+    .DESCRIPTION
+    This script can be used to run integration tests on Windows.
+
+    .PARAMETER TestPlugin
+    [Optional] Specifies the TestPlugin to be validated. Defaults to "cicd".
+
+    .PARAMETER FluentBitImage
+    [Optional] Specifies the fluent-bit image which needs to be validated. Defaults to "amazon/aws-for-fluent-bit:windowsservercore-latest"
+
+    .INPUTS
+    None. You cannot pipe objects to this script.
+
+    .OUTPUTS
+    None. This script does not generate an output object.
+
+    .EXAMPLE
+    PS> .\run-integ.ps1 -TestPlugin cicd
+    Runs all the integration tests as would be required in CICD.
+
+    .EXAMPLE
+    PS> .\run-integ.ps1 -TestPlugin cloudwatch_logs
+    Runs Cloudwatch Core plugin integration test against "amazon/aws-for-fluent-bit:windowsservercore-latest" image.
+
+    .EXAMPLE
+    PS> .\run-integ.ps1 -TestPlugin kinesis_firehose -FluentBitImage "amazon/aws-for-fluent-bit:windowsservercore-stable"
+    Runs Kinesis Firehose Core plugin integration test against "amazon/aws-for-fluent-bit:windowsservercore-stable" image.
+#>
+Param(
+    [Parameter(Mandatory=$false)]
+    [ValidateSet("cicd","cloudwatch","cloudwatch_logs","clean-cloudwatch","kinesis","kinesis_streams","firehose","kinesis_firehose","s3","clean-s3","delete")]
+    [string]$TestPlugin = "cicd",
+
+    [Parameter(Mandatory=$false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$FluentBitImage = "amazon/aws-for-fluent-bit:windowsservercore-latest"
+)
+
+$ErrorActionPreference = 'Stop'
+$DockerComposeVersion = "2.7.0"
+
+# Define variables.
+$IntegTestRoot = "${PSScriptRoot}"
+$env:AWS_REGION = "us-west-2"
+$env:PROJECT_ROOT = Resolve-Path -Path "${PSScriptRoot}\.."
+$env:FLUENT_BIT_IMAGE = $FluentBitImage
+# Tag is used in the s3 keys; each test run has a unique (random) tag
+$env:TAG = -join ((65..90) + (97..122) | Get-Random -Count 10 | % {[char]$_})
+# AWS_FOR_FLUENT_BIT_CONTAINER_NAME is the name for the fluent-bit container ran for each service.
+$env:AWS_FOR_FLUENT_BIT_CONTAINER_NAME = "aws-for-fluent-bit-$($env:TAG)"
+
+# Windows specific settings.
+$env:ARCHITECTURE= "x86-64"
+$env:VOLUME_MOUNT_CONTAINER="C:/out"
+$env:ValidateS3Dockerfile = "Dockerfile.windows"
+# For Windows, we need to specify a static IP address for the fluent-bit container.
+# This is because fluent-bit container would be started first and then the other containers
+# would need to connect to the fluent-bit container over a TCP socket.
+# Docker-compose doesn't provide a way to configure this IP address dynamically.
+# Since we are using a link-local IP over NAT, we would be able to have public access without
+# any IP conflicts.
+$env:DockerNetworkSubnet = "169.254.150.0/24"
+$env:DockerNetworkGateway = "169.254.150.1"
+$env:DockerNetworkStaticIP = "169.254.150.10"
+$env:FLUENT_CONTAINER_IP = $env:DockerNetworkStaticIP
+
+# Profiles used in docker-compose.
+# Core profile contains services which should be ran before the test services.
+# For integration tests, this would only have fluent-bit service.
+$CoreProfile = "core"
+$TestProfile = "test"
+
+Function Install-Package {
+    <#
+    .SYNOPSIS
+    Installs the packages required for running these integration tests.
+    #>
+
+    # Install docker-compose on the instance.
+    # Use installation instructions from "https://docs.docker.com/compose/install/compose-plugin/#install-compose-on-windows-server"
+    Write-Host "Installing Docker-Compose version ${DockerComposeVersion} on the instance."
+    if (-Not (Test-Path -Path "$Env:ProgramFiles\Docker\docker-compose.exe" -PathType Leaf))
+    {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Invoke-WebRequest "https://github.com/docker/compose/releases/download/v${DockerComposeVersion}/docker-compose-Windows-x86_64.exe" -UseBasicParsing -OutFile $Env:ProgramFiles\Docker\docker-compose.exe
+    }
+    Write-Host $( docker-compose version )
+}
+
+Function Test-Command {
+    <#
+    .SYNOPSIS
+    Tests if the previous executed method returned with an error.
+
+    .PARAMETER TestMethod
+    Specifies the name of the previous method so that it can be captured in the logs.
+    #>
+    Param (
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TestMethod
+    )
+
+    if ($LASTEXITCODE)
+    {
+        throw ("Integration tests failed for Windows during {0}: Message: {1}" -f $TestMethod, $_.Exception.Message)
+    }
+}
+
+Function Run-Test {
+    <#
+    .SYNOPSIS
+    Runs the test using the docker-compose config specified for the plugin.
+
+    .PARAMETER PluginUnderTest
+    Specifies the name of the plugin which we are testing.
+
+    .PARAMETER DockerComposeTestFilePath
+    Specifies the path of the docker-compose config file which has specifications for the test.
+
+    .PARAMETER SleepTime
+    [Optional] Specifies the time in seconds which we need to sleep after the tests are completed.
+
+    .Notes
+    When running the tests, we first start the core profile. Each service in core profile has the pre-defined
+    healthchecks. Once the core services are in healthy status, we start the test profile which runs the
+    services performing the tests. Finally, we sleep for some time so as to enable fluent-bit to send data to the
+    destination location.
+    #>
+    Param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$PluginUnderTest,
+
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$DockerComposeTestFilePath,
+
+        [Parameter(Mandatory=$false)]
+        [ValidateNotNullOrEmpty()]
+        [int]$SleepTime=120
+    )
+
+    Write-Host "Running tests which generate data for ${PluginUnderTest}"
+
+    # Build the core profile services.
+    docker-compose --file $DockerComposeTestFilePath --profile $CoreProfile build
+    Test-Command -TestMethod "$($MyInvocation.MyCommand): ${PluginUnderTest} - Core Build"
+
+    # Build the test profile services.
+    docker-compose --file $DockerComposeTestFilePath --profile $TestProfile build
+    Test-Command -TestMethod "$($MyInvocation.MyCommand): ${PluginUnderTest} - Test Build"
+
+    # Run the services in backgroud and wait for them to move into healthy status.
+    docker-compose --file $DockerComposeTestFilePath --profile $CoreProfile up --detach --wait
+    Test-Command -TestMethod "$($MyInvocation.MyCommand): ${PluginUnderTest} - Core Up"
+
+    # Run the test services in foreground. Abort when any the test containers exit.
+    docker-compose --file $DockerComposeTestFilePath --profile $TestProfile up
+    Test-Command -TestMethod "$($MyInvocation.MyCommand): ${PluginUnderTest} - Test Up"
+
+    # Giving a pause before running the validation tests.
+    Start-Sleep -Seconds $SleepTime
+
+    Write-Host "Tests completed for ${PluginUnderTest}"
+}
+
+Function Validate-Test {
+    <#
+    .SYNOPSIS
+    Runs the validation tests using the docker-compose config specified for the plugin.
+
+    .PARAMETER PluginUnderTest
+    Specifies the name of the plugin which we are testing.
+
+    .PARAMETER DockerComposeValidateFilePath
+    Specifies the path of the docker-compose config file which has specifications for the validation test.
+
+    .PARAMETER ValidationFileName
+    Specifies the name of the file which is used in the validation tests.
+    #>
+    Param (
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$PluginUnderTest,
+
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$DockerComposeValidateFilePath,
+
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ValidationFileName
+    )
+
+    Write-Host "Running validation test for ${PluginUnderTest}"
+
+    # Creates a file as a flag for the validation failure.
+    New-Item -Path "${IntegTestRoot}\out\${ValidationFileName}" -ItemType File -Force
+
+    # Build the validation services.
+    docker-compose --file $DockerComposeValidateFilePath build
+    Test-Command -TestMethod "$($MyInvocation.MyCommand): ${PluginUnderTest}"
+
+    # Run the validation services.
+    docker-compose --file $DockerComposeValidateFilePath up
+    Test-Command -TestMethod "$($MyInvocation.MyCommand): ${PluginUnderTest}"
+
+    if (Test-Path -Path "${IntegTestRoot}\out\${ValidationFileName}" -PathType Leaf) {
+        throw "Test failed for ${PluginUnderTest}."
+    }
+    Write-Host "Validation succeeded for ${PluginUnderTest}"
+}
+
+Function Clean-Test {
+    <#
+    .SYNOPSIS
+    Cleans up the docker-compose resources once the tests have been ran.
+
+    .PARAMETER PluginUnderTest
+    Specifies the name of the plugin which we are testing.
+
+    .PARAMETER DockerComposeFilePath
+    Specifies the path of the docker-compose config file which has specifications for the test.
+    #>
+    Param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$PluginUnderTest,
+
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$DockerComposeFilePath
+    )
+
+    # Run "docker-compose down" once the tests have been ran.
+    docker-compose --file $DockerComposeFilePath --profile $CoreProfile --profile $TestProfile down -v --rmi all --remove-orphans
+    Test-Command -TestMethod "$($MyInvocation.MyCommand): ${PluginUnderTest}"
+}
+
+Function Test-CloudWatch {
+    <#
+    .SYNOPSIS
+    Runs the integration tests for Cloudwatch plugin.
+
+    .PARAMETER CorePlugin
+    [Optional] Specifies if the core plugin is being tested.
+    #>
+    Param(
+        [Parameter(Mandatory=$false)]
+        [ValidateNotNullOrEmpty()]
+        [switch]$CorePlugin
+    )
+
+    $env:LOG_GROUP_NAME="fluent-bit-integ-test-amd64"
+    $DockerComposeTestFilePath = "${IntegTestRoot}/test_cloudwatch/docker-compose.windows.test.yml"
+    $DockerComposeValidateFilePath = "${IntegTestRoot}/test_cloudwatch/docker-compose.validate.yml"
+
+    # Set the envs based on whether core plugin or Golang plugin is being tested.
+    if ($CorePlugin) {
+        $env:CW_PLUGIN_UNDER_TEST="cloudwatch_logs"
+    } else {
+        $env:CW_PLUGIN_UNDER_TEST="cloudwatch"
+    }
+
+    # Run the tests which would generate test data. Once they end, perform "docker-compose down".
+    Run-Test -PluginUnderTest "Cloudwatch" -DockerComposeTestFilePath $DockerComposeTestFilePath
+    Clean-Test -PluginUnderTest "Cloudwatch" -DockerComposeFilePath $DockerComposeTestFilePath
+
+    # Perform validation of the tests.
+    Validate-Test -PluginUnderTest "Cloudwatch" -DockerComposeValidateFilePath $DockerComposeValidateFilePath -ValidationFileName "cloudwatch-test"
+    Clean-Test -PluginUnderTest "Cloudwatch" -DockerComposeFilePath $DockerComposeValidateFilePath
+}
+
+Function Clean-CloudWatch {
+    <#
+    .SYNOPSIS
+    Cleans the cloudwatche resources used during the integration tests.
+    #>
+
+    $env:LOG_GROUP_NAME="fluent-bit-integ-test-amd64"
+    $DockerComposeTestFilePath = "${IntegTestRoot}/test_cloudwatch/docker-compose.clean.yml"
+
+    # Run the tests which would clean Cloudwatch logs. Once this ends, perform "docker-compose down".
+    Run-Test -PluginUnderTest "Cloudwatch" -DockerComposeTestFilePath $DockerComposeTestFilePath -SleepTime 1
+    Clean-Test -PluginUnderTest "Cloudwatch" -DockerComposeFilePath $DockerComposeTestFilePath
+}
+
+Function Test-Kinesis {
+    <#
+    .SYNOPSIS
+    Runs the integration tests for Kinesis plugin.
+
+    .PARAMETER CorePlugin
+    [Optional] Specifies if the core plugin is being tested.
+    #>
+    Param(
+        [Parameter(Mandatory=$false)]
+        [ValidateNotNullOrEmpty()]
+        [switch]$CorePlugin
+    )
+
+    $DockerComposeTestFilePath = "${IntegTestRoot}/test_kinesis/docker-compose.windows.test.yml"
+    $DockerComposeValidateFilePath = "${IntegTestRoot}/test_kinesis/docker-compose.validate-and-clean-s3.yml"
+    $env:S3_ACTION="validate"
+    $env:S3_PREFIX="kinesis-test"
+    $env:TEST_FILE="kinesis-test"
+    $env:EXPECTED_EVENTS_LEN="1000"
+
+    # Set the envs based on whether core plugin or Golang plugin is being tested.
+    if ($CorePlugin) {
+        $env:FluentBitConfigDir = "windows-core-config"
+    } else {
+        $env:FluentBitConfigDir = "windows-config"
+    }
+
+    # Run the tests which would generate test data. Once they end, perform "docker-compose down".
+    Run-Test -PluginUnderTest "kinesis stream" -DockerComposeTestFilePath $DockerComposeTestFilePath
+    Clean-Test -PluginUnderTest "kinesis stream" -DockerComposeFilePath $DockerComposeTestFilePath
+
+    # Perform validation of the tests.
+    Validate-Test -PluginUnderTest "kinesis stream" -DockerComposeValidateFilePath $DockerComposeValidateFilePath -ValidationFileName "kinesis-test"
+    Clean-Test -PluginUnderTest "kinesis stream" -DockerComposeFilePath $DockerComposeValidateFilePath
+}
+
+Function Test-Firehose {
+    <#
+    .SYNOPSIS
+    Runs the integration tests for Firehose plugin.
+
+    .PARAMETER CorePlugin
+    [Optional] Specifies if the core plugin is being tested.
+    #>
+    Param(
+        [Parameter(Mandatory=$false)]
+        [ValidateNotNullOrEmpty()]
+        [switch]$CorePlugin
+    )
+
+    $DockerComposeTestFilePath = "${IntegTestRoot}/test_firehose/docker-compose.windows.test.yml"
+    $DockerComposeValidateFilePath = "${IntegTestRoot}/test_firehose/docker-compose.validate-and-clean-s3.yml"
+    $env:S3_ACTION="validate"
+    $env:S3_PREFIX="firehose-test"
+    $env:TEST_FILE="firehose-test"
+    $env:EXPECTED_EVENTS_LEN="1000"
+
+    # Set the envs based on whether core plugin or Golang plugin is being tested.
+    if ($CorePlugin) {
+        $env:FluentBitConfigDir = "windows-core-config"
+    } else {
+        $env:FluentBitConfigDir = "windows-config"
+    }
+
+    # Run the tests which would generate test data. Once they end, perform "docker-compose down".
+    Run-Test -PluginUnderTest "firehose" -DockerComposeTestFilePath $DockerComposeTestFilePath
+    Clean-Test -PluginUnderTest "firehose" -DockerComposeFilePath $DockerComposeTestFilePath
+
+    # Perform validation of the tests.
+    Validate-Test -PluginUnderTest "firehose" -DockerComposeValidateFilePath $DockerComposeValidateFilePath -ValidationFileName "firehose-test"
+    Clean-Test -PluginUnderTest "firehose" -DockerComposeFilePath $DockerComposeValidateFilePath
+}
+
+Function Test-S3 {
+    <#
+    .SYNOPSIS
+    Runs the S3 integration tests.
+    #>
+
+    # different S3 prefix for each test
+    $env:S3_PREFIX_PUT_OBJECT="logs/${env:ARCHITECTURE}/putobject"
+    $env:S3_PREFIX_MULTIPART="logs/${env:ARCHITECTURE}/multipart"
+    $env:S3_ACTION="validate"
+    $env:S3_PREFIX="logs"
+    $env:TEST_FILE="s3-test"
+    $env:EXPECTED_EVENTS_LEN="7717"
+
+    $DockerComposeTestFilePath = "${IntegTestRoot}/test_s3/docker-compose.windows.test.yml"
+    $DockerComposeValidateS3MultipartFilePath = "${IntegTestRoot}/test_s3/docker-compose.validate-s3-multipart.yml"
+    $DockerComposeValidateS3PutObjectFilePath = "${IntegTestRoot}/test_s3/docker-compose.validate-s3-putobject.yml"
+
+    # Run the tests which would generate test data. Once they end, perform "docker-compose down".
+    Run-Test -PluginUnderTest "S3" -DockerComposeTestFilePath $DockerComposeTestFilePath
+    Clean-Test -PluginUnderTest "S3" -DockerComposeFilePath $DockerComposeTestFilePath
+
+    # Perform validation of the tests.
+    Validate-Test -PluginUnderTest "S3" -DockerComposeValidateFilePath $DockerComposeValidateS3MultipartFilePath -ValidationFileName "s3-test"
+    Clean-Test -PluginUnderTest "S3" -DockerComposeFilePath $DockerComposeValidateS3MultipartFilePath
+
+    Validate-Test -PluginUnderTest "S3" -DockerComposeValidateFilePath $DockerComposeValidateS3PutObjectFilePath -ValidationFileName "s3-test"
+    Clean-Test -PluginUnderTest "S3" -DockerComposeFilePath $DockerComposeValidateS3PutObjectFilePath
+}
+
+Function Clean-S3 {
+    <#
+    .SYNOPSIS
+    Cleans the S3 locations where logs are stored for Kinesis, Firehose, and S3 plugins.
+    #>
+
+    $env:S3_ACTION="clean"
+    $env:EXPECTED_EVENTS_LEN="1000"
+    $DockerComposeKinesisTestFilePath = "${IntegTestRoot}/test_kinesis/docker-compose.validate-and-clean-s3.yml"
+    $DockerComposeFirehoseTestFilePath = "${IntegTestRoot}/test_firehose/docker-compose.validate-and-clean-s3.yml"
+    $DockerComposeKinesisTestFilePath = "${IntegTestRoot}/test_kinesis/docker-compose.validate-and-clean-s3.yml"
+    $DockerComposeS3MultipartFilePath = "${IntegTestRoot}/test_s3/docker-compose.validate-s3-multipart.yml"
+    $DockerComposeS3PutObjectFilePath = "${IntegTestRoot}/test_s3/docker-compose.validate-s3-putobject.yml"
+
+    # Clean the S3 locations used in Kinesis tests.
+    $env:S3_PREFIX="kinesis-test"
+    $env:TEST_FILE="kinesis-test"
+    Run-Test -PluginUnderTest "Clean-S3" -DockerComposeTestFilePath $DockerComposeKinesisTestFilePath -SleepTime 1
+    Clean-Test -PluginUnderTest "Clean-S3" -DockerComposeFilePath $DockerComposeKinesisTestFilePath
+
+    # Clean the S3 locations used in Firehose tests.
+    $env:S3_PREFIX="firehose-test"
+    $env:TEST_FILE="firehose-test"
+    Run-Test -PluginUnderTest "Clean-S3" -DockerComposeTestFilePath $DockerComposeFirehoseTestFilePath -SleepTime 1
+    Clean-Test -PluginUnderTest "Clean-S3" -DockerComposeFilePath $DockerComposeFirehoseTestFilePath
+
+    # Clean the S3 locations used in Multipart S3 tests.
+    $env:S3_PREFIX_MULTIPART="logs/${env:ARCHITECTURE}/multipart"
+    $env:TEST_FILE="s3-test"
+    Run-Test -PluginUnderTest "Clean-S3" -DockerComposeTestFilePath $DockerComposeS3MultipartFilePath -SleepTime 1
+    Clean-Test -PluginUnderTest "Clean-S3" -DockerComposeFilePath $DockerComposeS3MultipartFilePath
+
+    # Clean the S3 locations used in PutObject S3 tests.
+    $env:S3_PREFIX_PUT_OBJECT="logs/${env:ARCHITECTURE}/putobject"
+    Run-Test -PluginUnderTest "Clean-S3" -DockerComposeTestFilePath $DockerComposeS3PutObjectFilePath -SleepTime 1
+    Clean-Test -PluginUnderTest "Clean-S3" -DockerComposeFilePath $DockerComposeS3PutObjectFilePath
+}
+
+# Install the required packages
+Install-Package
+
+# Select the methods to execute based on the selected test plugin.
+switch ($TestPlugin) {
+    "cloudwatch" {
+        Test-CloudWatch
+        Clean-CloudWatch
+    }
+
+    "cloudwatch_logs" {
+        Test-CloudWatch -CorePlugin
+        Clean-CloudWatch
+    }
+
+    "clean-cloudwatch" {
+        Clean-CloudWatch
+    }
+
+    "kinesis" {
+        # Create and setup test environment.
+        Invoke-Expression "$IntegTestRoot\resources\manage_test_resources.ps1 -Action Create"
+        Invoke-Expression "$IntegTestRoot\resources\manage_test_resources.ps1 -Action Setup"
+
+        Clean-S3
+        Test-Kinesis
+    }
+
+    "kinesis_streams" {
+        # Create and setup test environment.
+        Invoke-Expression "$IntegTestRoot\resources\manage_test_resources.ps1 -Action Create"
+        Invoke-Expression "$IntegTestRoot\resources\manage_test_resources.ps1 -Action Setup"
+
+        Clean-S3
+        Test-Kinesis -CorePlugin
+    }
+
+    "firehose" {
+        # Create and setup test environment.
+        Invoke-Expression "$IntegTestRoot\resources\manage_test_resources.ps1 -Action Create"
+        Invoke-Expression "$IntegTestRoot\resources\manage_test_resources.ps1 -Action Setup"
+
+        Clean-S3
+        Test-Firehose
+    }
+
+    "kinesis_firehose" {
+        # Create and setup test environment.
+        Invoke-Expression "$IntegTestRoot\resources\manage_test_resources.ps1 -Action Create"
+        Invoke-Expression "$IntegTestRoot\resources\manage_test_resources.ps1 -Action Setup"
+
+        Clean-S3
+        Test-Firehose -CorePlugin
+    }
+
+    "s3" {
+        # Create and setup test environment.
+        Invoke-Expression "$IntegTestRoot\resources\manage_test_resources.ps1 -Action Create"
+        Invoke-Expression "$IntegTestRoot\resources\manage_test_resources.ps1 -Action Setup"
+
+        Clean-S3
+        Test-S3
+    }
+
+    "clean-s3" {
+        Invoke-Expression "$IntegTestRoot\resources\manage_test_resources.ps1 -Action Setup"
+        Clean-S3
+    }
+
+    "cicd" {
+        Test-CloudWatch
+        Clean-CloudWatch
+
+        Test-CloudWatch -CorePlugin
+        Clean-CloudWatch
+
+        Invoke-Expression "$IntegTestRoot\resources\manage_test_resources.ps1 -Action Create"
+        Invoke-Expression "$IntegTestRoot\resources\manage_test_resources.ps1 -Action Setup"
+
+        Clean-S3
+        Test-Kinesis
+
+        Clean-S3
+        Test-Kinesis -CorePlugin
+
+        Clean-S3
+        Test-Firehose
+
+        Clean-S3
+        Test-Firehose -CorePlugin
+
+        Clean-S3
+        Test-S3
+
+        Clean-S3
+    }
+
+    "delete" {
+        Invoke-Expression "$IntegTestRoot\resources\manage_test_resources.ps1 -Action Setup"
+        Clean-S3
+        Invoke-Expression "$IntegTestRoot\resources\manage_test_resources.ps1 -Action Delete"
+    }
+}

--- a/integ/test_cloudwatch/docker-compose.windows.test.yml
+++ b/integ/test_cloudwatch/docker-compose.windows.test.yml
@@ -1,0 +1,71 @@
+services:
+    fluent-bit:
+        container_name: ${AWS_FOR_FLUENT_BIT_CONTAINER_NAME}
+        image: ${FLUENT_BIT_IMAGE}
+        environment:
+            - "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}"
+            - "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}"
+            - "AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}"
+            - FLB_LOG_LEVEL=debug
+            - "LOG_GROUP_NAME=${LOG_GROUP_NAME}"
+            - "CW_PLUGIN_UNDER_TEST=${CW_PLUGIN_UNDER_TEST}"
+        healthcheck:
+            test: CMD Powershell -C Get-Process fluent-bit
+            interval: 30s
+            timeout: 5s
+            retries: 3
+            start_period: 10s
+        networks:
+            fluent-net:
+                ipv4_address: ${DockerNetworkStaticIP}
+        volumes:
+            - ${PROJECT_ROOT}/integ/test_cloudwatch/windows-config:C:/fluent-bit/etc/
+        profiles:
+            - core
+    logger-basic-test:
+        build: ${PROJECT_ROOT}/integ/logger
+        logging:
+            driver: fluentd
+            options:
+                tag: "basic-test-${TAG}"
+                fluentd-address: tcp://${FLUENT_CONTAINER_IP}:24542
+        networks:
+            - fluent-net
+        profiles:
+            - test
+    logger-log-key:
+        build: ${PROJECT_ROOT}/integ/logger
+        logging:
+            driver: fluentd
+            options:
+                tag: "log-key-test-${TAG}"
+                fluentd-address: tcp://${FLUENT_CONTAINER_IP}:24542
+        networks:
+            - fluent-net
+        profiles:
+            - test
+    logger-emf:
+        build: ${PROJECT_ROOT}/integ/emf_logger
+        environment:
+            - "EMF_METRIC_NAME_PATH=C:/out/expected-metric-name"
+            - "FLUENT_CONTAINER_IP=${FLUENT_CONTAINER_IP}"
+        logging:
+            driver: fluentd
+            options:
+                tag: "log-emf-test-${TAG}"
+                fluentd-address: tcp://${FLUENT_CONTAINER_IP}:24542
+        # this volume is used for synchronization between the test
+        # and the validator
+        volumes:
+            - ${PROJECT_ROOT}/integ/out:C:/out
+        networks:
+            - fluent-net
+        profiles:
+            - test
+networks:
+    fluent-net:
+        driver: nat
+        ipam:
+            config:
+                - subnet: ${DockerNetworkSubnet}
+                  gateway: ${DockerNetworkGateway}

--- a/integ/test_cloudwatch/windows-config/fluent-bit.conf
+++ b/integ/test_cloudwatch/windows-config/fluent-bit.conf
@@ -1,0 +1,52 @@
+[SERVICE]
+    Log_Level debug
+
+[INPUT]
+    Name              forward
+    Listen            0.0.0.0
+    Port              24542
+    Buffer_Chunk_Size 1M
+    Buffer_Max_Size   6M
+
+# TCP input used for EMF payloads
+[INPUT]
+    Name        tcp
+    Listen      0.0.0.0
+    Port        5170
+    Chunk_Size  32
+    Buffer_Size 64
+    Format      none
+    Tag         emf
+
+# Output for stdout -> CloudWatch
+[OUTPUT]
+    Name ${CW_PLUGIN_UNDER_TEST}
+    Match   basic-test-*
+    region us-west-2
+    log_group_name ${LOG_GROUP_NAME}
+    log_stream_prefix from-fluent-bit-
+    auto_create_group true
+    net.dns.resolver LEGACY
+
+# Filtered output from stdout -> CloudWatch
+[OUTPUT]
+    Name ${CW_PLUGIN_UNDER_TEST}
+    Match   log-key-test-*
+    region us-west-2
+    log_key log
+    log_group_name ${LOG_GROUP_NAME}
+    log_stream_prefix from-fluent-bit-
+    auto_create_group true
+    net.dns.resolver LEGACY
+
+# Output for EMF over TCP -> CloudWatch
+[OUTPUT]
+    Name                ${CW_PLUGIN_UNDER_TEST}
+    Match               emf
+    region              us-west-2
+    log_key             log
+    log_group_name      ${LOG_GROUP_NAME}
+    log_stream_prefix   from-fluent-bit-
+    auto_create_group   true
+    log_format          json/emf
+    net.dns.resolver LEGACY

--- a/integ/test_firehose/docker-compose.windows.test.yml
+++ b/integ/test_firehose/docker-compose.windows.test.yml
@@ -1,0 +1,40 @@
+services:
+    fluent-bit:
+        container_name: ${AWS_FOR_FLUENT_BIT_CONTAINER_NAME}
+        image: ${FLUENT_BIT_IMAGE}
+        environment:
+            - "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}"
+            - "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}"
+            - "AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}"
+            - "FIREHOSE_STREAM=${FIREHOSE_STREAM}"
+            - FLB_LOG_LEVEL=debug
+        volumes:
+            - ${PROJECT_ROOT}/integ/test_firehose/${FluentBitConfigDir}/:C:/fluent-bit/etc/
+        healthcheck:
+            test: CMD Powershell -C Get-Process fluent-bit
+            interval: 30s
+            timeout: 5s
+            retries: 3
+            start_period: 10s
+        networks:
+            fluent-net:
+                ipv4_address: ${DockerNetworkStaticIP}
+        profiles:
+            - core
+    logger-test:
+        build: ${PROJECT_ROOT}/integ/logger
+        logging:
+            driver: fluentd
+            options:
+                fluentd-address: tcp://${FLUENT_CONTAINER_IP}:24542
+        networks:
+            - fluent-net
+        profiles:
+            - test
+networks:
+    fluent-net:
+        driver: nat
+        ipam:
+            config:
+                - subnet: ${DockerNetworkSubnet}
+                  gateway: ${DockerNetworkGateway}

--- a/integ/test_firehose/windows-config/fluent-bit.conf
+++ b/integ/test_firehose/windows-config/fluent-bit.conf
@@ -1,0 +1,17 @@
+[SERVICE]
+    Log_Level debug
+
+[INPUT]
+    Name              forward
+    Listen            0.0.0.0
+    Port              24542
+    Buffer_Chunk_Size 1M
+    Buffer_Max_Size   6M
+
+[OUTPUT]
+    Name            firehose
+    Match           *
+    region          us-west-2
+    delivery_stream ${FIREHOSE_STREAM}
+    data_keys       log,source
+    net.dns.resolver LEGACY

--- a/integ/test_firehose/windows-core-config/fluent-bit.conf
+++ b/integ/test_firehose/windows-core-config/fluent-bit.conf
@@ -1,0 +1,16 @@
+[SERVICE]
+    Log_Level debug
+
+[INPUT]
+    Name              forward
+    Listen            0.0.0.0
+    Port              24542
+    Buffer_Chunk_Size 1M
+    Buffer_Max_Size   6M
+
+[OUTPUT]
+    Name            kinesis_firehose
+    Match           *
+    region          us-west-2
+    delivery_stream ${FIREHOSE_STREAM}
+    net.dns.resolver LEGACY

--- a/integ/test_kinesis/docker-compose.windows.test.yml
+++ b/integ/test_kinesis/docker-compose.windows.test.yml
@@ -1,0 +1,40 @@
+services:
+    fluent-bit:
+        container_name: ${AWS_FOR_FLUENT_BIT_CONTAINER_NAME}
+        image: ${FLUENT_BIT_IMAGE}
+        environment:
+            - "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}"
+            - "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}"
+            - "AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}"
+            - "KINESIS_STREAM=${KINESIS_STREAM}"
+            - FLB_LOG_LEVEL=debug
+        volumes:
+            - ${PROJECT_ROOT}/integ/test_kinesis/${FluentBitConfigDir}/:C:/fluent-bit/etc/
+        healthcheck:
+            test: CMD Powershell -C Get-Process fluent-bit
+            interval: 30s
+            timeout: 5s
+            retries: 3
+            start_period: 10s
+        networks:
+            fluent-net:
+                ipv4_address: ${DockerNetworkStaticIP}
+        profiles:
+            - core
+    logger-test:
+        build: ${PROJECT_ROOT}/integ/logger
+        logging:
+            driver: fluentd
+            options:
+                fluentd-address: tcp://${FLUENT_CONTAINER_IP}:24542
+        networks:
+            - fluent-net
+        profiles:
+            - test
+networks:
+    fluent-net:
+        driver: nat
+        ipam:
+            config:
+                - subnet: ${DockerNetworkSubnet}
+                  gateway: ${DockerNetworkGateway}

--- a/integ/test_kinesis/windows-config/fluent-bit.conf
+++ b/integ/test_kinesis/windows-config/fluent-bit.conf
@@ -1,0 +1,19 @@
+[SERVICE]
+    Log_Level debug
+
+[INPUT]
+    Name              forward
+    Listen            0.0.0.0
+    Port              24542
+    Buffer_Chunk_Size 1M
+    Buffer_Max_Size   6M
+
+[OUTPUT]
+    Name            kinesis
+    Match           *
+    region          us-west-2
+    stream          ${KINESIS_STREAM}
+    partition_key   wrong_key
+    data_keys       log,source
+    append_newline  true
+    net.dns.resolver LEGACY

--- a/integ/test_kinesis/windows-core-config/fluent-bit.conf
+++ b/integ/test_kinesis/windows-core-config/fluent-bit.conf
@@ -1,0 +1,16 @@
+[SERVICE]
+    Log_Level debug
+
+[INPUT]
+    Name              forward
+    Listen            0.0.0.0
+    Port              24542
+    Buffer_Chunk_Size 1M
+    Buffer_Max_Size   6M
+
+[OUTPUT]
+    Name            kinesis_streams
+    Match           *
+    region          us-west-2
+    stream          ${KINESIS_STREAM}
+    net.dns.resolver LEGACY

--- a/integ/test_s3/docker-compose.windows.test.yml
+++ b/integ/test_s3/docker-compose.windows.test.yml
@@ -1,0 +1,53 @@
+services:
+    fluent-bit:
+        container_name: ${AWS_FOR_FLUENT_BIT_CONTAINER_NAME}
+        image: ${FLUENT_BIT_IMAGE}
+        environment:
+            - "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}"
+            - "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}"
+            - "AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}"
+            - "S3_BUCKET_NAME=${S3_BUCKET_NAME}"
+            - "ARCHITECTURE=${ARCHITECTURE}"
+            - FLB_LOG_LEVEL=debug
+        volumes:
+            - ${PROJECT_ROOT}/integ/test_s3/windows-config/:C:/fluent-bit/etc/
+        healthcheck:
+            test: CMD Powershell -C Get-Process fluent-bit
+            interval: 30s
+            timeout: 5s
+            retries: 3
+            start_period: 10s
+        networks:
+            fluent-net:
+                ipv4_address: ${DockerNetworkStaticIP}
+        profiles:
+            - core
+    logger-multipart-test:
+        build: ${PROJECT_ROOT}/integ/s3-logger
+        logging:
+            driver: fluentd
+            options:
+                tag: "multipart-upload-test-${TAG}"
+                fluentd-address: tcp://${FLUENT_CONTAINER_IP}:24542
+        networks:
+            - fluent-net
+        profiles:
+            - test
+    logger-put-object-test:
+        build: ${PROJECT_ROOT}/integ/s3-logger
+        logging:
+            driver: fluentd
+            options:
+                tag: "put-object-test-${TAG}"
+                fluentd-address: tcp://${FLUENT_CONTAINER_IP}:24542
+        networks:
+            - fluent-net
+        profiles:
+            - test
+networks:
+    fluent-net:
+        driver: nat
+        ipam:
+            config:
+                - subnet: ${DockerNetworkSubnet}
+                  gateway: ${DockerNetworkGateway}

--- a/integ/test_s3/windows-config/fluent-bit.conf
+++ b/integ/test_s3/windows-config/fluent-bit.conf
@@ -1,0 +1,34 @@
+[SERVICE]
+    Log_Level debug
+
+[INPUT]
+    Name              forward
+    Listen            0.0.0.0
+    Port              24542
+    Buffer_Chunk_Size 1M
+    Buffer_Max_Size   6M
+
+[OUTPUT]
+    Name s3
+    Match multipart*
+    bucket ${S3_BUCKET_NAME}
+    region us-west-2
+    store_dir /fluent-bit/buffer
+    total_file_size 100M
+    s3_key_format /logs/${ARCHITECTURE}/multipart/$TAG[1]/logs/$TAG/%Y/%m/%d/%H/%M/%S
+    s3_key_format_tag_delimiters .-
+    upload_timeout 1m30s
+    net.dns.resolver LEGACY
+
+[OUTPUT]
+    Name s3
+    Match put-object*
+    bucket ${S3_BUCKET_NAME}
+    region us-west-2
+    store_dir /fluent-bit/buffer
+    total_file_size 1M
+    s3_key_format /logs/${ARCHITECTURE}/put$TAG[1]/logs/$TAG/%Y/%m/%d/%H/%M/%S
+    s3_key_format_tag_delimiters .-
+    use_put_object On
+    upload_timeout 30s
+    net.dns.resolver LEGACY


### PR DESCRIPTION
## Summary
This commits adds the required docker-compose projects, fluent-bit configurations, and the Powershell scripts needed to run the integration tests on Windows platform.

The design of the integration tests along with the constraints are detailed in the next section.

## Constraints and mitigations
When we are using docker-compose to orchestrate our tests, we encounter a few limitations. Here, we detail the ways in which the same are mitigated.
- Fluent-bit for Windows would have to use the TCP sockets for receiving logs from other containers as Unix Sockets are not well supported. Basically, Fluent-bit would start first and listen on a port. Application containers would start after that and would use `fluentd` logging driver and connect to Fluent-bit `IP Address:Port`. 
    - Therefore, in order to accommodate the same, we use different profiles for docker-compose. Core profile has fluent-bit service. Test profile has other services which generate test data.
    - Each core service has a health-check configured which checks if the Fluent-bit process is running or not.
    - We run the core profile first in detach mode and wait for the service to become healthy.
    - Then we run the test profile which would send data to fluent-bit started earlier.
    - Note that if for some reason, fluent-bit container exits before or in between the test, then test containers would not be able to connect to the TCP port, and therefore, test would error out.
- For the above reason itself, we need to know the IP address of the fluent-bit container.
    - Therefore, we use a static NAT network which is part of the docker-compose configuration. We use a static link local subnet for this network which ensures there aren't any IP conflicts.
    - A static IP address is assigned to FLB container.
- Upstream does not support async DNS in the scenario wherein we need to perform DNS queries multiple times from a Server List. Upstream Issue: https://github.com/fluent/fluent-bit/issues/5862
    - We are using a workaround wherein we use system resolver for performing the DNS query. This is achieved by setting `net.dns.resolver LEGACY` setting in the config. 
    - Note that this is applicable only when using NAT network mode.

## Implementation design
As part of each plugin test, we do the following-
-  For few plugins, we need to create test resources using CFN.
- Perform cleanup of destination if required. This is needed so that the data in destination is from current test only.
- Set the environment variables needed for the test.
- Run the Core services of docker-compose
- Run the Test data generation services of docker-compose
- Wait for sometime for data to be populated in the upstream destinations.
- Run the validation docker-compose projects.

At any point, if we encounter any error, then we error out at that point itself.

## Testing
The integration tests were triggered multiple times using the `run-integ.ps1` script.

## Description of changes:
Added support for running integration tests on Windows

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.