### PR TITLE
Codebuild changes for aws cli present

### DIFF
--- a/buildspec_load_test.yml
+++ b/buildspec_load_test.yml
@@ -35,8 +35,6 @@ phases:
       # install aws
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
       - unzip awscliv2.zip
-      - which aws
-      - ls -l /usr/local/bin/aws
       - ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/bin --update
       # install aws-iam-authenticator
       - curl -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator

--- a/buildspec_publish_public_ecr.yml
+++ b/buildspec_publish_public_ecr.yml
@@ -9,9 +9,7 @@ phases:
       - echo Publish the image to Public ECR
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
       - unzip awscliv2.zip
-      - which aws
-      - ls -l /root/.pyenv/shims/aws
-      - ./aws/install --bin-dir /root/.pyenv/shims --install-dir /root/.pyenv/shims --update
+      - ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/bin --update
   build:
     commands:
       # Enforce STS regional endpoints

--- a/buildspec_sync.yml
+++ b/buildspec_sync.yml
@@ -8,10 +8,7 @@ phases:
       - echo Sync latest image from Amazon ECR Public Gallery
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
       - unzip awscliv2.zip
-      - ./aws/install
-      - which aws
-      - ls -l /root/.pyenv/shims/aws || ls -l /usr/local/bin/aws
-      - ./aws/install --bin-dir /root/.pyenv/shims --install-dir /root/.pyenv/shims --update
+      - ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/bin --update
       - aws --version
   build:
     commands:


### PR DESCRIPTION
*Description of changes:*

Currently our 3 pipelines (load_test, public_ecr, sync) all install the aws cli v2. We were requested to move to a new CodeBuild project image, [STANDARD_5_0](https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-codebuild.LinuxBuildImage.html#static-standard_5_0) and noticed that AWS cli was already installed which caused a problem with our sync pipeline.

If we provide the `--update` field to the install it "should' handle updating if the AWS CLI is present or installing if not. The `--bin-dir` and `--install-dir` were slightly different across the pipelines which is not required. There were also additional shell commands which did not assist in the install/update of AWS CLI.

These changes were tested against STANDARD_2_0 (current) and STANDARD_5_0 CodeBuild images without issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
