### PR TITLE
windows: consolidate all configurable versions in the config file

### DIFF
--- a/buildspec_windows_fluent-bit.yml
+++ b/buildspec_windows_fluent-bit.yml
@@ -14,8 +14,10 @@ phases:
       - $FLB_VERSION = [System.Environment]::GetEnvironmentVariable('FLB_VERSION')
       - $AWS_FOR_FLUENT_BIT_VERSION = [System.Environment]::GetEnvironmentVariable('AWS_FOR_FLUENT_BIT_VERSION')
       - $BUILD_NUMBER = [System.Environment]::GetEnvironmentVariable('BUILD_NUMBER')
+      - $OPENSSL_VERSION = [System.Environment]::GetEnvironmentVariable('OPENSSL_VERSION')
+      - $FLEX_BISON_VERSION = [System.Environment]::GetEnvironmentVariable('FLEX_BISON_VERSION')
       # Invoke the build script
-      - Invoke-Expression -Command "${CODEBUILD_SRC_DIR}/scripts/build_windows_fluent_bit.ps1 -FLB_VERSION ${FLB_VERSION}"
+      - Invoke-Expression -Command "${CODEBUILD_SRC_DIR}/scripts/build_windows_fluent_bit.ps1 -FLB_VERSION ${FLB_VERSION} -OPENSSL_VERSION ${OPENSSL_VERSION} -FLEX_BISON_VERSION ${FLEX_BISON_VERSION}"
   post_build:
     commands:
       - $PLUGINS_BUILD_VERSION="${AWS_FOR_FLUENT_BIT_VERSION}/${BUILD_NUMBER}"

--- a/scripts/build_windows_fluent_bit.ps1
+++ b/scripts/build_windows_fluent_bit.ps1
@@ -21,6 +21,12 @@
     .PARAMETER FLB_VERSION
     Specifies the fluent bit version to be used for the build
 
+    .PARAMETER OPENSSL_VERSION
+    Specifies the OpenSSL version to be used for the build
+
+    .PARAMETER FLEX_BISON_VERSION
+    Specifies the Flex Bison version to be used for the build
+
     .PARAMETER FLB_REPOSITORY_URL
     [Optional] Specifies the fluent bit repository to be used for the build. Defaults to 'https://github.com/fluent/fluent-bit'.
 
@@ -35,8 +41,9 @@
     Builds the Windows artifacts based on fluent bit 1.9.4.
 
     .EXAMPLE
-    PS> .\build_windows_fluent_bit.ps1 -FLB_VERSION "1.9.4" -FLB_REPOSITORY_URL "https://github.com/xxxxx/fluent-bit"
+    PS> .\build_windows_fluent_bit.ps1 -FLB_VERSION "1.9.4" -OPENSSL_VERSION 3.0.7 -FLEX_BISON_VERSION 2.5.22 -FLB_REPOSITORY_URL "https://github.com/xxxxx/fluent-bit"
     Builds the Windows artifacts based on fluent bit 1.9.4 from the xxxxx fork of fluent-bit.
+    OpenSSL version used in the build would be 3.0.7 and the FlexBison version would be 2.5.22.
     Beneficial for dev testing.
 #>
 
@@ -45,16 +52,20 @@ Param(
     [ValidateNotNullOrEmpty()]
     [string]$FLB_VERSION,
 
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$OPENSSL_VERSION,
+
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$FLEX_BISON_VERSION,
+
     [Parameter(Mandatory=$false)]
     [ValidateNotNullOrEmpty()]
     [string]$FLB_REPOSITORY_URL = "https://github.com/fluent/fluent-bit"
 )
 
 $ErrorActionPreference = 'Stop'
-
-# Constants
-$FlexBisonVersion = "2.5.22"
-$OpenSSLVersion = "3.0.7"
 
 # Directory paths
 $BaseDir = "C:\build"
@@ -75,7 +86,7 @@ $OpenSSLInstallationPath = "${env:ProgramFiles}\OpenSSL"
 # All the URLS.
 $VisualStudioDownloadURL = "https://aka.ms/vs/16/release/vs_buildtools.exe"
 $VisualStudioChannelURL = "https://aka.ms/vs/16/release/channel"
-$FlexBisonDownloadURL = "https://github.com/lexxmark/winflexbison/releases/download/v${FlexBisonVersion}/win_flex_bison-${FlexBisonVersion}.zip"
+$FlexBisonDownloadURL = "https://github.com/lexxmark/winflexbison/releases/download/v${FLEX_BISON_VERSION}/win_flex_bison-${FLEX_BISON_VERSION}.zip"
 
 # Create working directories
 Write-Host "Creating the build directory"
@@ -184,7 +195,7 @@ cd openssl
 
 # Fetch the required version
 git fetch --all --tags
-git checkout tags/"openssl-${OpenSSLVersion}" -b "openssl-${OpenSSLVersion}"
+git checkout tags/"openssl-${OPENSSL_VERSION}" -b "openssl-${OPENSSL_VERSION}"
 git describe --tags
 
 # Run perl configure as mentioned in the docs

--- a/windows.versions
+++ b/windows.versions
@@ -6,7 +6,9 @@
       "fluent-bit": "1.9.9",
       "kinesis-plugin": "v1.10.0",
       "firehose-plugin": "v1.7.0",
-      "cloudwatch-plugin": "v1.9.0"
+      "cloudwatch-plugin": "v1.9.0",
+      "openssl": "3.0.7",
+      "flexBison": "2.5.22"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Presently, we have OpenSSL and FlexBison versions hardcoded in the build scripts itself. This means that changing the same requires a change to the build script. Additionally, the versions are then scattered across all the build files making it harder to understand.

Therefore, as part of this change, we are consolidating all in the master config file for Windows.

## Description of changes:
windows: consolidate all configurable versions in the config file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
