### PR TITLE
Makefile: env vars have to be exported to work on Mac because getopt with longoptions does not work on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 all: release
 
 # Improve build speeds during development by removing the --no-cache flag
-DOCKER_BUILD_FLAGS=--no-cache
+export DOCKER_BUILD_FLAGS=--no-cache
 
 .PHONY: release
 release: build build-init

--- a/scripts/build_plugins.sh
+++ b/scripts/build_plugins.sh
@@ -33,13 +33,16 @@ PLUGIN_BUILD_ARGS=""
 
 # windows or linux
 # set by env var in Makefile right now
+# setting this by env var ensures it works even on platforms where getopt and longoptions does not work
 OS_TYPE="${OS_TYPE}"
+DOCKER_BUILD_FLAGS="${DOCKER_BUILD_FLAGS}"
 
 # Go plugin versions can either be set by args to the script, or they will be sourced
 # from the windows.versions or linux.version file
 KINESIS_PLUGIN_TAG=""
 FIREHOSE_PLUGIN_TAG=""
 CLOUDWATCH_PLUGIN_TAG=""
+
 
 # Method to display usage of the script
 usage() {
@@ -161,6 +164,7 @@ then
 fi
 
 echo "Plugin build arguments for ${OS_TYPE} are: $PLUGIN_BUILD_ARGS"
+echo "Docker build flags are: $DOCKER_BUILD_FLAGS"
 
 # Run platform specific build commands
 if [ "$OS_TYPE" == "windows" ];


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
