### PR TITLE
Windows: added the scripts for verifying images and determining if sync required

### DIFF
--- a/buildspec_windows_sync_images.yml
+++ b/buildspec_windows_sync_images.yml
@@ -1,0 +1,22 @@
+version: 0.2
+
+# This variable is used to determine if the Sync workflow needs to copy image into the regional ECR.
+# Ensure that first exported variable is always SYNC_IMAGES as that is validated in the Step Function workflow.
+env:
+  exported-variables:
+    - SYNC_IMAGES
+
+phases:
+  install:
+    commands:
+      - echo "Verifies if the Windows images need to be synced from public ECR"
+      - yum update -y && yum upgrade -y
+      - yum install jq -y
+  build:
+    commands:
+      # Validates that the images present in regional ECR are in sync with the images present in public ECR.
+      # It would export a variable SYNC_IMAGES which would be read by subsequent stages.
+      # The execution of those stages (publish-image-to-regional-ecr) depend upon this variable.
+      - cd ./scripts
+      - './sync_windows_images.sh'
+      - SYNC_IMAGES=$(cat SYNC_IMAGES)

--- a/buildspec_windows_verify_images.yml
+++ b/buildspec_windows_verify_images.yml
@@ -1,0 +1,14 @@
+version: 0.2
+
+phases:
+  install:
+    commands:
+      - echo "Verifies the Windows images in the required registry"
+      - yum update -y && yum upgrade -y
+      - yum install jq -y
+  build:
+    commands:
+      # Validates that the images are present in the registries with the required manifest.
+      # The required variables would be passed on via CodeBuild Environment variables.
+      - cd ./scripts
+      - './verify_windows_images.sh'

--- a/scripts/sync_windows_images.sh
+++ b/scripts/sync_windows_images.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# 	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+set -uo pipefail
+
+#############################################################################################################
+# Start of the script
+#############################################################################################################
+
+# Source the common methods
+source ./common_windows.sh
+# Get the regional endpoint variable
+image_endpoint=$(get_regional_image_endpoint "${TARGET_AWS_REGION}")
+
+# Declare the constants
+SOURCE_REPOSITORY_URL="public.ecr.aws/${SOURCE_REGISTRY_ALIAS}/${SOURCE_REPOSITORY}"
+TARGET_REPOSITORY_URL="${TARGET_AWS_ACCOUNT}.dkr.ecr.${TARGET_AWS_REGION}.${image_endpoint}/${TARGET_REPOSITORY}"
+
+# Authenticate to ECR of target repository.
+# Since out sync-task workflows would only target regional ECR, we are explicitly logging into the same.
+aws ecr get-login-password --region "${TARGET_AWS_REGION}" | docker login --username AWS --password-stdin "${TARGET_REPOSITORY_URL}"
+
+echo "Verifying if the images need to be synced in: ${TARGET_AWS_REGION}@${TARGET_AWS_ACCOUNT}"
+
+# Obtain the source image and expected image url.
+LATEST_IMAGE_URI_WITH_LATEST_TAG_IN_SOURCE="${SOURCE_REPOSITORY_URL}:windowsservercore-latest"
+LATEST_IMAGE_URI_WITH_LATEST_TAG_IN_TARGET="${TARGET_REPOSITORY_URL}:windowsservercore-latest"
+
+# Compare manifests for both and determine if sync is required.
+compare_image_manifests "${LATEST_IMAGE_URI_WITH_LATEST_TAG_IN_SOURCE}" "${LATEST_IMAGE_URI_WITH_LATEST_TAG_IN_TARGET}"
+if [ $? = 1 ]; then
+  echo "true" > SYNC_IMAGES
+  echo "Images need to be synced in: ${TARGET_AWS_REGION}@${TARGET_AWS_ACCOUNT}"
+else
+  echo "false" > SYNC_IMAGES
+  echo "Images are already in sync: ${TARGET_AWS_REGION}@${TARGET_AWS_ACCOUNT}"
+fi

--- a/scripts/verify_windows_images.sh
+++ b/scripts/verify_windows_images.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# 	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+set -euo pipefail
+
+#############################################################################################################
+# Start of the script
+#############################################################################################################
+
+# Source the common methods
+source ./common_windows.sh
+# Get the regional endpoint variable
+image_endpoint=$(get_regional_image_endpoint "${AWS_REGION}")
+
+#############################################################################################################
+# For regional ECR, we create the specific image URL here. Additionally, we also authenticate to regional ECR.
+#############################################################################################################
+if [[ $TARGET_REGISTRY == "private-ecr" ]]; then
+  # Create Repository url specific for regional ECR.
+  REGISTRY="${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.${image_endpoint}"
+  REPOSITORY_PATH="${REGISTRY}/${REPOSITORY}"
+
+  # Authenticate to ECR.
+  aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${REGISTRY}"
+
+#############################################################################################################
+# For public ECR, we create the specific image URL here.
+#############################################################################################################
+elif [[ $TARGET_REGISTRY == "public-ecr" ]]; then
+  REGISTRY="public.ecr.aws/${PUBLIC_REGISTRY_ALIAS}"
+  REPOSITORY_PATH="${REGISTRY}/${REPOSITORY}"
+
+#############################################################################################################
+# For dockerhub, we create the specific image URL here.
+#############################################################################################################
+elif [[ $TARGET_REGISTRY == "dockerhub" ]]; then
+  REPOSITORY_PATH="${REPOSITORY}"
+fi
+
+#############################################################################################################
+# For "verify-images" action, we will verify that the image manifest exists for all the supported versions
+# in the target registry. We will also verify the latest image and compare the image digests for the same.
+#############################################################################################################
+if [[ $ACTION == "verify-images" ]]; then
+  # Validate that manifest exists for all the versions.
+  while read -r version; do
+    check_image_manifest_exists "${REPOSITORY_PATH}:${version}-windowsservercore"
+  done <<< "$(echo "${ALL_AWS_FOR_FLUENT_BIT_VERSIONS}")"
+
+  # Validate that latest manifest is same as the required version.
+  LATEST_IMAGE_URI_WITH_VERSION_TAG="${REPOSITORY_PATH}:${AWS_FOR_FLUENT_BIT_LATEST_VERSION}-windowsservercore"
+  LATEST_IMAGE_URI_WITH_LATEST_TAG="${REPOSITORY_PATH}:windowsservercore-latest"
+  compare_image_manifests "${LATEST_IMAGE_URI_WITH_LATEST_TAG}" "${LATEST_IMAGE_URI_WITH_VERSION_TAG}"
+
+#############################################################################################################
+# Any action not matching above is unsupported.
+#############################################################################################################
+else
+  echo "Unsupported action: ${ACTION}"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
As part of our publishing workflow, we are pushing the images as well as the manifest into the target repository of the target registry. The next step would then verify if the images are infact present in the target repository.

Additionally, we have a sync task workflow, wherein we need to determine if we want to sync the images in regional ECR repository with the ones present in public ECR. Therefore, we compare the manifests of the same and then export a variable in CodeBuild project. This would be read by the subsequent stages in Step Function to determine if we do need to publish images into the regional ECR repository.

## Testing
These scripts have been tested as part of an automated end to end workflow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
