### PR TITLE
Fixing comment that causes issue with git secrets usage

### DIFF
--- a/integ/test_init/integ_test/app.py
+++ b/integ/test_init/integ_test/app.py
@@ -17,10 +17,11 @@ IntegTestStack(app, "IntegTestStack",
 
     #env=cdk.Environment(account=os.getenv('CDK_DEFAULT_ACCOUNT'), region=os.getenv('CDK_DEFAULT_REGION')),
 
-    # Uncomment the next line if you know exactly what Account and Region you
-    # want to deploy the stack to. */
+    # Uncomment the next line and fill in account and region if you know exactly 
+    # what Account and Region you want to deploy the stack to.
+    # https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk/Environment.html
 
-    #env=cdk.Environment(account='123456789012', region='us-east-1'),
+    #env=cdk.Environment(account='', region='us-east-1'),
 
     # For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html
     )


### PR DESCRIPTION
*Description of changes:*

This comment below causes issue with running `git secrets` with aws-provider

```
integ/test_init/integ_test/app.py:23:    #env=cdk.Environment(account='123456789012', region='us-east-1'),

[ERROR] Matched one or more prohibited patterns
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
