### PR TITLE
windows: added the buildspec for creating Windows image manifests

### DIFF
--- a/buildspec_windows_create_manifest.yml
+++ b/buildspec_windows_create_manifest.yml
@@ -1,0 +1,53 @@
+version: 0.2
+
+phases:
+  install:
+    commands:
+      - echo "Creating manifest for aws-for-fluent-bit Windows image"
+      - yum update -y && yum upgrade -y
+      - yum install jq -y
+  build:
+    commands:
+      - |
+        export DOCKER_CLI_EXPERIMENTAL=enabled
+        declare -A os_releases=( ["windows2019"]="ltsc2019" ["windows2022"]="ltsc2022")
+        
+        # Push the image to ECR with corresponding architecture as the tag.
+        aws ecr get-login-password --region ${AWS_REGION}| docker login --username AWS --password-stdin ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com
+        
+        # Find the applicable windows versions.
+        cd $CODEBUILD_SRC_DIR
+        versions=$(cat windows.versions | jq -c -r '.windows[].version')
+        latest_version=""
+        
+        # Create and push the image manifests.
+        while read -r version; do
+          if [[ "$latest_version" < "$version" ]]; then
+            latest_version=$version
+          fi
+          
+          docker manifest create ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-windows:${version}-windowsservercore \
+          ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-windows:${version}-${os_releases[windows2019]} \
+          ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-windows:${version}-${os_releases[windows2022]}
+        
+          # Sanity check the manifest.
+          docker manifest inspect ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-windows:${version}-windowsservercore
+          
+          # Push manifest to ECR.
+          docker manifest push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-windows:${version}-windowsservercore
+        done <<< "$(echo "$versions")"
+        
+        # Create and push manifest for latest image.
+        docker manifest create ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-windows:windowsservercore-latest \
+        ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-windows:${latest_version}-${os_releases[windows2019]} \
+        ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-windows:${latest_version}-${os_releases[windows2022]}
+        
+        docker manifest push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-windows:windowsservercore-latest
+        
+        # Create and push manifest for stable image.
+        stable_version=$(cat AWS_FOR_FLUENT_BIT_STABLE_VERSION)
+        docker manifest create ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-windows:windowsservercore-stable \
+        ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-windows:${stable_version}-${os_releases[windows2019]} \
+        ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-windows:${stable_version}-${os_releases[windows2022]}
+        
+        docker manifest push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-windows:windowsservercore-stable

--- a/integ/run-integ.ps1
+++ b/integ/run-integ.ps1
@@ -250,7 +250,7 @@ Function Clean-Test {
     )
 
     # Run "docker-compose down" once the tests have been ran.
-    docker-compose --file $DockerComposeFilePath --profile $CoreProfile --profile $TestProfile down -v --rmi all --remove-orphans
+    docker-compose --file $DockerComposeFilePath --profile $CoreProfile --profile $TestProfile down
     Test-Command -TestMethod "$($MyInvocation.MyCommand): ${PluginUnderTest}"
 }
 

--- a/scripts/build_windows_image.ps1
+++ b/scripts/build_windows_image.ps1
@@ -109,7 +109,7 @@ $ECSConfigArchiveName = "ecs.zip"
 $AWSForFluentBitVersionFilename = "AWS_FOR_FLUENT_BIT_VERSION"
 $EntrypointScriptName = "entrypoint.ps1"
 $Dockerfile = "Dockerfile.windows"
-$ecrImageName = "${AccountId}.dkr.ecr.${Region}.amazonaws.com/aws-for-fluent-bit:${AWSForFluentBitVersion}-${BASEIMAGETAG}"
+$ecrImageName = "${AccountId}.dkr.ecr.${Region}.amazonaws.com/amazon/aws-for-fluent-bit-windows:${AWSForFluentBitVersion}-${BASEIMAGETAG}"
 
 # Create all the directories
 Write-Host "Creating all the required directories"


### PR DESCRIPTION
## Summary
Windows images would have the following manifests-
- <AWS_FOR_FLB_VERSION>-windowsservercore
- windowsservercore-latest
- windowsservercore-stable

This change adds the buildspec which would be used in a CodeBuild project to generate the manifests for Windows images.

## Description of changes:
added the buildspec to generate manifests for Windows images

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
