### PR TITLE
Stabilize our AWS CLI Install

### DIFF
--- a/buildspec_load_test.yml
+++ b/buildspec_load_test.yml
@@ -33,9 +33,11 @@ phases:
       - mkdir -p $HOME/bin && cp ./kubectl $HOME/bin/kubectl && export PATH=$PATH:$HOME/bin
       - echo 'export PATH=$PATH:$HOME/bin' >> ~/.bashrc
       # install aws
+      - pip3 uninstall awscli -y
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
       - unzip awscliv2.zip
       - ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/bin --update
+      - which aws
       - aws --version
       # install aws-iam-authenticator
       - curl -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator

--- a/buildspec_publish_public_ecr.yml
+++ b/buildspec_publish_public_ecr.yml
@@ -7,11 +7,10 @@ phases:
   pre_build:
     commands:
       - echo Publish the image to Public ECR
+      - pip3 uninstall awscli -y
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
       - unzip awscliv2.zip
-      - which aws
-      - ls -l /root/.pyenv/shims/aws
-      - ./aws/install --bin-dir /root/.pyenv/shims --install-dir /root/.pyenv/shims --update
+      - ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/bin --update
       - which aws
       - aws --version
   build:

--- a/buildspec_sync.yml
+++ b/buildspec_sync.yml
@@ -6,9 +6,11 @@ phases:
   pre_build:
     commands:
       - echo Sync latest image from Amazon ECR Public Gallery
+      - pip3 uninstall awscli -y
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
       - unzip awscliv2.zip
       - ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/bin --update
+      - which aws
       - aws --version
   build:
     commands:


### PR DESCRIPTION
*Description of changes:*
- Opt to remove AWS CLI v1 (present in Codebuild V2 images), will skip without error if not found
- Install AWS CLI v2
- Print `which aws` and the version for debugging purposes
- Used uninstall guide for [Amazon Linux for CLI V1](https://docs.aws.amazon.com/cli/v1/userguide/install-linux-al2017.html#install-amazon-linux-pip-uninstall)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
