### PR TITLE
lock to go 1.20.7

### DIFF
--- a/scripts/build_plugins.sh
+++ b/scripts/build_plugins.sh
@@ -166,10 +166,13 @@ fi
 # get Go stable version
 # Dockerfiles do not allow env vars to be set by commands
 # and persist from one command to the next
-GO_OUTPUT=$(curl --silent https://go.dev/VERSION?m=text | cut -d "o" -f 2)
-OLD_IFS=$IFS
-IFS=$'\n' GO_STABLE_VERSION=($GO_OUTPUT)
-IFS=$OLD_IFS
+# GO_OUTPUT=$(curl --silent https://go.dev/VERSION?m=text | cut -d "o" -f 2)
+# OLD_IFS=$IFS
+# IFS=$'\n' GO_STABLE_VERSION=($GO_OUTPUT)
+# IFS=$OLD_IFS
+# 2023-08-21: pinning to 1.20.7 go as 1.21.0 fails with FLB
+# https://github.com/golang/go/issues/62130#issuecomment-1684431260
+export GO_STABLE_VERSION="1.20.7"
 echo "Using go:stable version ${GO_STABLE_VERSION}"
 PLUGIN_BUILD_ARGS="$PLUGIN_BUILD_ARGS --build-arg GO_STABLE_VERSION=${GO_STABLE_VERSION}"
 

--- a/scripts/dockerfiles/Dockerfile.build
+++ b/scripts/dockerfiles/Dockerfile.build
@@ -38,11 +38,12 @@ RUN yum install -y  \
       --slave /usr/local/bin/ccmake ccmake /usr/bin/ccmake3 \
       --family cmake
 ENV HOME /home
+ENV GO_STABLE_VERSION 1.20.7
 
 # Lock Go Lang version to stable
-RUN export GO_STABLE_OUTPUT=`curl --silent https://go.dev/VERSION?m=text | cut -d "o" -f 2`; \
-      IFS=$'\n' GO_STABLE_VERSION=($GO_STABLE_OUTPUT); \
-      echo "Using go:stable version ${GO_STABLE_VERSION}"; \
+# RUN export GO_STABLE_OUTPUT=`curl --silent https://go.dev/VERSION?m=text | cut -d "o" -f 2`; \
+#       IFS=$'\n' GO_STABLE_VERSION=($GO_STABLE_OUTPUT); \
+RUN   echo "Using go:stable version ${GO_STABLE_VERSION}"; \
       gimme ${GO_STABLE_VERSION}; \
       ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.arm64 /home/.gimme/versions/gostable.linux.arm64; \
       ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.amd64 /home/.gimme/versions/gostable.linux.amd64

--- a/scripts/dockerfiles/Dockerfile.build-init
+++ b/scripts/dockerfiles/Dockerfile.build-init
@@ -4,11 +4,12 @@ RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/mas
 RUN chmod +x /bin/gimme
 RUN yum upgrade -y && yum install -y tar gzip git
 ENV HOME /home
+ENV GO_STABLE_VERSION 1.20.7
 
 # Lock Go Lang version to stable
-RUN export GO_STABLE_OUTPUT=`curl --silent https://go.dev/VERSION?m=text | cut -d "o" -f 2`; \
-      IFS=$'\n' GO_STABLE_VERSION=($GO_STABLE_OUTPUT); \
-      echo "Using go:stable version ${GO_STABLE_VERSION}"; \
+# RUN export GO_STABLE_OUTPUT=`curl --silent https://go.dev/VERSION?m=text | cut -d "o" -f 2`; \
+#       IFS=$'\n' GO_STABLE_VERSION=($GO_STABLE_OUTPUT); \
+RUN   echo "Using go:stable version ${GO_STABLE_VERSION}"; \
       gimme ${GO_STABLE_VERSION}; \
       ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.arm64 /home/.gimme/versions/gostable.linux.arm64; \
       ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.amd64 /home/.gimme/versions/gostable.linux.amd64


### PR DESCRIPTION
recent upgrade of go stable to 1.21.0 has
broken the Go plugins. Which are failing
in integ with: "morestack on g0"
We have not deeply investigated this yet.
Waiting on Go community
https://github.com/golang/go/issues/62130#issuecomment-1684431260

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.