### PR TITLE
load-tests: custom task_stopped waiter that logs state + won't fail due to expired session creds

### DIFF
--- a/load_tests/setup_test_environment.sh
+++ b/load_tests/setup_test_environment.sh
@@ -14,6 +14,8 @@ stackOutputs=$(aws cloudformation describe-stacks --stack-name ${LOG_STORAGE_STA
 read -r -a outputArray <<< "$stackOutputs"
 export S3_BUCKET_NAME="${outputArray[0]}"
 
+export AWS_DEFAULT_REGION=${AWS_REGION}
+
 # Set necessary images as env vars
 export FLUENT_BIT_IMAGE="${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:latest"
 export ECS_APP_IMAGE="906394416424.dkr.ecr.us-west-2.amazonaws.com/load-test-fluent-bit-ecs-app-image:latest"


### PR DESCRIPTION
### Why is it taking forever to fix the load tests?

I'm sorry. Also I have gotten the firehose and kinesis and S3 tests to pass with my recent changes. The remaining issue is session expiration in CW tests. 

### Why is this changed needed?

The remaining issue is session expiration in CW tests. 

This change does a couple of things:
1. Wait for tasks stopped using creds from the CodeBuild role, not the CFN role. This session should auto-refresh and should not expire. 
2. The custom waiter prints the task status as it checks which will help with debugging. It also doesn't call ECS as frequently which is more frugal (longer sleep time). 
3. Removes the usage of the CFN special role for actually running the tests. This isn't needed if our CodeBuild Role has ECS permissions and IAM:PassRole. I need to separately change our CDK to add perms to the role (which I've added in the account manually to unblock us). This makes us safer than previously because the CFN role has admin level permissions. 

### Testing

I've tested that this python is syntactically correct. Testing that it works is easiest in the actual pipeline. 

### Future work

We probably do not need the CFN role for resource deletion, only creation. I've left its use for deletion for now. 

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.