### PR TITLE
cherry-picks: support cloudwatch logs tls verify and port options

### DIFF
--- a/AWS_FLB_CHERRY_PICKS
+++ b/AWS_FLB_CHERRY_PICKS
@@ -52,3 +52,6 @@ https://github.com/PettitWesley/fluent-bit.git s3-str-fixes 38303131e04926527788
 https://github.com/fluent/fluent-bit.git master b725d6b8b289fccde4e9b31d3f3ac61f13711ef9
 # use total_chunks_up in max_chunks_up memory overlimit warn message
 https://github.com/fluent/fluent-bit.git master 9c72f3ac6510b701277936897cd9701ffce3646e
+
+# CloudWatch Logs options for connecting to CWL test destinations: tls verify and port
+https://github.com/matthewfala/fluent-bit.git immutable-cwl-net-options 5d9692f00b5295728bf0340d332896a7cc450a7e


### PR DESCRIPTION
CloudWatch Logs new options to support CWL api mocking.

While Mock API can support TLS, the Mock does not have valid CA Certs, and so TLS verify will fail.

Give an option to:
1. Opt out of TLS entirely (may use this only in rare cases)
2. Opt out of TLS verification (will use this commonly)

Here's the 1.9 code commit referenced:
- https://github.com/matthewfala/fluent-bit/commit/5d9692f00b5295728bf0340d332896a7cc450a7e

Here's the corresponding PR to master:
- https://github.com/fluent/fluent-bit/pull/7083