### PR TITLE
load-test: delete testing data is only needed at end of tests, since each test uses unique resource prefix

### DIFF
--- a/load_tests/logger/stdout_logger/fluent.conf
+++ b/load_tests/logger/stdout_logger/fluent.conf
@@ -1,0 +1,2 @@
+# no content needed for stdout test
+# the file exists so that the task def is the same across TCP and stdout


### PR DESCRIPTION
### Why is this change needed?

Last week I made a change to speed up the tests and fix a timeout that had occurred by starting all tests first, then checking all results. Basically, run all in parallel vs serial. 

However, the code currently deletes testing data in between each test runs, which no longer works since they run in parallel now. 

### When do we need to delete testing data?

There's already a `delete_testing_resources` phase after all testing runs are completed. That's the right place to delete test data.

The previous code to delete between test runs was entirely unnecessary. Each test run uses a unique log stream in CW or unique S3 key in S3. 

### Why is this change safe?

The previous code to delete between test runs was entirely unnecessary. Each test run uses a unique log stream in CW or unique S3 key in S3. 

### How was this change tested?

I used the commit here to check that the python syntax is correct and that the generated task defs are correct: https://github.com/PettitWesley/aws-for-fluent-bit/commit/d5fd7c1f32852411d0a747ada826925fd97eeee1

Since we do not have a test pipeline already available, its not possible to run the load tests prior to PR merge.

This change is needed to unblock the 2.31.12 release which multiple customers are waiting on. 





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.