### PR TITLE
load-test: differentiate task ARNs for each input logger

### DIFF
--- a/load_tests/load_test.py
+++ b/load_tests/load_test.py
@@ -212,7 +212,8 @@ def run_ecs_tests():
                     launchType='EC2',
                     taskDefinition=f'{PREFIX}{OUTPUT_PLUGIN}-{throughput}-{input_logger["name"]}'
             )
-            names[f'{OUTPUT_PLUGIN}_{throughput}_task_arn'] = response['tasks'][0]['taskArn']
+            print(f'run_task_response={response}')
+            names[f'{OUTPUT_PLUGIN}_{input_logger["name"]}_{throughput}_task_arn'] = response['tasks'][0]['taskArn']
         
         # Validation input type banner
         print(f'\nTest {input_logger["name"]} to {OUTPUT_PLUGIN} in progress...')
@@ -226,7 +227,7 @@ def run_ecs_tests():
             session = get_sts_boto_session()
             client = session.client('ecs')
             waiter = client.get_waiter('tasks_stopped')
-            task_arn = names[f'{OUTPUT_PLUGIN}_{throughput}_task_arn']
+            task_arn = names[f'{OUTPUT_PLUGIN}_{input_logger["name"]}_{throughput}_task_arn']
             waiter.wait(
                 cluster=ecs_cluster_name,
                 tasks=[


### PR DESCRIPTION
My change last week sped up the tests by starting all tasks first and then checking them. However, I didn't notice that the code doesn't properly distinguish the task arns for each input logger properly. There are two, TCP and standard out. Currently the standard out runs first and then TCP overwrites the task ARN for standard out. 

THis fixes that. 

Tested by commenting out all boto3 code and running locally which ensures my python is at least valid. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.