### PR TITLE
windows: setting debugging option in the entrypoint script

### DIFF
--- a/scripts/entrypoint.ps1
+++ b/scripts/entrypoint.ps1
@@ -8,6 +8,10 @@
     .PARAMETER ConfigFile
     [Optional] Specifies the region. Defaults to 'C:\fluent-bit\etc\fluent-bit.conf'.
 
+    .PARAMETER EnableCoreDump
+    [Optional] Specifies if the core dump needs to be generated on Fluent Bit crash. Defaults to false.
+    The dump is generated at location 'C:\fluent-bit\CrashDumps' inside the container and needs to be bind-mounted to the host to retrieve the same.
+
     .INPUTS
     None. You cannot pipe objects to this script.
 
@@ -15,16 +19,29 @@
     None. This script does not generate an output object.
 
     .EXAMPLE
-    PS> .\entrypoint.ps1 -ConfigFile "C:\ecs_windows\cloudwatch.conf"
+    PS> .\entrypoint.ps1 -ConfigFile "C:\ecs_windows_forward_daemon\cloudwatch.conf"
     Runs the aws-for-fluent-bit Windows image with the CloudWatch config baked into the image.
 #>
 Param(
     [Parameter(Mandatory=$false)]
     [ValidateNotNullOrEmpty()]
-    [string]$ConfigFile = "C:\fluent-bit\etc\fluent-bit.conf"
+    [string]$ConfigFile = "C:\fluent-bit\etc\fluent-bit.conf",
+
+    [Parameter(Mandatory=$false)]
+    [ValidateNotNullOrEmpty()]
+    [switch]$EnableCoreDump
 )
 
 $version = Get-Content -Path "C:\AWS_FOR_FLUENT_BIT_VERSION"
 Write-Host "AWS for Fluent Bit Container Image Version ${version}"
+
+if ($EnableCoreDump) {
+    Write-Host "Setting the registry keys to collect dumps"
+
+    # Setting registry keys based on https://learn.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps
+    New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting" -Name "LocalDumps"
+    New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -Name "DumpFolder" -Value "C:\fluent-bit\CrashDumps" -PropertyType ExpandString
+    New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -Name "DumpType" -Value 2 -PropertyType DWord
+}
 
 C:\fluent-bit\bin\fluent-bit.exe -e C:\fluent-bit\kinesis.dll -e C:\fluent-bit\firehose.dll -e C:\fluent-bit\cloudwatch.dll -c "${ConfigFile}"

--- a/windows.versions
+++ b/windows.versions
@@ -7,7 +7,7 @@
       "fluent-bit": "1.9.9",
       "kinesis-plugin": "v1.10.1",
       "firehose-plugin": "v1.7.1",
-      "cloudwatch-plugin": "v1.9.1"
+      "cloudwatch-plugin": "v1.9.1",
       "openssl": "3.0.7",
       "flexBison": "2.5.22"
     }


### PR DESCRIPTION
## Summary

In order to obtain code dumps on Windows, we need to set a registry key which specifies the dump folder as well as the level of dump information. This is as per the Microsoft documentation- https://learn.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps

We will be adding a parameter in the entrypoint.ps1 script which the customers can enable to generate the core dumps. Since these core dump files would be generated inside the container, we need to bind mount the location to the host to retrieve the same.

Additionally, the `windows.version` json was malformed and the same has been rectified.

## Testing
Created custom Windows images based on the new configuration and tested the same.

## Description of changes:
windows: add debugging option to the entrypoint script

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
