### PR TITLE
enhancements to the validator script to prevent flakiness

### DIFF
--- a/integ/validate_cloudwatch/validator.py
+++ b/integ/validate_cloudwatch/validator.py
@@ -5,13 +5,33 @@ import os
 import time
 from datetime import datetime, timedelta
 
-
 client = boto3.client('logs', region_name=os.environ.get('AWS_REGION'))
 metrics_client = boto3.client("cloudwatch", region_name=os.environ["AWS_REGION"])
-start_time = datetime.utcnow() - timedelta(seconds=600)
+start_time = datetime.utcnow() - timedelta(seconds=1200)
 end_time = datetime.utcnow()
 
 LOG_GROUP_NAME = os.environ.get('LOG_GROUP_NAME')
+
+
+def execute_with_retry(max_retry_attempts, retriable_function, *argv):
+    retry_time_secs = 10
+    attempt = 0
+
+    while attempt < max_retry_attempts:
+        success, ret_message = retriable_function(*argv)
+        # If we succeed, then return the success response.
+        if success:
+            return True
+
+        # If we fail, then increment the attempt and sleep for the specified time.
+        print(ret_message +
+              '. Current retry attempt: ' + str(attempt) +
+              '. Max retry attempt: ' + str(max_retry_attempts))
+        attempt += 1
+        time.sleep(retry_time_secs)
+
+    sys.exit(retriable_function.__name__ + ' failed after exhaustion of retry limit.')
+
 
 def validate_test_case(test_name, log_group, log_stream, validator_func):
     print('RUNNING: ' + test_name)
@@ -19,15 +39,18 @@ def validate_test_case(test_name, log_group, log_stream, validator_func):
     # test length
     if len(response['events']) != 1000:
         print(str(len(response['events'])) + ' events found in CloudWatch')
-        sys.exit('TEST_FAILURE: incorrect number of log events found')
+        return False, 'TEST_FAILURE: incorrect number of log events found'
 
     counter = 0
     for log in response['events']:
-        validator_func(counter, log)
+        success, ret_message = validator_func(counter, log)
+        if not success:
+            return False, ret_message
+
         counter += 1
 
     print('SUCCESS: ' + test_name)
-    return True
+    return True, 'Success'
 
 
 def vanilla_validator(counter, log):
@@ -35,7 +58,8 @@ def vanilla_validator(counter, log):
     val = int(event['log'])
     if val != counter:
         print('Expected: ' + str(counter) + '; Found: ' + str(val))
-        sys.exit('TEST_FAILURE: found out of order log message')
+        return False, 'TEST_FAILURE: found out of order log message'
+    return True, 'Success'
 
 
 def log_key_validator(counter, log):
@@ -43,21 +67,17 @@ def log_key_validator(counter, log):
     val = int(log['message'].strip('\"'))
     if val != counter:
         print('Expected: ' + str(counter) + '; Found: ' + str(val))
-        sys.exit('TEST_FAILURE: found out of order log message')
+        return False, 'TEST_FAILURE: found out of order log message'
+    return True, 'Success'
 
 
 def validate_metric(test_name, metric_namespace, dim_key, dim_value, expected_samples=1):
-    attempts = 0
-    max_attempts = 20
-    while attempts < max_attempts:
-        if metric_exists(metric_namespace, dim_key, dim_value, expected_samples):
-            print('SUCCESS: ' + test_name)
-            return True
-        attempts += 1
-        print(f"No metrics yet. Sleeping before trying again. Attempt # {attempts}")
-        time.sleep(10)
+    print('RUNNING: ' + test_name)
+    if metric_exists(metric_namespace, dim_key, dim_value, expected_samples):
+        print('SUCCESS: ' + test_name)
+        return True, 'Success'
 
-    sys.exit('TEST_FAILURE: failed to validate metric existence in CloudWatch')
+    return False, 'TEST_FAILURE: failed to validate metric existence in CloudWatch'
 
 
 def metric_exists(metric_namespace, dim_key, dim_value, expected_samples):
@@ -86,19 +106,36 @@ def metric_exists(metric_namespace, dim_key, dim_value, expected_samples):
     print(f"Did not find {metric_namespace}/{metric_name}/{dim_key}:{dim_value}")
     return False
 
-    
+
 def get_expected_metric_name():
     with open(os.environ.get('EMF_METRIC_NAME_PATH'), 'r') as file:
         return file.read().replace('\n', '')
 
+
 tag = os.environ.get('TAG')
+print('Tag for current run is: ' + tag)
 # CW Test Case 1: Simple/Basic Configuration, Log message is JSON
-success_case_1 = validate_test_case('CW Test 1: Basic Config', LOG_GROUP_NAME, 'from-fluent-bit-basic-test-' + tag, vanilla_validator)
+success_case_1 = execute_with_retry(5,
+                                    validate_test_case,
+                                    'CW Test 1: Basic Config',
+                                    LOG_GROUP_NAME,
+                                    'from-fluent-bit-basic-test-' + tag,
+                                    vanilla_validator)
 
 # CW Test Case 2: tests 'log_key' option, Log message is just the stdout output (a number)
-success_case_2 = validate_test_case('CW Test 2: log_key option', LOG_GROUP_NAME, 'from-fluent-bit-log-key-test-' + tag, log_key_validator)
+success_case_2 = execute_with_retry(5,
+                                    validate_test_case,
+                                    'CW Test 2: log_key option',
+                                    LOG_GROUP_NAME,
+                                    'from-fluent-bit-log-key-test-' + tag,
+                                    log_key_validator)
 
-success_case_emf = validate_metric('CW Test 3: EMF metrics', 'fluent-metrics', 'dimensionKey', 'dimensionValue')
+success_case_emf = execute_with_retry(25,
+                                      validate_metric,
+                                      'CW Test 3: EMF metrics',
+                                      'fluent-metrics',
+                                      'dimensionKey',
+                                      'dimensionValue')
 
 if success_case_1 and success_case_2 and success_case_emf:
     # if this file is still present, integ script will mark the test as a failure


### PR DESCRIPTION
## Summary
Presently, we are observing failures due to validator obtaining the logs from CloudWatch even though the same are present in CloudWatch. To account for flakiness, we are adding a universal retry mechanism in the script.

The following changes have been introduced in this PR-
- Added a retry mechanism to each validation test for max attempts of 20 and sleep time of 10 seconds.
- Changed the EMF start time to last 20 mins.

## Output on testing
New output after the changes-
```
validate_cloudwatch % python3 validator.py
Tag for current run is: lkXFLbHQCD
RUNNING: CW Test 1: Basic Config
SUCCESS: CW Test 1: Basic Config
RUNNING: CW Test 2: log_key option
SUCCESS: CW Test 2: log_key option
RUNNING: CW Test 3: EMF metrics
SUCCESS: CW Test 3: EMF metrics
```

Earlier output before changes-
```
validate_cloudwatch % python3 validator.py
RUNNING: CW Test 1: Basic Config
SUCCESS: CW Test 1: Basic Config
RUNNING: CW Test 2: log_key option
SUCCESS: CW Test 2: log_key option
SUCCESS: CW Test 3: EMF metrics
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
