### PR TITLE
Sync Changes for CDK v2

### DIFF
--- a/buildspec_sync.yml
+++ b/buildspec_sync.yml
@@ -2,7 +2,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      python: 3.7
+      python: 3.x
   pre_build:
     commands:
       - echo Sync latest image from Amazon ECR Public Gallery

--- a/buildspec_sync.yml
+++ b/buildspec_sync.yml
@@ -2,7 +2,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      python: 3.x
+      python: 3.10
   pre_build:
     commands:
       - echo Sync latest image from Amazon ECR Public Gallery


### PR DESCRIPTION
*Description of changes:*

- Move python value to 3.x to support existing CDK v1 sync tasks (only support up to 3.9) and CDK v2 sync tasks (support starts with 3.10)
- Avoids needing to update all sync tasks to CDK v2 immediately

This was tested in an AWS account against CDK v1 and v2 deployments without issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
