### PR TITLE
go: revert to always use latest go stable

### DIFF
--- a/scripts/build_plugins.sh
+++ b/scripts/build_plugins.sh
@@ -166,13 +166,14 @@ fi
 # get Go stable version
 # Dockerfiles do not allow env vars to be set by commands
 # and persist from one command to the next
-# GO_OUTPUT=$(curl --silent https://go.dev/VERSION?m=text | cut -d "o" -f 2)
-# OLD_IFS=$IFS
-# IFS=$'\n' GO_STABLE_VERSION=($GO_OUTPUT)
-# IFS=$OLD_IFS
+GO_OUTPUT=$(curl --silent https://go.dev/VERSION?m=text | cut -d "o" -f 2)
+OLD_IFS=$IFS
+IFS=$'\n' GO_STABLE_VERSION=($GO_OUTPUT)
+IFS=$OLD_IFS
 # 2023-08-21: pinning to 1.20.7 go as 1.21.0 fails with FLB
 # https://github.com/golang/go/issues/62130#issuecomment-1684431260
-export GO_STABLE_VERSION="1.20.7"
+# 2024-03-19: Tested Go 1.22.0 which works with FLB go plugins
+# export GO_STABLE_VERSION="1.20.7" # lock to a specific go version
 echo "Using go:stable version ${GO_STABLE_VERSION}"
 PLUGIN_BUILD_ARGS="$PLUGIN_BUILD_ARGS --build-arg GO_STABLE_VERSION=${GO_STABLE_VERSION}"
 


### PR DESCRIPTION
Previously I locked go to 1.20.7 due to an issue that stopped the Go plugins from working: https://github.com/aws/aws-for-fluent-bit/pull/723/files

I've tested the latest stable go (1.22.0) with the Fluent Bit AWS Go plugins and they work. 

```
AWS for Fluent Bit Container Image Version 2.32.0.20240304
Fluent Bit v1.9.10
* Copyright (C) 2015-2022 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2024/03/19 17:31:35] [ info] Configuration:
[2024/03/19 17:31:35] [ info]  flush time     | 1.000000 seconds
[2024/03/19 17:31:35] [ info]  grace          | 5 seconds
[2024/03/19 17:31:35] [ info]  daemon         | 0
[2024/03/19 17:31:35] [ info] ___________
[2024/03/19 17:31:35] [ info]  inputs:
[2024/03/19 17:31:35] [ info]      dummy
[2024/03/19 17:31:35] [ info] ___________
[2024/03/19 17:31:35] [ info]  filters:
[2024/03/19 17:31:35] [ info] ___________
[2024/03/19 17:31:35] [ info]  outputs:
[2024/03/19 17:31:35] [ info]      cloudwatch.0
[2024/03/19 17:31:35] [ info] ___________
[2024/03/19 17:31:35] [ info]  collectors:
[2024/03/19 17:31:35] [ info] [fluent bit] version=1.9.10, commit=463f00d6dd, pid=1
[2024/03/19 17:31:35] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2024/03/19 17:31:35] [ info] [storage] version=1.4.0, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2024/03/19 17:31:35] [ info] [cmetrics] version=0.3.7
DEBU[0000]fluent-bit-cloudwatch.go:150 main.FLBPluginInit() A new higher performance CloudWatch Logs plugin has been released; you are using the old plugin. Check out the new plugin's documentation and determine if you can migrate.
https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch
INFO[0000]fluent-bit-cloudwatch.go:72 main.getConfiguration() [cloudwatch 0] plugin parameter log_group_name = 'fluent-bit-cloudwatch'
INFO[0000]fluent-bit-cloudwatch.go:79 main.getConfiguration() [cloudwatch 0] plugin parameter default_log_group_name = 'fluentbit-default'
INFO[0000]fluent-bit-cloudwatch.go:82 main.getConfiguration() [cloudwatch 0] plugin parameter log_stream_prefix = 'from-fluent-bit-'
INFO[0000]fluent-bit-cloudwatch.go:85 main.getConfiguration() [cloudwatch 0] plugin parameter log_stream_name = ''
INFO[0000]fluent-bit-cloudwatch.go:92 main.getConfiguration() [cloudwatch 0] plugin parameter default_log_stream_name = '/fluentbit-default'
INFO[0000]fluent-bit-cloudwatch.go:95 main.getConfiguration() [cloudwatch 0] plugin parameter region = 'us-east-1'
INFO[0000]fluent-bit-cloudwatch.go:98 main.getConfiguration() [cloudwatch 0] plugin parameter log_key = ''
INFO[0000]fluent-bit-cloudwatch.go:101 main.getConfiguration() [cloudwatch 0] plugin parameter role_arn = ''
INFO[0000]fluent-bit-cloudwatch.go:104 main.getConfiguration() [cloudwatch 0] plugin parameter auto_create_group = 'true'
INFO[0000]fluent-bit-cloudwatch.go:107 main.getConfiguration() [cloudwatch 0] plugin parameter auto_create_stream = 'true'
INFO[0000]fluent-bit-cloudwatch.go:110 main.getConfiguration() [cloudwatch 0] plugin parameter new_log_group_tags = ''
INFO[0000]fluent-bit-cloudwatch.go:113 main.getConfiguration() [cloudwatch 0] plugin parameter log_retention_days = '0'
INFO[0000]fluent-bit-cloudwatch.go:116 main.getConfiguration() [cloudwatch 0] plugin parameter endpoint = ''
INFO[0000]fluent-bit-cloudwatch.go:119 main.getConfiguration() [cloudwatch 0] plugin parameter sts_endpoint = ''
INFO[0000]fluent-bit-cloudwatch.go:122 main.getConfiguration() [cloudwatch 0] plugin parameter external_id = ''
INFO[0000]fluent-bit-cloudwatch.go:125 main.getConfiguration() [cloudwatch 0] plugin parameter credentials_endpoint =
INFO[0000]fluent-bit-cloudwatch.go:128 main.getConfiguration() [cloudwatch 0] plugin parameter log_format = ''
DEBU[0000]cloudwatch.go:196 github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/cloudwatch.NewOutputPlugin() [cloudwatch 0] Initializing NewOutputPlugin
[2024/03/19 17:31:35] [debug] [dummy:dummy.0] created event channels: read=27 write=28
[2024/03/19 17:31:35] [debug] [cloudwatch:cloudwatch.0] created event channels: read=29 write=30
[2024/03/19 17:31:35] [debug] [router] match rule dummy.0:cloudwatch.0
[2024/03/19 17:31:35] [ info] [sp] stream processor started
[2024/03/19 17:31:35] [debug] [input chunk] update output instances with new chunk size diff=26, records=1, input=dummy.0
[2024/03/19 17:31:36] [debug] [task] created task=0x7f6f5c044460 id=0 OK
[2024/03/19 17:31:36] [debug] [input chunk] update output instances with new chunk size diff=26, records=1, input=dummy.0
DEBU[0001]fluent-bit-cloudwatch.go:176 main.FLBPluginFlushCtx() [cloudwatch 0] Found logs with tag: dummy
DEBU[0001]cloudwatch.go:386 github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/cloudwatch.(*OutputPlugin).AddEvent() [cloudwatch 0] Finding log group: fluent-bit-cloudwatch
INFO[0007]cloudwatch.go:618 github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/cloudwatch.(*OutputPlugin).createLogGroup() [cloudwatch 0] Log group fluent-bit-cloudwatch already exists
DEBU[0008]cloudwatch.go:492 github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/cloudwatch.(*OutputPlugin).existingLogStream() [cloudwatch 0] Initializing internal buffer for exising log stream from-fluent-bit-dummy
DEBU[0008]cloudwatch.go:735 github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/cloudwatch.(*OutputPlugin).Flush() [cloudwatch 0] Flush() Called
DEBU[0008]cloudwatch.go:819 github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/cloudwatch.(*OutputPlugin).putLogEvents() [cloudwatch 0] Sent 1 events to CloudWatch for stream 'from-fluent-bit-dummy' in group 'fluent-bit-cloudwatch'
DEBU[0008]fluent-bit-cloudwatch.go:210 main.FLBPluginFlushCtx() [cloudwatch 0] Processed 1 events
DEBU[0008]fluent-bit-cloudwatch.go:176 main.FLBPluginFlushCtx() [cloudwatch 0] Found logs with tag: dummy
[2024/03/19 17:31:43] [debug] [task] created task=0x7f6f5c0444d0 id=1 OK
[2024/03/19 17:31:43] [debug] [input chunk] update output instances with new chunk size diff=26, records=1, input=dummy.0
[2024/03/19 17:31:43] [debug] [out flush] cb_destroy coro_id=0
[2024/03/19 17:31:43] [debug] [task] destroy task=0x7f6f5c044460 (task_id=0)
DEBU[0008]cloudwatch.go:735 github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/cloudwatch.(*OutputPlugin).Flush() [cloudwatch 0] Flush() Called
DEBU[0008]cloudwatch.go:819 github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/cloudwatch.(*OutputPlugin).putLogEvents() [cloudwatch 0] Sent 1 events to CloudWatch for stream 'from-fluent-bit-dummy' in group 'fluent-bit-cloudwatch'
DEBU[0008]fluent-bit-cloudwatch.go:210 main.FLBPluginFlushCtx() [cloudwatch 0] Processed 1 events
[2024/03/19 17:31:43] [debug] [task] created task=0x7f6f5c044460 id=0 OK
[2024/03/19 17:31:43] [debug] [input chunk] update output instances with new chunk size diff=26, records=1, input=dummy.0
[2024/03/19 17:31:43] [debug] [out flush] cb_destroy coro_id=1
[2024/03/19 17:31:43] [debug] [task] destroy task=0x7f6f5c0444d0 (task_id=1)
DEBU[0008]fluent-bit-cloudwatch.go:176 main.FLBPluginFlushCtx() [cloudwatch 0] Found logs with tag: dummy
DEBU[0008]cloudwatch.go:735 github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/cloudwatch.(*OutputPlugin).Flush() [cloudwatch 0] Flush() Called
DEBU[0008]cloudwatch.go:819 github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/cloudwatch.(*OutputPlugin).putLogEvents() [cloudwatch 0] Sent 1 events to CloudWatch for stream 'from-fluent-bit-dummy' in group 'fluent-bit-cloudwatch'
DEBU[0008]fluent-bit-cloudwatch.go:210 main.FLBPluginFlushCtx() [cloudwatch 0] Processed 1 events
[2024/03/19 17:31:43] [debug] [out flush] cb_destroy coro_id=2
[2024/03/19 17:31:43] [debug] [task] destroy task=0x7f6f5c044460 (task_id=0)
[2024/03/19 17:31:44] [debug] [task] created task=0x7f6f5c044460 id=0 OK
[2024/03/19 17:31:44] [debug] [input chunk] update output instances with new chunk size diff=26, records=1, input=dummy.0
DEBU[0009]fluent-bit-cloudwatch.go:176 main.FLBPluginFlushCtx() [cloudwatch 0] Found logs with tag: dummy
DEBU[0009]cloudwatch.go:735 github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/cloudwatch.(*OutputPlugin).Flush() [cloudwatch 0] Flush() Called
DEBU[0009]cloudwatch.go:819 github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/cloudwatch.(*OutputPlugin).putLogEvents() [cloudwatch 0] Sent 1 events to CloudWatch for stream 'from-fluent-bit-dummy' in group 'fluent-bit-cloudwatch'
DEBU[0009]fluent-bit-cloudwatch.go:210 main.FLBPluginFlushCtx() [cloudwatch 0] Processed 1 events
[2024/03/19 17:31:44] [debug] [out flush] cb_destroy coro_id=3
[2024/03/19 17:31:44] [debug] [task] destroy task=0x7f6f5c044460 (task_id=0)
[2024/03/19 17:31:45] [debug] [task] created task=0x7f6f5c044460 id=0 OK
DEBU[0010]fluent-bit-cloudwatch.go:176 main.FLBPluginFlushCtx() [cloudwatch 0] Found logs with tag: dummy
DEBU[0010]cloudwatch.go:735 github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/cloudwatch.(*OutputPlugin).Flush() [cloudwatch 0] Flush() Called
[2024/03/19 17:31:45] [debug] [input chunk] update output instances with new chunk size diff=26, records=1, input=dummy.0
DEBU[0010]cloudwatch.go:819 github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/cloudwatch.(*OutputPlugin).putLogEvents() [cloudwatch 0] Sent 1 events to CloudWatch for stream 'from-fluent-bit-dummy' in group 'fluent-bit-cloudwatch'
DEBU[0010]fluent-bit-cloudwatch.go:210 main.FLBPluginFlushCtx() [cloudwatch 0] Processed 1 events
[2024/03/19 17:31:45] [debug] [out flush] cb_destroy coro_id=4
[2024/03/19 17:31:45] [debug] [task] destroy task=0x7f6f5c044460 (task_id=0)
[2024/03/19 17:31:46] [debug] [task] created task=0x7f6f5c044460 id=0 OK
[2024/03/19 17:31:46] [debug] [input chunk] update output instances with new chunk size diff=26, records=1, input=dummy.0
DEBU[0011]fluent-bit-cloudwatch.go:176 main.FLBPluginFlushCtx() [cloudwatch 0] Found logs with tag: dummy
DEBU[0011]cloudwatch.go:735 github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/cloudwatch.(*OutputPlugin).Flush() [cloudwatch 0] Flush() Called
DEBU[0011]cloudwatch.go:819 github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/cloudwatch.(*OutputPlugin).putLogEvents() [cloudwatch 0] Sent 1 events to CloudWatch for stream 'from-fluent-bit-dummy' in group 'fluent-bit-cloudwatch'
DEBU[0011]fluent-bit-cloudwatch.go:210 main.FLBPluginFlushCtx() [cloudwatch 0] Processed 1 events
[2024/03/19 17:31:46] [debug] [out flush] cb_destroy coro_id=5
[2024/03/19 17:31:46] [debug] [task] destroy task=0x7f6f5c044460 (task_id=0)
[2024/03/19 17:31:47] [debug] [task] created task=0x7f6f5c044460 id=0 OK
[2024/03/19 17:31:47] [debug] [input chunk] update output instances with new chunk size diff=26, records=1, input=dummy.0
DEBU[0012]fluent-bit-cloudwatch.go:176 main.FLBPluginFlushCtx() [cloudwatch 0] Found logs with tag: dummy
DEBU[0012]cloudwatch.go:735 github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/cloudwatch.(*OutputPlugin).Flush() [cloudwatch 0] Flush(
) Called
DEBU[0012]cloudwatch.go:819 github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/cloudwatch.(*OutputPlugin).putLogEvents() [cloudwatch 0] Sent 1 events to CloudWatch for stream 'from-fluent-bit-dummy' in group 'fluent-bit-cloudwatch'
DEBU[0012]fluent-bit-cloudwatch.go:210 main.FLBPluginFlushCtx() [cloudwatch 0] Processed 1 events
[2024/03/19 17:31:47] [debug] [out flush] cb_destroy coro_id=6
[2024/03/19 17:31:47] [debug] [task] destroy task=0x7f6f5c044460 (task_id=0)
^C[2024/03/19 17:31:48] [engine] caught signal (SIGINT)
[2024/03/19 17:31:48] [debug] [task] created task=0x7f6f5c044460 id=0 OK
[2024/03/19 17:31:48] [ warn] [engine] service will shutdown in max 5 seconds
DEBU[0013]fluent-bit-cloudwatch.go:176 main.FLBPluginFlushCtx() [cloudwatch 0] Found logs with tag: dummy
DEBU[0013]cloudwatch.go:735 github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/cloudwatch.(*OutputPlugin).Flush() [cloudwatch 0] Flush() Called
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.