### PR TITLE
pipeline: verify resolve variable overwrite

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -686,10 +686,10 @@ verify_public_ecr() {
 }
 
 verify_sha() {
-	sha1=${1}
-	sha2=${2}
+	_sha1=${1}
+	_sha2=${2}
 
-	match_two_sha $sha1 $sha2
+	match_two_sha $_sha1 $_sha2
 
 	if [ "$IMAGE_SHA_MATCHED" = "TRUE" ]; then
 		echo '[Publish Verification] Successfull'
@@ -701,12 +701,12 @@ verify_sha() {
 }
 
 match_two_sha() {
-	sha1=${1}
-	sha2=${2}
+	_sha1=${1}
+	_sha2=${2}
 
 	# Get the last 64 chars of the SHA string
-	last64_1=$(echo $sha1 | egrep -o '.{1,64}$')
-	last64_2=$(echo $sha2 | egrep -o '.{1,64}$')
+	last64_1=$(echo $_sha1 | egrep -o '.{1,64}$')
+	last64_2=$(echo $_sha2 | egrep -o '.{1,64}$')
 
 	if [ "$last64_1" = "$last64_2" ]; then
 		IMAGE_SHA_MATCHED="TRUE"


### PR DESCRIPTION
Sha1 is set to the sync repo's private ecr image of current version number here: https://github.com/aws/aws-for-fluent-bit/blob/120e5df2a24709a01d5138dc101636516e0dddde/scripts/publish.sh#L555 

And is compared with sha2 which is the latest image here: https://github.com/aws/aws-for-fluent-bit/blob/120e5df2a24709a01d5138dc101636516e0dddde/scripts/publish.sh#L584

These should be the same, and are compared with a verify_sha. However between setting sha1 and sha2, `verify_sha $sha1_init $sha2_init` is called which (as an error) overwrites sha1 variable to the sha1_init variable causing the future comparison of sha1 and sha2 to fail.

https://github.com/aws/aws-for-fluent-bit/blob/120e5df2a24709a01d5138dc101636516e0dddde/scripts/publish.sh#L569

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.