### PR TITLE
Updates debugging guide to use latest version

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -140,7 +140,7 @@ EXPOSE 2020
 # Default: Run under valgrind
 # alternatively, you can change this to run FB directly and try
 # to get a core file instead
-CMD valgrind --leak-check=full /fluent-bit/bin/fluent-bit -c /fluent-bit/etc/fluent-bit.conf
+CMD valgrind --leak-check=full --error-limit=no /fluent-bit/bin/fluent-bit -c /fluent-bit/etc/fluent-bit.conf
 
 # Alternate: Run directly and get core file
 # make sure you run with `docker run --ulimit core=-1`

--- a/troubleshooting/debugging.md
+++ b/troubleshooting/debugging.md
@@ -191,7 +191,7 @@ If you're running on an old version, it may have been fixed in the latest releas
 
 Or, you may be facing an unresolved or not-yet-discovered issue in a newer version. Downgrading to our latest stable version may work: https://github.com/aws/aws-for-fluent-bit#using-the-stable-tag
 
-In the AWS for Fluent Bit repo, we always attempt to tag bug reports with which versions are affected, for example see [this query](https://github.com/aws/aws-for-fluent-bit/issues?q=is%3Aissue+is%3Aopen+label%3Aaws-2.28.0).  
+In the AWS for Fluent Bit repo, we always attempt to tag bug reports with which versions are affected, for example see [this query](https://github.com/aws/aws-for-fluent-bit/issues?q=is%3Aissue+is%3Aopen+label%3Aaws-2.21.0).  
 
 #### Network Connection Issues
 
@@ -235,10 +235,10 @@ There are some caveats when using Valgrind. Its a debugging tool, and so it sign
 
 ##### Option 1: Build from prod release (Easier but less robust)
 
-Use the Dockerfile below to create a new container image that will invoke your Fluent Bit version using Valgrind. Replace the "builder" image with whatever AWS for Fluent Bit release you are using, in this case, we are testing 2.28.0. The Dockerfile here will copy the original binary into a new image with Valgrind. Valgrind is a little bit like a mini-VM that will run the Fluent Bit binary and inspect the code at runtime. When you terminate the container, Valgrind will output diagnostic information on shutdown, with summary of memory leaks it detected. This output will allow us to determine which part of the code caused the leak. Valgrind can also be used to find the source of segmentation faults
+Use the Dockerfile below to create a new container image that will invoke your Fluent Bit version using Valgrind. Replace the "builder" image with whatever AWS for Fluent Bit release you are using, in this case, we are testing the latest image. The Dockerfile here will copy the original binary into a new image with Valgrind. Valgrind is a little bit like a mini-VM that will run the Fluent Bit binary and inspect the code at runtime. When you terminate the container, Valgrind will output diagnostic information on shutdown, with summary of memory leaks it detected. This output will allow us to determine which part of the code caused the leak. Valgrind can also be used to find the source of segmentation faults
 
 ```
-FROM public.ecr.aws/aws-observability/aws-for-fluent-bit:2.28.0 as builder
+FROM public.ecr.aws/aws-observability/aws-for-fluent-bit:latest as builder
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:latest
 RUN yum upgrade -y \

--- a/troubleshooting/debugging.md
+++ b/troubleshooting/debugging.md
@@ -191,7 +191,7 @@ If you're running on an old version, it may have been fixed in the latest releas
 
 Or, you may be facing an unresolved or not-yet-discovered issue in a newer version. Downgrading to our latest stable version may work: https://github.com/aws/aws-for-fluent-bit#using-the-stable-tag
 
-In the AWS for Fluent Bit repo, we always attempt to tag bug reports with which versions are affected, for example see [this query](https://github.com/aws/aws-for-fluent-bit/issues?q=is%3Aissue+is%3Aopen+label%3Aaws-2.21.0).  
+In the AWS for Fluent Bit repo, we always attempt to tag bug reports with which versions are affected, for example see [this query](https://github.com/aws/aws-for-fluent-bit/issues?q=is%3Aissue+is%3Aopen+label%3Aaws-2.28.0).  
 
 #### Network Connection Issues
 
@@ -235,10 +235,10 @@ There are some caveats when using Valgrind. Its a debugging tool, and so it sign
 
 ##### Option 1: Build from prod release (Easier but less robust)
 
-Use the Dockerfile below to create a new container image that will invoke your Fluent Bit version using Valgrind. Replace the "builder" image with whatever AWS for Fluent Bit release you are using, in this case, we are testing 2.21.0. The Dockerfile here will copy the original binary into a new image with Valgrind. Valgrind is a little bit like a mini-VM that will run the Fluent Bit binary and inspect the code at runtime. When you terminate the container, Valgrind will output diagnostic information on shutdown, with summary of memory leaks it detected. This output will allow us to determine which part of the code caused the leak. Valgrind can also be used to find the source of segmentation faults
+Use the Dockerfile below to create a new container image that will invoke your Fluent Bit version using Valgrind. Replace the "builder" image with whatever AWS for Fluent Bit release you are using, in this case, we are testing 2.28.0. The Dockerfile here will copy the original binary into a new image with Valgrind. Valgrind is a little bit like a mini-VM that will run the Fluent Bit binary and inspect the code at runtime. When you terminate the container, Valgrind will output diagnostic information on shutdown, with summary of memory leaks it detected. This output will allow us to determine which part of the code caused the leak. Valgrind can also be used to find the source of segmentation faults
 
 ```
-FROM public.ecr.aws/aws-observability/aws-for-fluent-bit:2.21.0 as builder
+FROM public.ecr.aws/aws-observability/aws-for-fluent-bit:2.28.0 as builder
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:latest
 RUN yum upgrade -y \
@@ -247,11 +247,12 @@ RUN yum upgrade -y \
           pkgconfig \
           systemd-devel \
           zlib-devel \
+          libyaml \
           valgrind \
           nc && rm -fr /var/cache/yum
 
 COPY --from=builder /fluent-bit /fluent-bit
-CMD valgrind --leak-check=full /fluent-bit/bin/fluent-bit -c /fluent-bit/etc/fluent-bit.conf
+CMD valgrind --leak-check=full --error-limit=no /fluent-bit/bin/fluent-bit -c /fluent-bit/etc/fluent-bit.conf
 ```
 
 ##### Option 2: Debug Build (More robust)


### PR DESCRIPTION
Updates the debugging guide to use version 2.28.

In addition to changing references from 2.21 to 2.28, this adds the `libyaml` library to the Dockerfile. The container will not start without it. I also added the `--error-limit=no` argument for valgrind to ensure that it will continue to log errors - even if there are a lot of them.