### PR TITLE
load-test: CFN role trust policy requires session name be exactly 'load-test-cfn'

### DIFF
--- a/load_tests/load_test.py
+++ b/load_tests/load_test.py
@@ -520,7 +520,7 @@ def get_sts_boto_session():
     # ARN and a role session name.
     assumed_role_object = sts_client.assume_role(
         RoleArn=os.environ["LOAD_TEST_CFN_ROLE_ARN"],
-        RoleSessionName="load-test-python",
+        RoleSessionName="load-test-cfn",
         DurationSeconds=3600
     )
 


### PR DESCRIPTION
I don't remember why we decided this and I think its unnecessary but the load test CFN role has this:

```
"Action": "sts:AssumeRole",
            "Condition": {
                "StringLike": {
                    "sts:RoleSessionName": "load-test-cfn"
                }
            }
```

So my previous change to the role session name to differentiate the python vs buildspec calls doesn't work..

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.