### PR TITLE
windows: ignore windows tags while fetching latest version

### DIFF
--- a/scripts/get_latest_dockerhub_version.py
+++ b/scripts/get_latest_dockerhub_version.py
@@ -3,7 +3,8 @@ import sys
 
 numeric_tags = []
 for tag in sys.argv:
-    if tag[0].isdigit():
+    # Windows images have numeric starting but have letters separated by -.
+    if tag[0].isdigit() and tag.find("-") == -1:
         numeric_tags.append(tag)
 
 numeric_tags.sort(key=lambda s: list(map(int, s.split('.'))), reverse=True)


### PR DESCRIPTION
## Summary
Presently, we are using get_latest_dockerhub_version.py script to fetch the latest version of image present on dockerhub. Since Windows tags start with number but later have letters, the scripts are failing. To mitigate the same, we add an extra condition wherein any tag which has - in them is ignored.

## Description of changes:
windows: ignore windows tags while fetching latest version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
