### PR TITLE
windows: update the openssl version to 3.0.7

### DIFF
--- a/scripts/build_windows_fluent_bit.ps1
+++ b/scripts/build_windows_fluent_bit.ps1
@@ -54,7 +54,7 @@ $ErrorActionPreference = 'Stop'
 
 # Constants
 $FlexBisonVersion = "2.5.22"
-$OpenSSLVersion = "3.0.5"
+$OpenSSLVersion = "3.0.7"
 
 # Directory paths
 $BaseDir = "C:\build"


### PR DESCRIPTION
## Summary
There is a new CVE found in `openssl` due to which we are updating the openssl version used during Windows build to 3.0.7.

CVE description: https://www.openssl.org/blog/blog/2022/11/01/email-address-overflows/

## Description of changes:
upgrading openssl version to 3.0.7 for Windows build

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
