### PR TITLE
changelog: add al2 version to date stamped linux release for 2.31.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### 2.31.12.20230629 Linux re-build
 
 *This release has the same Fluent Bit contents as 2.31.12, and is simply a linux-only re-build for recent patches in dependencies installed in the image. There are no windows images for this release.* 
+* Amazon Linux Base: [2.0.20230612.0](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-20230615.html)
+
 
 
 ### 2.31.12


### PR DESCRIPTION
Adding this will go in our runbook for these linux CVE releases. 

I'm not happy though because I can't find any command I can run in the image to get it to print this version. I just went to the AL2 docker hub and checked for their latest. Which I think is sketchy. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.