### PR TITLE
Bump test loadtests 4

### DIFF
--- a/AWS_FOR_FLUENT_BIT_VERSION
+++ b/AWS_FOR_FLUENT_BIT_VERSION
@@ -1,1 +1,1 @@
-loadtest-test-2-2.28.1
+loadtest-test-3-2.28.1

--- a/load_tests/create_testing_resources/ecs/app.py
+++ b/load_tests/create_testing_resources/ecs/app.py
@@ -40,7 +40,7 @@ class TestingResources(core.Stack):
         )
         capacity_provider = ecs.AsgCapacityProvider(self, "asgCapacityProvider",
             auto_scaling_group=asg,
-            enable_managed_termination_protection=False
+            enable_managed_termination_protection=True
         )
         cluster.add_asg_capacity_provider(capacity_provider)
         cluster.apply_removal_policy(core.RemovalPolicy.DESTROY)


### PR DESCRIPTION
Added termination protection on instances protecting load tests from transient host kill errors


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
