### PR TITLE
updated python version to 3.9 for sync task

### DIFF
--- a/buildspec_sync.yml
+++ b/buildspec_sync.yml
@@ -2,7 +2,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      python: 3.7
+      python: 3.9
   pre_build:
     commands:
       - echo Sync latest image from Amazon ECR Public Gallery

--- a/buildspec_windows_publish_ssm_params.yml
+++ b/buildspec_windows_publish_ssm_params.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      python: 3.x
+      python: 3.9
     commands:
       - echo "Publishing SSM Parameters for Windows"
       - yum update -y && yum upgrade -y

--- a/buildspec_windows_verify_ssm_parameters.yml
+++ b/buildspec_windows_verify_ssm_parameters.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      python: 3.x
+      python: 3.9
     commands:
       - echo "Verifies the SSM parameters for Windows"
       - yum update -y && yum upgrade -y


### PR DESCRIPTION
## Summary

Gov-Cloud only supports Python runtime version 3.7, 3.8, and 3.9. Therefore, we cannot use 3.x and would use 3.9.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
