### PR TITLE
Scripts to execute athena queries for image download statistics

### DIFF
--- a/scripts/athena_usage_query/exec_query.sh
+++ b/scripts/athena_usage_query/exec_query.sh
@@ -7,8 +7,8 @@ FROM ${TABLE_NAME}
 WHERE
     eventsource = 'ecr.amazonaws.com' AND
     eventname in ('GetDownloadUrlForLayer', 'BatchGetImage') AND
-    eventTime > '${YEAR}-${START}-01T00:00:00Z' AND
-    eventTime < '${YEAR}-${END}-01T00:00:00Z'
+    eventTime > '${START_YEAR}-${START}-01T00:00:00Z' AND
+    eventTime < '${END_YEAR}-${END}-01T00:00:00Z'
 "
 }
 
@@ -19,19 +19,19 @@ get_version_download_query() {
 
 usage() {
     echo "Requires: AWS CLI, jq. Run with creds for the account."
-    echo "Usage: bash $0 {all | version number} {AWS Region} {AWS Account ID} {Year} {Target Month} {Next Month}"
+    echo "Usage: bash $0 {all | version number} {AWS Region} {AWS Account ID} {Start Year} {Target/first Month} {End Year} {Next/excluded Month}"
     echo "If you want November's downloads, then Target Month=11, Next Month=12"
     echo "Outputs the Athena Query Execution ID, which can be used with get_results.sh"
     echo "-----Examples: Query total image downloads for a month-----"
-    echo "CLASSIC: bash exec_query.sh all us-west-2 906394416424 2023 11 12"
-    echo "BAH: bash $0 all me-south-1 741863432321 2023 11 12"
-    echo "HKG: bash $0 all ap-east-1 449074385750 2023 11 12"
-    echo "MXP: bash $0 all eu-south-1 960320637246 2023 11 12"
-    echo "CPT: bash $0 all af-south-1 928143927712 2023 11 12"
-    echo "USGOV: bash $0 all us-gov-west-1 161423150738 2023 11 12"
+    echo "CLASSIC: bash exec_query.sh all us-west-2 906394416424 2023 11 2023 12"
+    echo "BAH: bash $0 all me-south-1 741863432321 2023 12 2024 01"
+    echo "HKG: bash $0 all ap-east-1 449074385750 2024 01 2024 02"
+    echo "MXP: bash $0 all eu-south-1 960320637246 2023 11 2023 12"
+    echo "CPT: bash $0 all af-south-1 928143927712 2023 01 2023 02"
+    echo "USGOV: bash $0 all us-gov-west-1 161423150738 2023 11 2023 12"
     echo "-----Examples: Query total image downloads for specific version in a month-----"
     echo "bash exec_query.sh 2.28.4 us-west-2 906394416424 2023 11 12"
-    echo "bash exec_query.sh 2.31.12.20230727 us-west-2 906394416424 2023 11 12"
+    echo "bash exec_query.sh 2.31.12.20230727 us-west-2 906394416424 2023 11 2023 12"
     exit 1;
 }
 
@@ -67,8 +67,8 @@ then
     usage
 fi
 
-export YEAR=$4
-if [ -z "${YEAR}" ];
+export START_YEAR=$4
+if [ -z "${START_YEAR}" ];
 then
     usage
 fi
@@ -79,7 +79,13 @@ then
     usage
 fi
 
-export END=$6
+export END_YEAR=$6
+if [ -z "${END_YEAR}" ];
+then
+    usage
+fi
+
+export END=$7
 if [ -z "${END}" ];
 then
     usage
@@ -103,6 +109,7 @@ fi
 
 if [ "${VERSION}" = "all" ]; then
     get_all_download_query
+    exec_query
 else
     get_version_download_query
     exec_query

--- a/scripts/athena_usage_query/exec_query.sh
+++ b/scripts/athena_usage_query/exec_query.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+get_all_download_query() {
+    export QUERY="
+SELECT COUNT(*) as call_count
+FROM ${TABLE_NAME}
+WHERE
+    eventsource = 'ecr.amazonaws.com' AND
+    eventname in ('GetDownloadUrlForLayer', 'BatchGetImage') AND
+    eventTime > '${YEAR}-${START}-01T00:00:00Z' AND
+    eventTime < '${YEAR}-${END}-01T00:00:00Z'
+"
+}
+
+get_version_download_query() {
+    scripts=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+    export QUERY=$(bash "${scripts}/version_download_query.sh" ${VERSION} -s)
+}
+
+usage() {
+    echo "Requires: AWS CLI, jq. Run with creds for the account."
+    echo "Usage: bash $0 {all | version number} {AWS Region} {AWS Account ID} {Year} {Target Month} {Next Month}"
+    echo "If you want November's downloads, then Target Month=11, Next Month=12"
+    echo "Outputs the Athena Query Execution ID, which can be used with get_results.sh"
+    echo "-----Examples: Query total image downloads for a month-----"
+    echo "CLASSIC: bash exec_query.sh all us-west-2 906394416424 2023 11 12"
+    echo "BAH: bash $0 all me-south-1 741863432321 2023 11 12"
+    echo "HKG: bash $0 all ap-east-1 449074385750 2023 11 12"
+    echo "MXP: bash $0 all eu-south-1 960320637246 2023 11 12"
+    echo "CPT: bash $0 all af-south-1 928143927712 2023 11 12"
+    echo "USGOV: bash $0 all us-gov-west-1 161423150738 2023 11 12"
+    echo "-----Examples: Query total image downloads for specific version in a month-----"
+    echo "bash exec_query.sh 2.28.4 us-west-2 906394416424 2023 11 12"
+    echo "bash exec_query.sh 2.31.12.20230727 us-west-2 906394416424 2023 11 12"
+    exit 1;
+}
+
+exec_query() {
+    export S3_LOC="s3://aws-athena-query-results-${ACCT_ID}-${AWS_REGION}"
+    echo ""
+    echo "Athena Query Execution ID:"
+    aws athena start-query-execution \
+        --region "${AWS_REGION}" \
+        --query-string "${QUERY}" \
+        --query-execution-context Database="${DB_NAME}",Catalog="${CATALOG}" \
+        --result-configuration OutputLocation="${S3_LOC}" \
+        --output text
+    echo ""
+}
+
+export VERSION=$1
+if [ -z "${VERSION}" ];
+then
+    usage
+fi
+
+export AWS_REGION=$2
+if [ -z "${AWS_REGION}" ];
+then
+    usage
+fi
+
+# Run script with creds for the account
+export ACCT_ID=$3
+if [ -z "${ACCT_ID}" ];
+then
+    usage
+fi
+
+export YEAR=$4
+if [ -z "${YEAR}" ];
+then
+    usage
+fi
+
+export START=$5
+if [ -z "${START}" ];
+then
+    usage
+fi
+
+export END=$6
+if [ -z "${END}" ];
+then
+    usage
+fi
+
+export CATALOG="AwsDataCatalog"
+export TABLE_NAME="cloudtrail_fluentbit"
+
+# DB name and table name are not consistent across regions
+if [ "${ACCT_ID}" = "906394416424" ]; then
+    export DB_NAME="cloudtraillogs"
+    export TABLE_NAME="cloudtrail_fluentbitimage"
+elif [ "${ACCT_ID}" = "928143927712" ]; then
+    export DB_NAME="cloudtraillogs"
+elif [ "${ACCT_ID}" = "161423150738" ]; then
+    export DB_NAME="cloudtraillogs"
+    export TABLE_NAME="cloudtrail_fluentbitimage"
+else
+    export DB_NAME="default"
+fi
+
+if [ "${VERSION}" = "all" ]; then
+    get_all_download_query
+else
+    get_version_download_query
+    exec_query
+fi

--- a/scripts/athena_usage_query/get_results.sh
+++ b/scripts/athena_usage_query/get_results.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+usage() {
+    echo "Requires: AWS CLI, jq. Run with creds for the account."
+    echo "Queries can take 1+ hours to complete. Run this command some time after exec_query.sh."
+    echo "This script copies the query result from the S3 output bucket and prints & downloads it locally"
+    echo "Usage: bash $0 {AWS Region} {Athena Query Execution ID}"
+    echo "-----Examples-----"
+    echo "bash $0 us-west-2 f5125589-0003-49bf-a8f4-25dd9407aef2"
+    exit 1;
+}
+
+get_results() {
+    query_state=$(aws athena get-query-execution --query-execution-id ${QUERY_ID} --region ${AWS_REGION} | jq '.QueryExecution.Status.State' | tr -d '"')
+    if [[ "${query_state}" == "SUCCEEDED" ]];
+    then
+        s3_uri=$(aws athena get-query-execution --query-execution-id ${QUERY_ID} --region ${AWS_REGION} | jq '.QueryExecution.ResultConfiguration.OutputLocation' | tr -d '"')
+        aws s3 cp ${s3_uri} ${QUERY_ID}_results.txt
+        cat ${QUERY_ID}_results.txt
+    elif [[ "${query_state}" == "FAILED" ]];
+    then
+        echo "Query state is |FAILED|"
+        echo ""
+        query=$(aws athena get-query-execution --query-execution-id ${QUERY_ID} --region ${AWS_REGION} | jq '.QueryExecution.Query')
+        echo ${query}
+        echo ""
+        error=$(aws athena get-query-execution --query-execution-id ${QUERY_ID} --region ${AWS_REGION} | jq '.QueryExecution.Status')
+        echo ${error}
+        echo ""
+    else
+        echo "Query state is |${query_state}|. Wait for state to be SUCCEEDED or re-run."
+        echo ""
+    fi;
+}
+
+export AWS_REGION=$1
+if [ -z "${AWS_REGION}" ];
+then
+    usage
+fi
+
+export QUERY_ID=$2
+if [ -z "${QUERY_ID}" ];
+then
+    usage
+fi
+
+
+get_results


### PR DESCRIPTION
Convenient, the help text shows you how to use it:

Exec query:
```
$ bash scripts/athena_usage_query/exec_query.sh
Requires: AWS CLI, jq. Run with creds for the account.
Usage: bash scripts/athena_usage_query/exec_query.sh {all | version number} {AWS Region} {AWS Account ID} {Year} {Target Month} {Next Month}
If you want November's downloads, then Target Month=11, Next Month=12
Outputs the Athena Query Execution ID, which can be used with get_results.sh
-----Examples: Query total image downloads for a month-----
CLASSIC: bash exec_query.sh all us-west-2 906394416424 2023 11 12
BAH: bash scripts/athena_usage_query/exec_query.sh all me-south-1 741863432321 2023 11 12
HKG: bash scripts/athena_usage_query/exec_query.sh all ap-east-1 449074385750 2023 11 12
MXP: bash scripts/athena_usage_query/exec_query.sh all eu-south-1 960320637246 2023 11 12
CPT: bash scripts/athena_usage_query/exec_query.sh all af-south-1 928143927712 2023 11 12
USGOV: bash scripts/athena_usage_query/exec_query.sh all us-gov-west-1 161423150738 2023 11 12
-----Examples: Query total image downloads for specific version in a month-----
bash exec_query.sh 2.28.4 us-west-2 906394416424 2023 11 12
bash exec_query.sh 2.31.12.20230727 us-west-2 906394416424 2023 11 12
```

Fetch query results:
```
$ bash scripts/athena_usage_query/get_results.sh
Requires: AWS CLI, jq. Run with creds for the account.
Queries can take 1+ hours to complete. Run this command some time after exec_query.sh.
This script copies the query result from the S3 output bucket and prints & downloads it locally
Usage: bash scripts/athena_usage_query/get_results.sh {AWS Region} {Athena Query Execution ID}
-----Examples-----
bash scripts/athena_usage_query/get_results.sh us-west-2 f5125589-0003-49bf-a8f4-25dd9407aef2
```

Wait ~1 hour for query to complete, and then fetch result from S3:
```
$ bash scripts/athena_usage_query/get_results.sh us-west-2 5ec420b6-e7b3-40a8-8ff9-aaa8e2ca2845
download: s3://aws-athena-query-results-906394416424-us-west-2/5ec420b6-e7b3-40a8-8ff9-aaa8e2ca2845.csv to ./5ec420b6-e7b3-40a8-8ff9-aaa8e2ca2845_results.txt
"call_count"
"5"
```

If it isn't finished yet:
```
$ bash scripts/athena_usage_query/get_results.sh us-west-2 5ec420b6-e7b3-40a8-8ff9-aaa8e2ca2845
Query state is |RUNNING|. Wait for state to be SUCCEEDED or re-run.
```

Code also has decent error printing if the query fails: note that you can't run more than ~2 queries at a time:
```
$ bash scripts/athena_usage_query/get_results.sh  us-west-2 d2d3b902-b449-40fa-8e67-300765b98852
Query state is |FAILED|

"SELECT COUNT(*) as call_count\nFROM cloudtrail_fluentbitimage\nWHERE\n eventsource = 'ecr.amazonaws.com' AND\n eventname in ('GetDownloadUrlForLayer', 'BatchGetImage') AND\n eventTime > '2023-11-01T00:00:00Z' AND\n eventTime < '2023-12-01T00:00:00Z' AND (\n requestparameters like '%imageTag:2.31.12.20230911%' OR\n requestparameters like '%imageTag:amd64-2.31.12.20230911%' OR\n requestparameters like '%imageTag:arm64-2.31.12.20230911%' OR\n requestparameters like '%imageTag:init-2.31.12.20230911%' OR\n requestparameters like '%imageTag:init-amd64-2.31.12.20230911%' OR\n requestparameters like '%imageTag:init-arm64-2.31.12.20230911%' OR\n requestparameters like '%imageTag:2.31.12.20230911-windowsservercore%' OR\n requestparameters like '%imageTag:2.31.12.20230911-ltsc2019%' OR\n requestparameters like '%imageTag:2.31.12.20230911-ltsc2022%' OR\n requestparameters like '%%' OR\n requestparameters like '%%' OR\n requestparameters like '%%' OR\n requestparameters like '%%' OR\n requestparameters like '%%' OR\n requestparameters like '%%' OR\n requestparameters like '%%' OR\n requestparameters like '%%'\n )"

{ "State": "FAILED", "StateChangeReason": "HIVE_CURSOR_ERROR: com.amazonaws.services.s3.model.AmazonS3Exception: Please reduce your request rate. (Service: Amazon S3; Status Code: 503; Error Code: SlowDown; Request ID: 1Z381Z8Y7SHJBBA9; S3 Extended Request ID: phO17wsYxTqFhuVoZAaWzJ4atzpgeriiYlSku4T0Ka67JBqSXJr/0UPTMSqTc4f2JLfHaoKJRaA=; Proxy: null), S3 Extended Request ID: phO17wsYxTqFhuVoZAaWzJ4atzpgeriiYlSku4T0Ka67JBqSXJr/0UPTMSqTc4f2JLfHaoKJRaA=", "SubmissionDateTime": "2023-12-06T15:46:04.223000-08:00", "CompletionDateTime": "2023-12-06T16:15:50.253000-08:00", "AthenaError": { "ErrorCategory": 2, "ErrorType": 1403, "Retryable": false, "ErrorMessage": "HIVE_CURSOR_ERROR: com.amazonaws.services.s3.model.AmazonS3Exception: Please reduce your request rate. (Service: Amazon S3; Status Code: 503; Error Code: SlowDown; Request ID: 1Z381Z8Y7SHJBBA9; S3 Extended Request ID: phO17wsYxTqFhuVoZAaWzJ4atzpgeriiYlSku4T0Ka67JBqSXJr/0UPTMSqTc4f2JLfHaoKJRaA=; Proxy: null), S3 Extended Request ID: phO17wsYxTqFhuVoZAaWzJ4atzpgeriiYlSku4T0Ka67JBqSXJr/0UPTMSqTc4f2JLfHaoKJRaA=" } }
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.