### PR TITLE
windows: increase timeout for Kinesis and Firehose integ tests

### DIFF
--- a/integ/run-integ.ps1
+++ b/integ/run-integ.ps1
@@ -339,7 +339,7 @@ Function Test-Kinesis {
     }
 
     # Run the tests which would generate test data. Once they end, perform "docker-compose down".
-    Run-Test -PluginUnderTest "kinesis stream" -DockerComposeTestFilePath $DockerComposeTestFilePath
+    Run-Test -PluginUnderTest "kinesis stream" -DockerComposeTestFilePath $DockerComposeTestFilePath -SleepTime 720
     Clean-Test -PluginUnderTest "kinesis stream" -DockerComposeFilePath $DockerComposeTestFilePath
 
     # Perform validation of the tests.
@@ -376,7 +376,7 @@ Function Test-Firehose {
     }
 
     # Run the tests which would generate test data. Once they end, perform "docker-compose down".
-    Run-Test -PluginUnderTest "firehose" -DockerComposeTestFilePath $DockerComposeTestFilePath
+    Run-Test -PluginUnderTest "firehose" -DockerComposeTestFilePath $DockerComposeTestFilePath -SleepTime 720
     Clean-Test -PluginUnderTest "firehose" -DockerComposeFilePath $DockerComposeTestFilePath
 
     # Perform validation of the tests.


### PR DESCRIPTION
*Issue #, if available:*
Due to less timeout, the integration tests for Kinesis Streams are failing. Therefore we are increasing the same.


*Description of changes:*
windows: increase timeout for Kinesis and Firehose integ tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
