### PR TITLE
load-test: increase waiter sleep time and handle task missing

### DIFF
--- a/load_tests/load_test.py
+++ b/load_tests/load_test.py
@@ -253,6 +253,9 @@ def run_ecs_tests():
         # Validation input type banner
         print(f'\nTest {input_logger["name"]} to {OUTPUT_PLUGIN} in progress...')
 
+    # Tasks need time to run
+    time.sleep(600)
+
     # wait for tasks and validate
     for input_logger in INPUT_LOGGERS:
         # Wait until task stops and start validation
@@ -282,7 +285,6 @@ def run_ecs_tests():
                 # and ECS already reaped/deleted it
                 # try skipping straight to validation
                 log_delay = 'not supported' # we don't actually use this right now in results
-
 
             # Validate logs
             os.environ['LOG_SOURCE_NAME'] = input_logger["name"]
@@ -327,9 +329,6 @@ def run_ecs_tests():
         }, processes))
 
         test_results.extend(parsedValidationOutputs)
-
-        # Wait for task resources to free up
-        time.sleep(60)
 
     # Print output
     print("\n\nValidation results:\n")

--- a/load_tests/load_test.py
+++ b/load_tests/load_test.py
@@ -9,8 +9,8 @@ import validation_bar
 from datetime import datetime, timezone
 import create_testing_resources.kinesis_s3_firehose.resource_resolver as resource_resolver
 
-WAITER_SLEEP = 180
-MAX_WAITER_ATTEMPTS = 30
+WAITER_SLEEP = 300
+MAX_WAITER_ATTEMPTS = 24
 MAX_WAITER_DESCRIBE_FAILURES = 5
 IS_TASK_DEFINITION_PRINTED = True
 PLATFORM = os.environ['PLATFORM'].lower()


### PR DESCRIPTION
This isn't needed to fix any failure or code bug, it just makes the code I contributed in last PR a little better.

1. Increase sleep wait time so that it prints describe task output less often (I want the full output for debugging)
2. Handle missing task response, which shouldn't happen normally, but did once in my local test, not clear why. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.