### PR TITLE
CHANGELOG: fix 1.9.2 cw go plugin was released in 2.31.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### 2.31.7
 This release includes:
 * Fluent Bit [1.9.10](https://fluentbit.io/announcements/v1.9.10/)
-* Amazon CloudWatch Logs for Fluent Bit 1.9.1
+* Amazon CloudWatch Logs for Fluent Bit 1.9.2
 * Amazon Kinesis Streams for Fluent Bit 1.10.1
 * Amazon Kinesis Firehose for Fluent Bit 1.7.1
 
@@ -16,7 +16,7 @@ This release includes the same fixes and features that we are working on getting
 ### 2.31.6
 This release includes:
 * Fluent Bit [1.9.10](https://fluentbit.io/announcements/v1.9.10/)
-* Amazon CloudWatch Logs for Fluent Bit 1.9.1
+* Amazon CloudWatch Logs for Fluent Bit 1.9.2
 * Amazon Kinesis Streams for Fluent Bit 1.10.1
 * Amazon Kinesis Firehose for Fluent Bit 1.7.1
 


### PR DESCRIPTION
This was correctly released: https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/releases/tag/v1.9.2
See: https://github.com/aws/aws-for-fluent-bit/blob/v2.31.6/linux.version
And: https://github.com/aws/aws-for-fluent-bit/blob/v2.31.6/windows.versions


But I forgot to put it correctly in the changelog and release notes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
