### PR TITLE
Stable go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,9 @@ RUN yum install -y  \
 ENV HOME /home
 
 # Lock Go Lang version to stable
-RUN /bin/gimme stable; \
-      export GO_STABLE_VERSION=`cat /home/.gimme/versions/stable`; \
+RUN export GO_STABLE_VERSION=`curl --silent https://go.dev/VERSION?m=text | cut -d "o" -f 2`; \
+      echo "Using go:stable version ${GO_STABLE_VERSION}"; \
+      gimme ${GO_STABLE_VERSION}; \
       ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.arm64 /home/.gimme/versions/gostable.linux.arm64; \
       ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.amd64 /home/.gimme/versions/gostable.linux.amd64
 ENV PATH ${PATH}:/home/.gimme/versions/gostable.linux.arm64/bin:/home/.gimme/versions/gostable.linux.amd64/bin

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -40,8 +40,9 @@ RUN yum install -y  \
 ENV HOME /home
 
 # Lock Go Lang version to stable
-RUN /bin/gimme stable; \
-      export GO_STABLE_VERSION=`cat /home/.gimme/versions/stable`; \
+RUN export GO_STABLE_VERSION=`curl --silent https://go.dev/VERSION?m=text | cut -d "o" -f 2`; \
+      echo "Using go:stable version ${GO_STABLE_VERSION}"; \
+      gimme ${GO_STABLE_VERSION}; \
       ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.arm64 /home/.gimme/versions/gostable.linux.arm64; \
       ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.amd64 /home/.gimme/versions/gostable.linux.amd64
 ENV PATH ${PATH}:/home/.gimme/versions/gostable.linux.arm64/bin:/home/.gimme/versions/gostable.linux.amd64/bin

--- a/Dockerfile.init
+++ b/Dockerfile.init
@@ -6,8 +6,9 @@ RUN yum upgrade -y && yum install -y tar gzip git
 ENV HOME /home
 
 # Lock Go Lang version to stable
-RUN /bin/gimme stable; \
-      export GO_STABLE_VERSION=`cat /home/.gimme/versions/stable`; \
+RUN export GO_STABLE_VERSION=`curl --silent https://go.dev/VERSION?m=text | cut -d "o" -f 2`; \
+      echo "Using go:stable version ${GO_STABLE_VERSION}"; \
+      gimme ${GO_STABLE_VERSION}; \
       ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.arm64 /home/.gimme/versions/gostable.linux.arm64; \
       ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.amd64 /home/.gimme/versions/gostable.linux.amd64
 ENV PATH ${PATH}:/home/.gimme/versions/gostable.linux.arm64/bin:/home/.gimme/versions/gostable.linux.amd64/bin

--- a/Dockerfile.plugins
+++ b/Dockerfile.plugins
@@ -5,8 +5,9 @@ RUN yum upgrade -y && yum install -y tar gzip git make gcc
 ENV HOME /home
 
 # Lock Go Lang version to stable
-RUN /bin/gimme stable; \
-      export GO_STABLE_VERSION=`cat /home/.gimme/versions/stable`; \
+RUN export GO_STABLE_VERSION=`curl --silent https://go.dev/VERSION?m=text | cut -d "o" -f 2`; \
+      echo "Using go:stable version ${GO_STABLE_VERSION}"; \
+      gimme ${GO_STABLE_VERSION}; \
       ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.arm64 /home/.gimme/versions/gostable.linux.arm64; \
       ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.amd64 /home/.gimme/versions/gostable.linux.amd64
 ENV PATH ${PATH}:/home/.gimme/versions/gostable.linux.arm64/bin:/home/.gimme/versions/gostable.linux.amd64/bin


### PR DESCRIPTION
The GIMME script actually has a bug preventing "stable" go from being downloaded only on ARM platforms.

you can see it on the following line:
https://github.com/travis-ci/gimme/blob/master/gimme#L884

The line should have an extra check for GIMME_GO_VERSION=stable, or should evaluate stable to an integer before running the version guard checks for ARM.

As a solution, we determine stable GO version via a curl request:
```
curl --silent https://go.dev/VERSION?m=text 
```

then cut the version tag off of the response
```
| cut -d "o" -f 2
```

This solution should be durable because the GIMME script uses this to obtain stable:
https://github.com/travis-ci/gimme/blob/master/gimme#L665

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
