### PR TITLE
windows: rectifying the malformed json and entrypoint script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,11 @@ debug:
 	docker build --no-cache -t aws-fluent-bit-plugins:latest -f Dockerfile.plugins .
 	docker build --no-cache -t amazon/aws-for-fluent-bit:debug -f Dockerfile.debug .
 
+.PHONY: validate-version-file-format
+validate-version-file-format:
+	jq -e . windows.versions && true || false
+	jq -e . linux.version && true || false
+
 .PHONY: cloudwatch-dev
 cloudwatch-dev:
 	docker build \

--- a/scripts/entrypoint.ps1
+++ b/scripts/entrypoint.ps1
@@ -35,8 +35,6 @@ Param(
 $version = Get-Content -Path "C:\AWS_FOR_FLUENT_BIT_VERSION"
 Write-Host "AWS for Fluent Bit Container Image Version ${version}"
 
-$PluginsToBindParams = "-e C:\fluent-bit\kinesis.dll -e C:\fluent-bit\firehose.dll -e C:\fluent-bit\cloudwatch.dll"
-
 if ($EnableCoreDump) {
     Write-Host "Setting the registry keys to collect dumps"
 
@@ -51,7 +49,9 @@ if ($EnableCoreDump) {
     # Github issue: https://github.com/golang/go/issues/20498
     # Therefore, we will not bind the Golang plugins when in debug mode.
     # We recommend that the corresponding core plugins are used instead of the Golang plugins.
-    $PluginsToBindParams = ""
+    Write-Host "Running in debug mode"
+    C:\fluent-bit\bin\fluent-bit.exe -c "${ConfigFile}"
+} else
+{
+    C:\fluent-bit\bin\fluent-bit.exe -e C:\fluent-bit\kinesis.dll -e C:\fluent-bit\firehose.dll -e C:\fluent-bit\cloudwatch.dll -c "${ConfigFile}"
 }
-
-C:\fluent-bit\bin\fluent-bit.exe "${PluginsToBindParams}" -c "${ConfigFile}"

--- a/windows.versions
+++ b/windows.versions
@@ -34,7 +34,7 @@
       "openssl": "3.0.7",
       "flexBison": "2.5.22",
       "latest": false,
-      "stable": true,
+      "stable": true
     },
     {
       "version": "2.29.0",


### PR DESCRIPTION
## Summary
Presently, the json is malformed in windows.versions file. The same has been rectified in this commit.

Also, added a makefile target "validate-version-file-format" which validates that the version file format is correct.

Lastly, there was an error in entrypoint script which was leading to failure for the build images. The same has been rectified as well.

---


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
