### PR TITLE
windows: decouple Linux and Windows Dockerhub tags

### DIFF
--- a/scripts/common_windows.sh
+++ b/scripts/common_windows.sh
@@ -55,7 +55,7 @@ set_dockerhub_version() {
   # Find the dockerhub version.
   docker_hub_image_tags=$(curl -s -S 'https://registry.hub.docker.com/v2/repositories/amazon/aws-for-fluent-bit/tags/?page=1&page_size=250' | jq -r '.results[].name')
   tag_array=(`echo ${docker_hub_image_tags}`)
-  AWS_FOR_FLUENT_BIT_VERSION_DOCKERHUB=$(./get_latest_dockerhub_version.py ${tag_array[@]})
+  AWS_FOR_FLUENT_BIT_VERSION_DOCKERHUB=$(./get_latest_dockerhub_version.py windows ${tag_array[@]})
 }
 
 # Returns the regional endpoint.

--- a/scripts/get_latest_dockerhub_version.py
+++ b/scripts/get_latest_dockerhub_version.py
@@ -1,11 +1,25 @@
 #!/usr/bin/env python3
 import sys
 
+# First argument would be the platform.
+platform = sys.argv[1]
+
 numeric_tags = []
-for tag in sys.argv:
-    # Windows images have numeric starting but have letters separated by -.
-    if tag[0].isdigit() and tag.find("-") == -1:
-        numeric_tags.append(tag)
+for tag in sys.argv[2:]:
+    if tag[0].isdigit():
+        tag_to_store = tag
+        if platform == 'linux':
+            # This is the case wherein we encounter tags for Windows. For Linux, we skip the same.
+            if tag.find("windowsservercore") != -1 or tag.find("ltsc") != -1:
+                continue
+        if platform == 'windows':
+            # When we do not encounter Windows tag, we skip it.
+            if tag.find("windowsservercore") == -1:
+                continue
+            # For Windows, we store the prefix version.
+            tag_to_store = tag.split("-")[0]
+
+        numeric_tags.append(tag_to_store)
 
 numeric_tags.sort(key=lambda s: list(map(int, s.split('.'))), reverse=True)
 print(numeric_tags[0])

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -23,7 +23,7 @@ AWS_FOR_FLUENT_BIT_STABLE_VERSION=$(cat ../AWS_FOR_FLUENT_BIT_STABLE_VERSION)
 
 docker_hub_image_tags=$(curl -s -S 'https://registry.hub.docker.com/v2/repositories/amazon/aws-for-fluent-bit/tags/?page=1&page_size=250' | jq -r '.results[].name')
 tag_array=(`echo ${docker_hub_image_tags}`)
-AWS_FOR_FLUENT_BIT_VERSION_DOCKERHUB=$(./get_latest_dockerhub_version.py ${tag_array[@]})
+AWS_FOR_FLUENT_BIT_VERSION_DOCKERHUB=$(./get_latest_dockerhub_version.py linux ${tag_array[@]})
 
 # Enforce STS regional endpoints
 AWS_STS_REGIONAL_ENDPOINTS=regional


### PR DESCRIPTION
## Summary
Presently, the Python script was used to fetch the latest version on Dockerhub irrespective of the platform. This couples the Linux releases to Windows releases. In order to decouple the same, we have introduced the first param as the platform name for which we need to fetch the latest version.

The workflow is-
- For Linux, consider the tags which do not have `windowsservercore` and `ltsc` in the tag name.
- For Windows, consider only the `windowsservercore` tags. The ones with `ltsc` are individual OS version tags and therefore can be skipped.
- Store the appropriate tag based on the platform.

## Description of changes:
windows: decouple Linux and Windows Dockerhub tags

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
