### PR TITLE
build: fix for go stable version API output change

### DIFF
--- a/scripts/build_plugins.sh
+++ b/scripts/build_plugins.sh
@@ -163,6 +163,16 @@ then
   PLUGIN_BUILD_ARGS="$PLUGIN_BUILD_ARGS --build-arg CLOUDWATCH_PLUGIN_TAG=$CLOUDWATCH_PLUGIN_TAG"
 fi
 
+# get Go stable version
+# Dockerfiles do not allow env vars to be set by commands
+# and persist from one command to the next
+GO_OUTPUT=$(curl --silent https://go.dev/VERSION?m=text | cut -d "o" -f 2)
+OLD_IFS=$IFS
+IFS=$'\n' GO_STABLE_VERSION=($GO_OUTPUT)
+IFS=$OLD_IFS
+echo "Using go:stable version ${GO_STABLE_VERSION}"
+PLUGIN_BUILD_ARGS="$PLUGIN_BUILD_ARGS --build-arg GO_STABLE_VERSION=${GO_STABLE_VERSION}"
+
 echo "Plugin build arguments for ${OS_TYPE} are: $PLUGIN_BUILD_ARGS"
 echo "Docker build flags are: $DOCKER_BUILD_FLAGS"
 

--- a/scripts/dockerfiles/Dockerfile.plugins
+++ b/scripts/dockerfiles/Dockerfile.plugins
@@ -3,11 +3,11 @@ RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/mas
 RUN chmod +x /bin/gimme
 RUN yum upgrade -y && yum install -y tar gzip git make gcc
 ENV HOME /home
+ARG GO_STABLE_VERSION
+env GO_STABLE_VERSION=$GO_STABLE_VERSION
 
 # Lock Go Lang version to stable
-RUN export GO_STABLE_VERSION=`curl --silent https://go.dev/VERSION?m=text | cut -d "o" -f 2`; \
-      echo "Using go:stable version ${GO_STABLE_VERSION}"; \
-      gimme ${GO_STABLE_VERSION}; \
+RUN gimme ${GO_STABLE_VERSION}; \
       ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.arm64 /home/.gimme/versions/gostable.linux.arm64; \
       ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.amd64 /home/.gimme/versions/gostable.linux.amd64
 ENV PATH ${PATH}:/home/.gimme/versions/gostable.linux.arm64/bin:/home/.gimme/versions/gostable.linux.amd64/bin

--- a/scripts/dockerfiles/Dockerfile.plugins-windows
+++ b/scripts/dockerfiles/Dockerfile.plugins-windows
@@ -4,11 +4,11 @@ RUN apt-get install -y tar gzip git make gcc curl gcc-multilib gcc-mingw-w64
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
 RUN chmod +x /bin/gimme
 ENV HOME /home
+ARG GO_STABLE_VERSION
+env GO_STABLE_VERSION=$GO_STABLE_VERSION
 
 # Lock Go Lang version to stable
-RUN export GO_STABLE_VERSION=`curl --silent https://go.dev/VERSION?m=text | cut -d "o" -f 2`; \
-      echo "Using go:stable version ${GO_STABLE_VERSION}"; \
-      gimme ${GO_STABLE_VERSION}; \
+RUN gimme ${GO_STABLE_VERSION}; \
       ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.arm64 /home/.gimme/versions/gostable.linux.arm64; \
       ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.amd64 /home/.gimme/versions/gostable.linux.amd64
 ENV PATH ${PATH}:/home/.gimme/versions/gostable.linux.arm64/bin:/home/.gimme/versions/gostable.linux.amd64/bin


### PR DESCRIPTION
Previously, ` https://go.dev/VERSION?m=text` responded with output like: `go1.21.0`. 

Now it gives us:
```
go1.21.0
time 2023-08-04T20:14:06Z
```

So we need to change our parsing. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.