### PR TITLE
Allow failover of SSM query when namespace has never been used

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -352,7 +352,7 @@ sync_latest_image() {
 	stable_uri=$(sed -e 's/^"//' -e 's/"$//' <<<"$stable_uri")
 
 	if [ "$stable_uri" != "${account_id}.dkr.ecr.${region}.${endpoint}/aws-for-fluent-bit:${AWS_FOR_FLUENT_BIT_STABLE_VERSION}" ]; then
-		publish_stable_ssm ${region} ${account_id}.dkr.ecr.${region}.${endpoint}/aws-for-fluent-bit ${AWS_FOR_FLUENT_BIT_STABLE_VERSION} true
+		publish_ssm ${region} ${account_id}.dkr.ecr.${region}.${endpoint}/aws-for-fluent-bit ${AWS_FOR_FLUENT_BIT_STABLE_VERSION} true
 	fi
 }
 


### PR DESCRIPTION
*Description of changes:*
- fix naming of imageTag --> tagCount for readability
- Provide helper method, sync_ssm, to handle checking/fallback logic with SSM Parameter Store with the following behavior

> If value is not present, we would receive error (set -e) and exit
> Instead we use `!` to check if the command failed and set a prepare boolean
> If the command succeeds we follow the normal logic to check if the request had invalid parameters
> If we should prepare the namespace or had invalid parameters we should attempt to put a variable in the namespace
> If we are an owner the request will succeed and the namespace is prepared
> If we are not an owner the request will fail with access denied and exit immediately

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
