### PR TITLE
build: change dockerfile to set user to non-root

### DIFF
--- a/scripts/dockerfiles/Dockerfile.init-release
+++ b/scripts/dockerfiles/Dockerfile.init-release
@@ -9,5 +9,8 @@ COPY --from=init-builder /fluent_bit_init_process /init/fluent_bit_init_process
 COPY init/fluent_bit_init_entrypoint.sh /init/fluent_bit_init_entrypoint.sh
 RUN chmod +x /init/fluent_bit_init_entrypoint.sh
 
+# Change to non-root user
+RUN groupadd -r user && useradd -r -g user user
+
 # Only last CMD command will be executed, automatically replaces the original entrypoint
 CMD /init/fluent_bit_init_entrypoint.sh

--- a/scripts/dockerfiles/Dockerfile.main-release
+++ b/scripts/dockerfiles/Dockerfile.main-release
@@ -54,5 +54,8 @@ RUN chmod +x /entrypoint.sh
 # Optional Metrics endpoint
 EXPOSE 2020
 
+# Change to non-root user
+RUN groupadd -r user && useradd -r -g user user
+
 # Entry point
 CMD /entrypoint.sh


### PR DESCRIPTION
*Issue #, if available:*

Special consideration should be taken to see if "Exec" input will still work for all common use cases. Otherwise this is a breaking change.

*Description of changes:*
Add a new user called user and switched to that user at the end of the dockerfile. This should cause fluent-bit to no-longer run as root, reducing security risks.

Test before change
```
docker run -it aws-for-fluent-bit:.../bin/bash
bash-4.2# whoami
root
```

Test after change
```
$ docker run -it amazon/aws-for-fluent-bit:main-release /bin/bash
bash-4.2$ whoami
user
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.