### PR TITLE
windows: add debugging option to the entrypoint script

### DIFF
--- a/scripts/entrypoint.ps1
+++ b/scripts/entrypoint.ps1
@@ -8,6 +8,10 @@
     .PARAMETER ConfigFile
     [Optional] Specifies the region. Defaults to 'C:\fluent-bit\etc\fluent-bit.conf'.
 
+    .PARAMETER EnableCoreDump
+    [Optional] Specifies if the core dump needs to be generated on Fluent Bit crash. Defaults to false.
+    The dump is generated at location 'C:\fluent-bit\CrashDumps' inside the container and needs to be bind-mounted to the host to retrieve the same.
+
     .INPUTS
     None. You cannot pipe objects to this script.
 
@@ -15,16 +19,39 @@
     None. This script does not generate an output object.
 
     .EXAMPLE
-    PS> .\entrypoint.ps1 -ConfigFile "C:\ecs_windows\cloudwatch.conf"
+    PS> .\entrypoint.ps1 -ConfigFile "C:\ecs_windows_forward_daemon\cloudwatch.conf"
     Runs the aws-for-fluent-bit Windows image with the CloudWatch config baked into the image.
 #>
 Param(
     [Parameter(Mandatory=$false)]
     [ValidateNotNullOrEmpty()]
-    [string]$ConfigFile = "C:\fluent-bit\etc\fluent-bit.conf"
+    [string]$ConfigFile = "C:\fluent-bit\etc\fluent-bit.conf",
+
+    [Parameter(Mandatory=$false)]
+    [ValidateNotNullOrEmpty()]
+    [switch]$EnableCoreDump
 )
 
 $version = Get-Content -Path "C:\AWS_FOR_FLUENT_BIT_VERSION"
 Write-Host "AWS for Fluent Bit Container Image Version ${version}"
 
-C:\fluent-bit\bin\fluent-bit.exe -e C:\fluent-bit\kinesis.dll -e C:\fluent-bit\firehose.dll -e C:\fluent-bit\cloudwatch.dll -c "${ConfigFile}"
+$PluginsToBindParams = "-e C:\fluent-bit\kinesis.dll -e C:\fluent-bit\firehose.dll -e C:\fluent-bit\cloudwatch.dll"
+
+if ($EnableCoreDump) {
+    Write-Host "Setting the registry keys to collect dumps"
+
+    # Setting registry keys based on https://learn.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps
+    New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting" -Name "LocalDumps"
+    New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -Name "DumpFolder" -Value "C:\fluent-bit\CrashDumps" -PropertyType ExpandString
+    New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -Name "DumpType" -Value 2 -PropertyType DWord
+
+    # On Windows, the external plugins which we bind are Golang based. Golang presently has an issue wherein it
+    # disables the WER and itercepts all the exceptions. However, crashing in native way is not yet supported.
+    # This leads to crash dumps not generated,
+    # Github issue: https://github.com/golang/go/issues/20498
+    # Therefore, we will not bind the Golang plugins when in debug mode.
+    # We recommend that the corresponding core plugins are used instead of the Golang plugins.
+    $PluginsToBindParams = ""
+}
+
+C:\fluent-bit\bin\fluent-bit.exe "${PluginsToBindParams}" -c "${ConfigFile}"


### PR DESCRIPTION
## Summary
In order to obtain code dumps on Windows, we need to set a registry key which specifies the dump folder as well as the level of dump information. This is as per the Microsoft documentation- https://learn.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps

We will be adding a parameter in the entrypoint.ps1 script which the customers can enable to generate the core dumps. Since these core dump files would be generated inside the container, we need to bind mount the location to the host to retrieve the same.

## Testing
Created custom Windows images based on the new configuration and tested the same.

## Description of changes:
windows: add debugging option to the entrypoint script


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
