### PR TITLE
Fix load test failures

### DIFF
--- a/load_tests/load_test.py
+++ b/load_tests/load_test.py
@@ -80,10 +80,6 @@ def calculate_total_input_number(throughput):
 # 1. Configure task definition for each load test based on existing templates
 # 2. Register generated task definition
 def generate_task_definition(session, throughput, input_logger, s3_fluent_config_arn):
-    if not hasattr(generate_task_definition, "counter"):
-        generate_task_definition.counter = 0  # it doesn't exist yet, so initialize it
-    generate_task_definition.counter += 1
-
     # Generate configuration information for STD and TCP tests
     std_config      = resource_resolver.get_input_configuration(PLATFORM, resource_resolver.STD_INPUT_PREFIX, throughput)
     custom_config   = resource_resolver.get_input_configuration(PLATFORM, resource_resolver.CUSTOM_INPUT_PREFIX, throughput)

--- a/load_tests/load_test.py
+++ b/load_tests/load_test.py
@@ -394,7 +394,7 @@ def parse_json_template(template, dict):
     for key in dict:
             if(key[0] == '$'):
                 data = data.replace(key, dict[key])
-            elif(key == OUTPUT_PLUGIN):
+            else:
                 for sub_key in dict[key]:
                     data = data.replace(sub_key, dict[key][sub_key])
     return data

--- a/load_tests/load_test.py
+++ b/load_tests/load_test.py
@@ -220,12 +220,12 @@ def run_ecs_tests():
     # wait for tasks and validate
     for input_logger in INPUT_LOGGERS:
         # Wait until task stops and start validation
-        session = get_sts_boto_session()
         processes = []
-
-        client = session.client('ecs')
-        waiter = client.get_waiter('tasks_stopped')
+        
         for throughput in THROUGHPUT_LIST:
+            session = get_sts_boto_session()
+            client = session.client('ecs')
+            waiter = client.get_waiter('tasks_stopped')
             task_arn = names[f'{OUTPUT_PLUGIN}_{throughput}_task_arn']
             waiter.wait(
                 cluster=ecs_cluster_name,

--- a/load_tests/load_test.py
+++ b/load_tests/load_test.py
@@ -210,7 +210,7 @@ def run_ecs_tests():
             response = client.run_task(
                     cluster=ecs_cluster_name,
                     launchType='EC2',
-                    taskDefinition=f'{PREFIX}{OUTPUT_PLUGIN}-{throughput}'
+                    taskDefinition=f'{PREFIX}{OUTPUT_PLUGIN}-{throughput}-{input_logger['name']}'
             )
             names[f'{OUTPUT_PLUGIN}_{throughput}_task_arn'] = response['tasks'][0]['taskArn']
         

--- a/load_tests/task_definitions/cloudwatch.json
+++ b/load_tests/task_definitions/cloudwatch.json
@@ -1,5 +1,5 @@
 {
-	"family": "load-test-fluent-bit-cloudwatch-$THROUGHPUT",
+	"family": "load-test-fluent-bit-cloudwatch-$THROUGHPUT-$INPUT_NAME",
 	"taskRoleArn": "$TASK_ROLE_ARN",
 	"executionRoleArn": "$TASK_EXECUTION_ROLE_ARN",
 	"networkMode": "bridge",

--- a/load_tests/task_definitions/firehose.json
+++ b/load_tests/task_definitions/firehose.json
@@ -1,5 +1,5 @@
 {
-	"family": "load-test-fluent-bit-firehose-$THROUGHPUT",
+	"family": "load-test-fluent-bit-firehose-$THROUGHPUT-$INPUT_NAME",
 	"taskRoleArn": "$TASK_ROLE_ARN",
 	"executionRoleArn": "$TASK_EXECUTION_ROLE_ARN",
 	"networkMode": "bridge",

--- a/load_tests/task_definitions/kinesis.json
+++ b/load_tests/task_definitions/kinesis.json
@@ -1,5 +1,5 @@
 {
-	"family": "load-test-fluent-bit-kinesis-$THROUGHPUT",
+	"family": "load-test-fluent-bit-kinesis-$THROUGHPUT-$INPUT_NAME",
 	"taskRoleArn": "$TASK_ROLE_ARN",
 	"executionRoleArn": "$TASK_EXECUTION_ROLE_ARN",
 	"networkMode": "bridge",

--- a/load_tests/task_definitions/s3.json
+++ b/load_tests/task_definitions/s3.json
@@ -1,5 +1,5 @@
 {
-	"family": "load-test-fluent-bit-s3-$THROUGHPUT",
+	"family": "load-test-fluent-bit-s3-$THROUGHPUT-$INPUT_NAME",
 	"taskRoleArn": "$TASK_ROLE_ARN",
 	"executionRoleArn": "$TASK_EXECUTION_ROLE_ARN",
 	"networkMode": "bridge",


### PR DESCRIPTION
The main cause of the failures seems to be that task def names are re-used across tests. I made some other improvements as well. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.