### PR TITLE
Disable imdsv1 in loadtest infra

### DIFF
--- a/load_tests/create_testing_resources/ecs/app.py
+++ b/load_tests/create_testing_resources/ecs/app.py
@@ -25,6 +25,7 @@ class TestingResources(core.Stack):
 
         asg = autoscaling.AutoScalingGroup(
             self, "fleet",
+            require_imdsv2=True,  # Disable IMDSv1
             instance_type=ec2.InstanceType("c5.24xlarge"),
             machine_image=ecs.EcsOptimizedImage.amazon_linux2(),
             associate_public_ip_address=True,


### PR DESCRIPTION
### Summary
Disable imdsv1 in load test infrastructure

### How to test

1. Start local pipeline
2. Wait for infra to be created
3. Obtain instance id in the AWS console.
4. Call the following aws-cli command: `aws ec2 modify-instance-metadata-options     --instance-id <my-instance-id>`
5. Check the results


### Success criteria:
1. The return value should have the InstanceMetadataOptions.HttpTokens fields set to "required"
```
{
    "InstanceId": "<my-instance-id>",
    "InstanceMetadataOptions": {
        ...
        "HttpTokens": "required",
    }
}
```
2. The loadtests still successfully run.

### Failure criteria:
The return value should not have the InstanceMetadataOptions.HttpTokens fields set to "optional"
```
{
    "InstanceId": "<my-instance-id>",
    "InstanceMetadataOptions": {
        ...
        "HttpTokens": "required",
    }
}
```