### PR TITLE
init: add multiline_parser

### DIFF
--- a/init/fluent_bit_init_process.go
+++ b/init/fluent_bit_init_process.go
@@ -185,7 +185,7 @@ func processConfigFile(path string) {
 
 	content := string(contentBytes)
 
-	if strings.Contains(content, "[PARSER]") {
+	if strings.Contains(content, "[PARSER]") || strings.Contains(content, "[MULTILINE_PARSER]") {
 		// this is a parser config file, change command
 		updateCommand(path)
 	} else {


### PR DESCRIPTION
*Issue #, if available:*
[#537](https://github.com/aws/aws-for-fluent-bit/issues/537)

*Description of changes:*
The init process should handle MULTILINE_PARSER in the same way as PARSER.

Currently, a validation error will occur in fluent bit.
https://github.com/fluent/fluent-bit/blob/v2.0.5/src/fluent-bit.c#L862

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
