### PR TITLE
load-tests: fix issue caused by not reading boto3 docs carefully enough

### DIFF
--- a/load_tests/load_test.py
+++ b/load_tests/load_test.py
@@ -202,7 +202,7 @@ def wait_ecs_tasks(ecs_cluster_name, task_arn):
                 ]
             )
         print(f'describe_task_wait_on={response}')
-        status = response['lastStatus']
+        status = response['tasks'][0]['lastStatus']
         print(f'task {task_arn} is {status}')
         # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-lifecycle.html
         if status == 'STOPPED' or status == 'DELETED':


### PR DESCRIPTION
THIS TIME WE KNOW IT WORKS SINCE I SPENT THE (very non-trivial) EFFORTS TO ACTUALLY RUN THE TESTS LOCALLY:

The new custom waiter gives output like this:
```
Test tcp to cloudwatch in progress...
waiting on task_arn=arn:aws:ecs:us-west-2:906394416424:task/load-test-fluent-bit-testing-resources-ecsCluster15812518-wEZ20io8xI8u/3af3f5c1caf2429db8d99ac75a83642b
describe_task_wait_on={'tasks': [{'attachments': [], 'attributes': [{'name': 'ecs.cpu-architecture', 'value': 'x86_64'}], 'availabilityZone': 'us-west-2b', 'clusterArn': 'arn:aws:ecs:us-west-2:906394416424:cluster/load-test-fluent-bit-testing-resources-ecsCluster15812518-wEZ20io8xI8u', 'connectivity': 'CONNECTED', 'connectivityAt': datetime.datetime(2023, 6, 14, 17, 8, 0, 606000, tzinfo=tzlocal()), 'containerInstanceArn': 'arn:aws:ecs:us-west-2:906394416424:container-instance/load-test-fluent-bit-testing-resources-ecsCluster15812518-wEZ20io8xI8u/1fe292f3c9734fe4a421d1b037ea61fb', 'containers': [{'containerArn': 'arn:aws:ecs:us-west-2:906394416424:container/load-test-fluent-bit-testing-resources-ecsCluster15812518-wEZ20io8xI8u/3af3f5c1caf2429db8d99ac75a83642b/c38f969c-b0aa-4da9-8dba-9d009f404020', 'taskArn': 'arn:aws:ecs:us-west-2:906394416424:task/load-test-fluent-bit-testing-resources-ecsCluster15812518-wEZ20io8xI8u/3af3f5c1caf2429db8d99ac75a83642b', 'name': 'log_router', 'image': '906394416424.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-for-fluent-bit-test:latest', 'imageDigest': 'sha256:35226d291e09d091d8fa93de25991caff42109d1efcccc0e549cedc0082d4688', 'runtimeId': '5a6ecf1ef4d267bda44c1f64e48ced224f42a03009aea40bd1ccaf2c76544162', 'lastStatus': 'RUNNING', 'networkBindings': [], 'networkInterfaces': [], 'healthStatus': 'UNKNOWN', 'cpu': '512', 'memoryReservation': '50'}, {'containerArn': 'arn:aws:ecs:us-west-2:906394416424:container/load-test-fluent-bit-testing-resources-ecsCluster15812518-wEZ20io8xI8u/3af3f5c1caf2429db8d99ac75a83642b/cd07106f-601d-4bb6-91cb-82cab0c81ed7', 'taskArn': 'arn:aws:ecs:us-west-2:906394416424:task/load-test-fluent-bit-testing-resources-ecsCluster15812518-wEZ20io8xI8u/3af3f5c1caf2429db8d99ac75a83642b', 'name': 'app', 'image': '906394416424.dkr.ecr.us-west-2.amazonaws.com/load-test-fluent-bit-ecs-app-image:latest', 'imageDigest': 'sha256:34f44d632044cb302d5d5d5e0321a5ef6c978f2a1a1a29e57210eec49f9480b4', 'runtimeId': 'b3fa3d8b5f141faa16bde9cc5f8feb9ceda3ddea122216a0a1bd61d2ad59c6e6', 'lastStatus': 'RUNNING', 'networkBindings': [], 'networkInterfaces': [], 'healthStatus': 'UNKNOWN', 'cpu': '0', 'memoryReservation': '100'}], 'cpu': '512', 'createdAt': datetime.datetime(2023, 6, 14, 17, 8, 0, 606000, tzinfo=tzlocal()), 'desiredStatus': 'RUNNING', 'enableExecuteCommand': False, 'group': 'family:load-test-fluent-bit-cloudwatch-1m-stdstream', 'healthStatus': 'UNKNOWN', 'lastStatus': 'RUNNING', 'launchType': 'EC2', 'memory': '150', 'overrides': {'containerOverrides': [{'name': 'app'}, {'name': 'log_router'}], 'inferenceAcceleratorOverrides': []}, 'pullStartedAt': datetime.datetime(2023, 6, 14, 17, 8, 2, 832000, tzinfo=tzlocal()), 'pullStoppedAt': datetime.datetime(2023, 6, 14, 17, 8, 4, 144000, tzinfo=tzlocal()), 'startedAt': datetime.datetime(2023, 6, 14, 17, 8, 6, 251000, tzinfo=tzlocal()), 'tags': [], 'taskArn': 'arn:aws:ecs:us-west-2:906394416424:task/load-test-fluent-bit-testing-resources-ecsCluster15812518-wEZ20io8xI8u/3af3f5c1caf2429db8d99ac75a83642b', 'taskDefinitionArn': 'arn:aws:ecs:us-west-2:906394416424:task-definition/load-test-fluent-bit-cloudwatch-1m-stdstream:6', 'version': 2}], 'failures': [], 'ResponseMetadata': {'RequestId': 'ee95cfb2-70b2-4a4f-9f0d-87627a106f2a', 'HTTPStatusCode': 200, 'HTTPHeaders': {'x-amzn-requestid': 'ee95cfb2-70b2-4a4f-9f0d-87627a106f2a', 'content-type': 'application/x-amz-json-1.1', 'content-length': '2806', 'date': 'Wed, 14 Jun 2023 17:11:01 GMT'}, 'RetryAttempts': 0}}
task arn:aws:ecs:us-west-2:906394416424:task/load-test-fluent-bit-testing-resources-ecsCluster15812518-wEZ20io8xI8u/3af3f5c1caf2429db8d99ac75a83642b 
is RUNNING
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.