### PR TITLE
feat: Add Helm chart from `eks-charts` repository

### DIFF
--- a/helm/aws-for-fluent-bit/.helmignore
+++ b/helm/aws-for-fluent-bit/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/aws-for-fluent-bit/Chart.yaml
+++ b/helm/aws-for-fluent-bit/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+name: aws-for-fluent-bit
+description: A Helm chart to deploy aws-for-fluent-bit project
+version: 0.1.34
+appVersion: 2.32.2.20240516
+# TODO - update to public ECR repository
+home: https://github.com/aws/eks-charts
+icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
+# TODO - update to public ECR repository
+sources:
+  - https://github.com/aws/eks-charts
+maintainers:
+  - name: Wesley Pettit
+    url: https://github.com/pettitwesley
+  - name: Mohammad Forutan
+    url: https://github.com/mforutan
+    email: mforutan@users.noreply.github.com
+keywords:
+  - eks
+  - fluentbit
+  - fluent-bit
+  - cloudwatch
+  - firehose
+  - kinesis

--- a/helm/aws-for-fluent-bit/README.md
+++ b/helm/aws-for-fluent-bit/README.md
@@ -1,0 +1,233 @@
+# AWS for fluent bit
+
+A helm chart for [AWS-for-fluent-bit](https://github.com/aws/aws-for-fluent-bit)
+
+## Installing the Chart
+
+Add the EKS repository to Helm:
+
+```bash
+# TODO - update to public ECR repository
+helm repo add eks https://aws.github.io/eks-charts
+```
+
+Install or upgrading the AWS for fluent bit chart with default configuration:
+
+```bash
+# TODO - update to public ECR repository
+helm upgrade --install aws-for-fluent-bit --namespace kube-system eks/aws-for-fluent-bit
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `aws-for-fluent-bit` release:
+
+```bash
+# TODO - update to public ECR repository
+helm delete aws-for-fluent-bit --namespace kube-system
+```
+
+## Configuration
+
+| Parameter | Description | Default | Required |
+| - | - | - | -
+| `global.namespaceOverride` | Override the deployment namespace | Not set (`Release.Namespace`) |
+| `image.repository` | Image to deploy | `amazon/aws-for-fluent-bit` | ✔
+| `image.tag` | Image tag to deploy | `stable` |
+| `image.pullPolicy` | Pull policy for the image | `IfNotPresent` | ✔
+| `podSecurityContext` | Security Context for pod | `{}` |
+| `containerSecurityContext` | Security Context for container | `{}` |
+| `rbac.pspEnabled` | Whether a pod security policy should be created | `false`
+| `imagePullSecrets` | Docker registry pull secret | `[]` |
+| `serviceAccount.create` | Whether a new service account should be created | `true` |
+| `serviceAccount.name` | Name of the service account | `aws-for-fluent-bit` |
+| `service.extraService` | Append to existing service with this value | HTTP_Server  On <br> HTTP_Listen  0.0.0.0 <br> HTTP_PORT    2020 <br> Health_Check On <br> HC_Errors_Count 5 <br> HC_Retry_Failure_Count 5 <br> HC_Period 5 |
+| `service.parsersFiles` | List of available parser files | `/fluent-bit/parsers/parsers.conf` |
+| `service.extraParsers` | Adding more parsers with this value | `""` |
+| `input.enabled` | Enable the tail input to collect kubernetes pod logs | `true` |
+| `input.tag` | The tag pattern for pod logs | `kube.*` |
+| `input.path` | Path pattern for pod logs | `/var/log/containers/*.log` |
+| `input.db` | DB to track file offsets and files read | `/var/log/flb_kube.db` |
+| `input.multilineParser` | Specify one more or more [multiline parsers](https://docs.fluentbit.io/manual/pipeline/inputs/tail#multiline-and-containers-v1.8). Only the first that matches is applied; therefore, use this field to parse docker or cri log format, and then use the [multiline filter](https://docs.fluentbit.io/manual/pipeline/filters/multiline-stacktrace) if additional [custom multiline parsing](https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/multiline-parsing) rules need to be applied. | `docker, cri` |
+| `input.memBufLimit` | Limit the [buffer memory](https://github.com/aws-samples/amazon-ecs-firelens-examples/tree/mainline/examples/fluent-bit/oomkill-prevention) used by the tail input. | `5MB` |
+| `input.skipLongLines` | `On` means that long lines will be skipped [instead of the entire log file](https://github.com/aws/aws-for-fluent-bit/blob/mainline/troubleshooting/debugging.md#tail-input-skipping-file) | `On` |
+| `input.refreshInterval` | The interval to refresh the list of watched files in seconds. | `10` |
+| `extraInputs` | Append to existing input with this value | `""` |
+| `additionalInputs` | Adding more inputs with this value | `""` |
+| `filter.*` | Values for kubernetes filter | |
+| `filter.extraFilters` | Append to existing filter with value |
+| `additionalFilters` | Adding more filters with value |
+| `cloudWatch.enabled` | Enable this to activate old golang plugin [details](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit). For guidance on choosing go vs c plugin, please refer to [debugging guide](https://github.com/aws/aws-for-fluent-bit/blob/mainline/troubleshooting/debugging.md#aws-go-plugins-vs-aws-core-c-plugins) | `false` | ✔
+| `cloudWatch.match` | The log filter | `*` | ✔
+| `cloudWatch.region` | The AWS region for CloudWatch.  | `us-east-1` | ✔
+| `cloudWatch.logGroupName` | The name of the CloudWatch Log Group that you want log records sent to. | `"/aws/eks/fluentbit-cloudwatch/logs"` | ✔
+| `cloudWatch.logStreamName` | The name of the CloudWatch Log Stream that you want log records sent to. |  |
+| `cloudWatch.logStreamPrefix` | Prefix for the Log Stream name. The tag is appended to the prefix to construct the full log stream name. Not compatible with the log_stream_name option. | `"fluentbit-"` |
+| `cloudWatch.logKey` | By default, the whole log record will be sent to CloudWatch. If you specify a key name with this option, then only the value of that key will be sent to CloudWatch. For example, if you are using the Fluentd Docker log driver, you can specify logKey log and only the log message will be sent to CloudWatch. |  |
+| `cloudWatch.logRetentionDays` | If set to a number greater than zero, and newly create log group's retention policy is set to this many days. | |
+| `cloudWatch.logFormat` | An optional parameter that can be used to tell CloudWatch the format of the data. A value of json/emf enables CloudWatch to extract custom metrics embedded in a JSON payload. See the Embedded Metric Format. |  |
+| `cloudWatch.roleArn` | ARN of an IAM role to assume (for cross account access). |  |
+| `cloudWatch.autoCreateGroup` | Automatically create the log group. Valid values are "true" or "false" (case insensitive). | true |
+| `cloudWatch.endpoint` | Specify a custom endpoint for the CloudWatch Logs API. |  |
+| `cloudWatch.credentialsEndpoint` | Specify a custom HTTP endpoint to pull credentials from. [more info](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit) |  |
+| `cloudWatch.extraOutputs` | Append extra outputs with value | `""` |
+| `cloudWatchLogs.enabled` | This section is used to enable new high performance plugin. The Golang plugin was named `cloudwatch`; this new high performance CloudWatch plugin is called `cloudwatch_logs` in fluent bit configuration to prevent conflicts/confusion [details](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch). For guidance on choosing go vs c plugin, please refer to [debugging guide](https://github.com/aws/aws-for-fluent-bit/blob/mainline/troubleshooting/debugging.md#aws-go-plugins-vs-aws-core-c-plugins) | `true` | ✔
+| `cloudWatchLogs.match` | The log filter | `*` | ✔
+| `cloudWatchLogs.region` | The AWS region for CloudWatch.  | `us-east-1` | ✔
+| `cloudWatchLogs.logGroupName` | The name of the CloudWatch Log Group that you want log records sent to. | `"/aws/eks/fluentbit-cloudwatch/logs"` | ✔
+| `cloudWatchLogs.logGroupTemplate` | Template for Log Group name using Fluent Bit [record_accessor](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch#log-stream-and-group-name-templating-using-record_accessor-syntax) syntax. This field is optional and if configured it overrides the logGroupName. If the template translation fails, an error is logged and the logGroupName (which is still required) is used instead. |  |
+| `cloudWatchLogs.logStreamName` | The name of the CloudWatch Log Stream that you want log records sent to. |  |
+| `cloudWatchLogs.logStreamPrefix` | Prefix for the Log Stream name. The tag is appended to the prefix to construct the full log stream name. Not compatible with the log_stream_name option. | `"fluentbit-"` |
+| `cloudWatchLogs.logStreamTemplate` | Template for Log Stream name using Fluent Bit [record_accessor](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch#log-stream-and-group-name-templating-using-record_accessor-syntax) syntax. This field is optional and if configured it overrides the other log stream options. If the template translation fails, an error is logged and the log_stream_name or log_stream_prefix are used instead (and thus one of those fields is still required to be configured). |  |
+| `cloudWatchLogs.logKey` | By default, the whole log record will be sent to CloudWatch. If you specify a key name with this option, then only the value of that key will be sent to CloudWatch. For example, if you are using the Fluentd Docker log driver, you can specify logKey log and only the log message will be sent to CloudWatch. Check the example [here](https://github.com/aws-samples/amazon-ecs-firelens-examples/tree/mainline/examples/fluent-bit/cloudwatchlogs#what-if-i-just-want-the-raw-log-line-from-the-container-to-appear-in-cloudwatch). |  |
+| `cloudWatchLogs.logFormat` | An optional parameter that can be used to tell CloudWatch the format of the data. A value of json/emf enables CloudWatch to extract custom metrics embedded in a JSON payload. See the [Embedded Metric Format](https://github.com/aws-samples/amazon-ecs-firelens-examples/tree/mainline/examples/fluent-bit/cloudwatchlogs-emf). |  |
+| `cloudWatchLogs.roleArn` | ARN of an IAM role to assume (for cross account access). |  |
+| `cloudWatchLogs.autoCreateGroup` | Automatically create the log group. Valid values are "true" or "false" (case insensitive). | true |
+| `cloudWatchLogs.logRetentionDays` | If set to a number greater than zero, and newly create log group's retention policy is set to this many days. | |
+| `cloudWatchLogs.endpoint` | Specify a custom endpoint for the CloudWatch Logs API. |  |
+| `cloudWatchLogs.metricNamespace` | An optional string representing the CloudWatch namespace for the metrics. Please refer to [tutorial](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch#metrics-tutorial). |  |
+| `cloudWatchLogs.metricDimensions` | A list of lists containing the dimension keys that will be applied to all metrics. If you have only one list of dimensions, put the values as a comma separated string. If you want to put list of lists, use the list as semicolon separated strings. Please refer to [tutorial](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch#metrics-tutorial). |  |
+| `cloudWatchLogs.stsEndpoint` | Specify a custom STS endpoint for the AWS STS API. |  |
+| `cloudWatchLogs.autoRetryRequests` | Immediately retry failed requests to AWS services once. This option does not affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which may help improve throughput when there are transient/random networking issues. This option defaults to true. Please check [here]( https://github.com/aws/aws-for-fluent-bit/blob/mainline/troubleshooting/debugging.md#network-connection-issues) for more details |  |
+| `cloudWatchLogs.externalId` | Specify an external ID for the STS API, can be used with the role_arn parameter if your role requires an external ID. |  |
+| `cloudWatchLogs.extraOutputs` | Append extra outputs with value. This section helps you extend current chart implementation with ability to add extra parameters. For example, you can add [network](https://docs.fluentbit.io/manual/administration/networking) config like `cloudWatchLogs.extraOutputs.net.dns.mode=TCP`. | `""` |
+| `firehose.enabled` | Whether this plugin should be enabled or not, [details](https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit) | `false` | ✔
+| `firehose.match` | The log filter | `"*"` | ✔
+| `firehose.region` | The region which your Firehose delivery stream(s) is/are in. | `"us-east-1"` | ✔
+| `firehose.deliveryStream` | The name of the delivery stream that you want log records sent to. | `"my-stream"` | ✔
+| `firehose.dataKeys` | By default, the whole log record will be sent to Kinesis. If you specify a key name(s) with this option, then only those keys and values will be sent to Kinesis. For example, if you are using the Fluentd Docker log driver, you can specify data_keys log and only the log message will be sent to Kinesis. If you specify multiple keys, they should be comma delimited. | |
+| `firehose.roleArn` | ARN of an IAM role to assume (for cross account access). | |
+| `firehose.endpoint` | Specify a custom endpoint for the Kinesis Firehose API. | |
+| `firehose.timeKey` | Add the timestamp to the record under this key. By default the timestamp from Fluent Bit will not be added to records sent to Kinesis. | |
+| `firehose.timeKeyFormat` | strftime compliant format string for the timestamp; for example, `%Y-%m-%dT%H:%M:%S%z`. This option is used with `time_key`. | |
+| `firehose.extraOutputs` | Append extra outputs with value | `""` |
+| `kinesis_streams.enabled` | It has all the core features of the [documentation](https://github.com/aws/amazon-kinesis-streams-for-fluent-bit) Golang Fluent Bit plugin released in 2019. The Golang plugin was named `kinesis`; this new high performance and highly efficient kinesis plugin is called `kinesis_streams` to prevent conflicts/confusion, [details](https://docs.fluentbit.io/manual/pipeline/outputs/kinesis) | `false` | ✔
+| `kinesis_streams.region` | The AWS region. | ✔
+| `kinesis_streams.stream` | The name of the Kinesis Streams Delivery Stream that you want log records send to. | ✔
+| `kinesis_streams.endpoint` | Specify a custom endpoint for the Kinesis Streams API. | |
+| `kinesis_streams.role_arn` | ARN of an IAM role to assume (for cross account access). | |
+| `kinesis_streams.sts_endpoint` | Custom endpoint for the STS API. | |
+| `kinesis_streams.time_key` | Add the timestamp to the record under this key. By default the timestamp from Fluent Bit will not be added to records sent to Kinesis. | |
+| `kinesis_streams.time_key_format` |  strftime compliant format string for the timestamp; for example, the default is `%Y-%m-%dT%H:%M:%S`. Supports millisecond precision with `%3N` and supports nanosecond precision with `%9N` and `%L`; for example, adding `%3N` to support millisecond `%Y-%m-%dT%H:%M:%S.%3N`. This option is used with `time_key`. | |
+| `kinesis_streams.log_key` | By default, the whole log record will be sent to Kinesis. If you specify a key name with this option, then only the value of that key will be sent to Kinesis. For example, if you are using the Fluentd Docker log driver, you can specify `log_key log` and only the log message will be sent to Kinesis. | |
+| `kinesis_streams.auto_retry_requests` | Immediately retry failed requests to AWS services once. This option does not affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which may help improve throughput when there are transient/random networking issues. This option defaults to `true`. | |
+| `kinesis_streams.external_id` | Specify an external ID for the STS API, can be used with the role_arn parameter if your role requries an external ID. | |
+| `kinesis.enabled` | Whether this plugin should be enabled or not, [details](https://github.com/aws/amazon-kinesis-streams-for-fluent-bit) | `false` | ✔
+| `kinesis.match` | The log filter | `"*"` | ✔
+| `kinesis.region` | The region which your Kinesis Data Stream is in. | `"us-east-1"` | ✔
+| `kinesis.stream` | The name of the Kinesis Data Stream that you want log records sent to. | `"my-kinesis-stream-name"` | ✔
+| `kinesis.partitionKey` | A partition key is used to group data by shard within a stream. A Kinesis Data Stream uses the partition key that is associated with each data record to determine which shard a given data record belongs to. For example, if your logs come from Docker containers, you can use container_id as the partition key, and the logs will be grouped and stored on different shards depending upon the id of the container they were generated from. As the data within a shard are coarsely ordered, you will get all your logs from one container in one shard roughly in order. If you don't set a partition key or put an invalid one, a random key will be generated, and the logs will be directed to random shards. If the partition key is invalid, the plugin will print an warning message. | `"container_id"` |
+| `kinesis.appendNewline` | If you set append_newline as true, a newline will be addded after each log record. | |
+| `kinesis.replaceDots` | Replace dot characters in key names with the value of this option. | |
+| `kinesis.dataKeys` | By default, the whole log record will be sent to Kinesis. If you specify key name(s) with this option, then only those keys and values will be sent to Kinesis. For example, if you are using the Fluentd Docker log driver, you can specify data_keys log and only the log message will be sent to Kinesis. If you specify multiple keys, they should be comma delimited. | |
+| `kinesis.roleArn` | ARN of an IAM role to assume (for cross account access). | |
+| `kinesis.endpoint` | Specify a custom endpoint for the Kinesis Streams API. | |
+| `kinesis.stsEndpoint` | Specify a custom endpoint for the STS API; used to assume your custom role provided with `kinesis.roleArn`. | |
+| `kinesis.timeKey` | Add the timestamp to the record under this key. By default the timestamp from Fluent Bit will not be added to records sent to Kinesis. | |
+| `kinesis.timeKeyFormat` |  strftime compliant format string for the timestamp; for example, `%Y-%m-%dT%H:%M:%S%z`. This option is used with `time_key`. | |
+| `kinesis.aggregation` | Setting aggregation to `true` will enable KPL aggregation of records sent to Kinesis. This feature isn't compatible with the `partitionKey` feature.  See more about KPL aggregation [here](https://github.com/aws/amazon-kinesis-streams-for-fluent-bit#kpl-aggregation). | |
+| `kinesis.compression` | Setting `compression` to `zlib` will enable zlib compression of each record. By default this feature is disabled and records are not compressed. | |
+| `kinesis.extraOutputs` | Append extra outputs with value | `""` |
+| `elasticsearch.enabled` | Whether this plugin should be enabled or not, [details](https://docs.fluentbit.io/manual/pipeline/outputs/elasticsearch) | `false` | ✔
+| `elasticsearch.match` | The log filter | `"*"` | ✔
+| `elasticsearch.awsRegion` | The region in which your Amazon OpenSearch Service cluster is in. | `"us-east-1"` | ✔
+| `elasticsearch.host` | The url of the Elastic Search endpoint you want log records sent to. | | ✔
+| `elasticsearch.awsAuth` | Enable AWS Sigv4 Authentication for Amazon ElasticSearch Service | On |
+| `elasticsearch.tls` | Enable or disable TLS support | On |
+| `elasticsearch.port` | TCP Port of the target service. | 443 |
+| `elasticsearch.retryLimit` | Integer value to set the maximum number of retries allowed. N must be >= 1  | 6 |
+| `elasticsearch.replaceDots` | Enable or disable Replace_Dots  | On |
+| `elasticsearch.suppressTypeName` | OpenSearch 2.0 and above needs to have type option being removed by setting Suppress_Type_Name On  | |
+| `elasticsearch.extraOutputs` | Append extra outputs with value | `""` |
+| `s3.enabled` | Whether this plugin should be enabled or not, [details](https://docs.fluentbit.io/manual/pipeline/outputs/s3) | `false`
+| `s3.match` | The log filter. | `"*"`
+| `s3.bucket` | S3 Bucket name. |
+| `s3.region` | The AWS region of your S3 bucket. | `"us-east-1"`
+| `s3.jsonDateKey` | Specify the name of the time key in the output record. To disable the time key just set the value to false. | `"date"`
+| `s3.jsonDateFormat` | Specify the format of the date. Supported formats are double, epoch, iso8601 (eg: 2018-05-30T09:39:52.000681Z) and java_sql_timestamp (eg: 2018-05-30 09:39:52.000681). | `"iso8601"`
+| `s3.totalFileSize` | Specifies the size of files in S3. Maximum size is 50G, minimim is 1M. | `"100M"`
+| `s3.uploadChunkSize` | The size of each 'part' for multipart uploads. Max: 50M | `"6M"`
+| `s3.uploadTimeout` | Whenever this amount of time has elapsed, Fluent Bit will complete an upload and create a new file in S3. For example, set this value to 60m and you will get a new file every hour. | `"10m"`
+| `s3.storeDir` | Directory to locally buffer data before sending. When multipart uploads are used, data will only be buffered until the `upload_chunk_size` is reached. S3 will also store metadata about in progress multipart uploads in this directory; this allows pending uploads to be completed even if Fluent Bit stops and restarts. It will also store the current $INDEX value if enabled in the S3 key format so that the $INDEX can keep incrementing from its previous value after Fluent Bit restarts. | `"/tmp/fluent-bit/s3"`
+| `s3.storeDirLimitSize` | The size of the limitation for disk usage in S3. Limit the amount of s3 buffers in the `store_dir` to limit disk usage. Note: Use `store_dir_limit_size` instead of `storage.total_limit_size` which can be used to other plugins, because S3 has its own buffering system. | `0`
+| `s3.s3KeyFormat` | Format string for keys in S3. This option supports UUID (`$UUID`), strftime time formatters, `$INDEX`, a syntax for selecting parts of the Fluent log tag using `$TAG`/`$TAG[n]` inspired by the rewrite_tag filter. Check [S3 Key Format and Tag Delimiters](https://docs.fluentbit.io/manual/pipeline/outputs/s3#s3-key-format-and-tag-delimiters) documentation for more details. | `"/pod-logs/$TAG/%Y-%m-%d/%H-%M-%S"`
+| `s3.s3KeyFormatTagDelimiters` | A series of characters which will be used to split the tag into 'parts' for use with the s3_key_format option. See the in depth examples and tutorial in the [documentation](https://docs.fluentbit.io/manual/pipeline/outputs/s3/). |
+| `s3.staticFilePath` | Disables behavior where UUID string is automatically appended to end of S3 key name when $UUID is not provided in s3_key_format. $UUID, time formatters, $TAG, and other dynamic key formatters all work as expected while this feature is set to true. | `false`
+| `s3.usePutObject` | Use the S3 PutObject API, instead of the multipart upload API. Check [documentation](https://docs.fluentbit.io/manual/pipeline/outputs/s3) for more details. | `false`
+| `s3.roleArn` | ARN of an IAM role to assume (ex. for cross account access). |
+| `s3.endpoint` | Custom endpoint for the S3 API. An endpoint can contain scheme and port. |
+| `s3.stsEndpoint` | Custom endpoint for the STS API. |
+| `s3.cannedAcl` | Predefined Canned ACL policy for S3 objects. |
+| `s3.compression` | Compression type for S3 objects. AWS distro `aws-for-fluent-bit` supports `gzip` & `arrow`. |
+| `s3.contentType` | A standard MIME type for the S3 object; this will be set as the Content-Type HTTP header. |
+| `s3.sendContentMd5` | Send the Content-MD5 header with PutObject and UploadPart requests, as is required when Object Lock is enabled. | `false`
+| `s3.autoRetryRequests` | Immediately retry failed requests to AWS services once. This option does not affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which may help improve throughput when there are transient/random networking issues. This option defaults to true. Please check [here]( https://github.com/aws/aws-for-fluent-bit/blob/mainline/troubleshooting/debugging.md#network-connection-issues) for more details. | `true`
+| `s3.logKey` | By default, the whole log record will be sent to S3. If you specify a key name with this option, then only the value of that key will be sent to S3. For example, if you are using Docker, you can specify `log_key log` and only the log message will be sent to S3. |
+| `s3.preserveDataOrdering` | Normally, when an upload request fails, there is a high chance for the last received chunk to be swapped with a later chunk, resulting in data shuffling. This feature prevents this shuffling by using a queue logic for uploads. | `true`
+| `s3.storageClass` | Specify the storage class for S3 objects. If this option is not specified, objects will be stored with the default 'STANDARD' storage class. | |
+| `s3.retryLimit`| Integer value to set the maximum number of retries allowed. Note: this configuration is released since version 1.9.10 and 2.0.1. For previous version, the number of retries is 5 and is not configurable. |`1`|
+| `s3.externalId`| Specify an external ID for the STS API, can be used with the role_arn parameter if your role requires an external ID.
+| `s3.extraOutputs`| Append extra outputs with value. This section helps you extend current chart implementation with ability to add extra parameters. For example, you can add [network](https://docs.fluentbit.io/manual/administration/networking) config like `s3.extraOutputs.net.dns.mode=TCP`. | |
+| `opensearch.enabled`| Whether this plugin should be enabled or not, [details](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch) |`false`| ✔
+| `opensearch.match`| The log filter |`"*"`| ✔
+| `opensearch.host`| The url of the Opensearch Search endpoint you want log records sent to. | | ✔
+| `opensearch.awsRegion`| The region in which your Opensearch search is/are in. |`"us-east-1"`|
+| `opensearch.awsAuth`| Enable AWS Sigv4 Authentication for Amazon Opensearch Service. |`"On"`|
+| `opensearch.tls`| Enable or disable TLS support | `"On"` |
+| `opensearch.port`| TCP Port of the target service. |`443`|
+| `opensearch.path`| OpenSearch accepts new data on HTTP query path "/_bulk". But it is also possible to serve OpenSearch behind a reverse proxy on a subpath. This option defines such path on the fluent-bit side. It simply adds a path prefix in the indexing HTTP POST URI. | |
+| `opensearch.bufferSize`| Specify the buffer size used to read the response from the OpenSearch HTTP service. |`"5m"`|
+| `opensearch.pipeline`| OpenSearch allows to setup filters called pipelines. This option allows to define which pipeline the database should use. For performance reasons is strongly suggested to do parsing and filtering on Fluent Bit side, avoid pipelines. | |
+| `opensearch.awsStsEndpoint`| Specify the custom sts endpoint to be used with STS API for Amazon OpenSearch Service. | |
+| `opensearch.awsRoleArn`| AWS IAM Role to assume to put records to your Amazon cluster. | |
+| `opensearch.awsExternalId`| External ID for the AWS IAM Role specified with aws_role_arn. | |
+| `opensearch.awsServiceName`| Service name to be used in AWS Sigv4 signature. For integration with Amazon OpenSearch Serverless, set to`aoss`. See the [FAQ](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch#faq) section on Amazon OpenSearch Serverless for more information. To use this option: make sure you set`image.tag`to`v2.30.0`or higher. | |
+| `opensearch.httpUser`| Optional username credential for access. | |
+| `opensearch.httpPasswd`| Password for user defined in HTTP_User. | |
+| `opensearch.index`| Index name, supports [Record Accessor syntax](https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/classic-mode/record-accessor) |`"aws-fluent-bit"`|
+| `opensearch.type`| Type name |`"_doc"`|
+| `opensearch.logstashFormat`| Enable Logstash format compatibility. This option takes a boolean value: True/False, On/Off |`"on"`|
+| `opensearch.logstashPrefix`| When Logstash_Format is enabled, the Index name is composed using a prefix and the date, e.g: If Logstash_Prefix is equals to 'mydata' your index will become 'mydata-YYYY.MM.DD'. The last string appended belongs to the date when the data is being generated. |`"logstash"`|
+| `opensearch.logstashDateFormat`| Time format (based on strftime) to generate the second part of the Index name. |`"%Y.%m.%d"`|
+| `opensearch.timeKey`| When Logstash_Format is enabled, each record will get a new timestamp field. The Time_Key property defines the name of that field. |`"@timestamp"`|
+| `opensearch.timeKeyFormat`| When Logstash_Format is enabled, this property defines the format of the timestamp. |`"%Y-%m-%dT%H:%M:%S"`|
+| `opensearch.timeKeyNanos`| When Logstash_Format is enabled, enabling this property sends nanosecond precision timestamps. |`"Off"`|
+| `opensearch.includeTagKey`| When enabled, it append the Tag name to the record. |`"Off"`|
+| `opensearch.tagKey`| When Include_Tag_Key is enabled, this property defines the key name for the tag. |`"_flb-key"`|
+| `opensearch.generateId`| When enabled, generate _id for outgoing records. This prevents duplicate records when retrying. |`"Off"`|
+| `opensearch.idKey`| If set, _id will be the value of the key from incoming record and Generate_ID option is ignored. | |
+| `opensearch.writeOperation`| Operation to use to write in bulk requests. |`"create"`|
+| `opensearch.replaceDots`| When enabled, replace field name dots with underscore. |`"Off"`|
+| `opensearch.traceOutput`| When enabled print the OpenSearch API calls to stdout (for diag only) |`"Off"`|
+| `opensearch.traceError`| When enabled print the OpenSearch API calls to stdout when OpenSearch returns an error (for diag only). |`"Off"`|
+| `opensearch.currentTimeIndex`| Use current time for index generation instead of message record |`"Off"`|
+| `opensearch.logstashPrefixKey`| When included: the value in the record that belongs to the key will be looked up and over-write the Logstash_Prefix for index generation. If the key/value is not found in the record then the Logstash_Prefix option will act as a fallback. Nested keys are not supported (if desired, you can use the nest filter plugin to remove nesting) | |
+| `opensearch.suppressTypeName`| When enabled, mapping types is removed and Type option is ignored. |`"Off"`|
+| `opensearch.extraOutputs`| Append extra outputs with value. This section helps you extend current chart implementation with ability to add extra parameters. For example, you can add [network](https://docs.fluentbit.io/manual/administration/networking) config like `opensearch.extraOutputs.net.dns.mode=TCP`. |`""`|
+| `additionalOutputs`| add outputs with value |`""`|
+| `priorityClassName`| Name of Priority Class to assign pods | |
+| `updateStrategy`| Optional update strategy |`type: RollingUpdate`|
+| `affinity`| Map of node/pod affinities |`{}`|
+| `env`| Optional List of pod environment variables for the pods |`[]`|
+| `livenessProbe`| Optional yaml to define liveness probe - In order for liveness probe to work correctly defaults have been set in `service.extraService`, [details](https://docs.fluentbit.io/manual/administration/monitoring#health-check-for-fluent-bit) |httpGet:<br> &nbsp;&nbsp; path: /api/v1/health <br> &nbsp;&nbsp; port: 2020 <br> &nbsp;&nbsp; scheme: HTTP <br> failureThreshold: 2 <br> initialDelaySeconds: 30 <br> timeoutSeconds: 10 |
+| `readinessProbe`| Optional yaml to define readiness probe |`{}`|
+| `serviceMonitor.enabled`| Whether serviceMonitor should be enabled or not, [details](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md) |`false`| ✔ |`[]`|
+| `serviceMonitor.service.type`| Type of service to be created - options are ClusterIP, NodePort, LoadBalancer, ExternalName - [details](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |`ClusterIP`|
+| `serviceMonitor.service.port`| Incoming TCP port of the kubernetes service - Traffic is routed from this port to the targetPort to gain access to the application -  By default and for convenience, the targetPort is set to the same value as the port field. [details](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service) | 2020 |
+| `serviceMonitor.service.targetPort`| TCP targetPort for service to connect to fluent-bit. | 2020 |
+| `serviceMonitor.service.extraPorts`| Extra ports to expose on fluent-bit service | `[]` |
+| `serviceMonitor.interval`| Set how frequently Prometheus should scrape |`30s`|
+| `serviceMonitor.telemetryPath`| Set path to scrape metrics from |`/api/v1/metrics/prometheus`|
+| `serviceMonitor.labels`| Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator |`[]`|
+| `serviceMonitor.timeout`| Set timeout for scrape |`10s`|
+| `serviceMonitor.relabelings`| Set relabel_configs as per [details](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) |`[]`|
+| `serviceMonitor.targetLabels`| Set of labels to transfer on the Kubernetes Service onto the target. |`[]`|
+| `serviceMonitor.metricRelabelings`| MetricRelabelConfigs to apply to samples before ingestion. |`[]`|
+| `serviceMonitor.extraEndpoints`| Extra endpoints on the fluent-bit service for the serviceMonitor to monitor |`[]`|
+| `tolerations`| Optional deployment tolerations |`[]`|
+| `nodeSelector`| Node labels for pod assignment |`{}`|
+| `annotations`| Optional pod annotations |`{}`|
+| `volumes`| Volumes for the pods, provide as a list of volume objects (see values.yaml) |  volumes for /var/log and /var/lib/docker/containers are present, along with a fluentbit config volume |
+| `volumeMounts`| Volume mounts for the pods, provided as a list of volumeMount objects (see values.yaml) | volumes for /var/log and /var/lib/docker/containers are mounted, along with a fluentbit config volume |
+| `dnsPolicy`| Optional dnsPolicy |`ClusterFirst`|
+| `hostNetwork`| If true, use hostNetwork |`false` |

--- a/helm/aws-for-fluent-bit/templates/NOTES.txt
+++ b/helm/aws-for-fluent-bit/templates/NOTES.txt
@@ -1,0 +1,3 @@
+{{ .Release.Name }} has been installed or updated. To check the status of pods, run:
+
+kubectl get pods -n {{ include "aws-for-fluent-bit.namespace" . }}

--- a/helm/aws-for-fluent-bit/templates/_helpers.tpl
+++ b/helm/aws-for-fluent-bit/templates/_helpers.tpl
@@ -1,0 +1,74 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "aws-for-fluent-bit.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "aws-for-fluent-bit.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "aws-for-fluent-bit.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "aws-for-fluent-bit.labels" -}}
+helm.sh/chart: {{ include "aws-for-fluent-bit.chart" . }}
+{{ include "aws-for-fluent-bit.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "aws-for-fluent-bit.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "aws-for-fluent-bit.name" . }}
+app.kubernetes.io/instance: {{ include "aws-for-fluent-bit.fullname" . }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "aws-for-fluent-bit.serviceAccountName" -}}
+  {{ default (include "aws-for-fluent-bit.fullname" .) .Values.serviceAccount.name }}
+{{- end -}}
+
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts.
+*/}}
+{{- define "aws-for-fluent-bit.namespace" -}}
+  {{- if .Values.global -}}
+    {{- if .Values.global.namespaceOverride -}}
+      {{- .Values.global.namespaceOverride -}}
+    {{- else -}}
+      {{- .Release.Namespace -}}
+    {{- end -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}

--- a/helm/aws-for-fluent-bit/templates/clusterrole.yaml
+++ b/helm/aws-for-fluent-bit/templates/clusterrole.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "aws-for-fluent-bit.fullname" . }}
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - pods
+      - pods/logs
+      - nodes
+      - nodes/proxy
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+    resourceNames:
+      - {{ include "aws-for-fluent-bit.fullname" . }}

--- a/helm/aws-for-fluent-bit/templates/clusterrolebinding.yaml
+++ b/helm/aws-for-fluent-bit/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "aws-for-fluent-bit.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "aws-for-fluent-bit.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "aws-for-fluent-bit.serviceAccountName" . }}
+    namespace: {{ include "aws-for-fluent-bit.namespace" . }}

--- a/helm/aws-for-fluent-bit/templates/configmap.yaml
+++ b/helm/aws-for-fluent-bit/templates/configmap.yaml
@@ -1,0 +1,501 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "aws-for-fluent-bit.fullname" . }}
+  namespace: {{ include "aws-for-fluent-bit.namespace" . }}
+  labels:
+    {{- include "aws-for-fluent-bit.labels" . | nindent 4 }}
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+{{- if .Values.service.extraService }}
+{{ .Values.service.extraService | indent 8 }}
+{{- end }}
+{{- range .Values.service.parsersFiles }}
+        Parsers_File {{ . }}
+{{- end }}
+{{- if .Values.service.extraParsers }}
+        Parsers_File /fluent-bit/etc/parser_extra.conf
+{{- end }}
+
+{{- if .Values.input.enabled }}
+    [INPUT]
+        Name              tail
+        Tag               {{ .Values.input.tag }}
+        Path              {{ .Values.input.path }}
+        DB                {{ .Values.input.db }}
+        {{- if .Values.input.parser }}
+        Parser            {{ .Values.input.parser }}
+        {{- end }}
+        {{- if .Values.input.dockerMode }}
+        Docker_Mode       {{ .Values.input.dockerMode }}
+        {{- end }}
+        {{- if .Values.input.multilineParser }}
+        multiline.parser  {{ .Values.input.multilineParser }}
+        {{- end }}
+        Mem_Buf_Limit     {{ .Values.input.memBufLimit }}
+        Skip_Long_Lines   {{ .Values.input.skipLongLines }}
+        Refresh_Interval  {{ .Values.input.refreshInterval }}
+{{- end }}
+{{- if .Values.input.extraInputs }}
+{{ .Values.input.extraInputs | indent 8 }}
+{{- end }}
+
+{{- if .Values.additionalInputs }}
+{{ .Values.additionalInputs | indent 4 }}
+{{- end }}
+
+{{- if .Values.filter.enabled }}
+    [FILTER]
+        Name                kubernetes
+        Match               {{ .Values.filter.match }}
+        Kube_URL            {{ .Values.filter.kubeURL }}
+        Merge_Log           {{ .Values.filter.mergeLog }}
+        {{- if .Values.filter.mergeLogKey }}
+        Merge_Log_Key       {{ .Values.filter.mergeLogKey }}
+        {{- end }}
+        Keep_Log            {{ .Values.filter.keepLog }}
+        K8S-Logging.Parser  {{ .Values.filter.k8sLoggingParser }}
+        K8S-Logging.Exclude {{ .Values.filter.k8sLoggingExclude }}
+        Buffer_Size         {{ .Values.filter.bufferSize }}
+{{- end }}
+
+{{- if .Values.filter.extraFilters }}
+{{ .Values.filter.extraFilters | indent 8 }}
+{{- end }}
+
+{{- if .Values.additionalFilters }}
+{{ .Values.additionalFilters | indent 4}}
+{{- end }}
+
+{{- if .Values.cloudWatch.enabled }}
+    [OUTPUT]
+        Name                  cloudwatch
+        Match                 {{ .Values.cloudWatch.match }}
+        region                {{ .Values.cloudWatch.region }}
+        log_group_name        {{ .Values.cloudWatch.logGroupName }}
+        {{- if .Values.cloudWatch.logStreamName }}
+        log_stream_name       {{ .Values.cloudWatch.logStreamName }}
+        {{- end }}
+        {{- if .Values.cloudWatch.logStreamPrefix }}
+        log_stream_prefix     {{ .Values.cloudWatch.logStreamPrefix }}
+        {{- end }}
+        {{- if .Values.cloudWatch.logKey }}
+        log_key               {{ .Values.cloudWatch.logKey }}
+        {{- end }}
+        {{- if .Values.cloudWatch.logFormat }}
+        log_format            {{ .Values.cloudWatch.logFormat }}
+        {{- end }}
+        {{- if .Values.cloudWatch.logRetentionDays }}
+        log_retention_days    {{ .Values.cloudWatch.logRetentionDays }}
+        {{- end }}
+        {{- if .Values.cloudWatch.roleArn }}
+        role_arn              {{ .Values.cloudWatch.roleArn }}
+        {{- end }}
+        {{- if .Values.cloudWatch.autoCreateGroup }}
+        auto_create_group     {{ .Values.cloudWatch.autoCreateGroup }}
+        {{- end }}
+        {{- if .Values.cloudWatch.endpoint }}
+        endpoint              {{ .Values.cloudWatch.endpoint }}
+        {{- end }}
+        {{- if .Values.cloudWatch.credentialsEndpoint }}
+        credentials_endpoint  {{ toJson .Values.cloudWatch.credentialsEndpoint }}
+        {{- end -}}
+        {{- if .Values.cloudWatch.extraOutputs }}
+{{ .Values.cloudWatch.extraOutputs | indent 8 }}
+        {{- end }}
+{{- end }}
+
+{{- if .Values.cloudWatchLogs.enabled }}
+    [OUTPUT]
+        Name                  cloudwatch_logs
+        Match                 {{ .Values.cloudWatchLogs.match }}
+        region                {{ .Values.cloudWatchLogs.region }}
+        log_group_name        {{ .Values.cloudWatchLogs.logGroupName }}
+        {{- if .Values.cloudWatchLogs.logGroupTemplate }}
+        log_group_template    {{ .Values.cloudWatchLogs.logGroupTemplate }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.logStreamName }}
+        log_stream_name       {{ .Values.cloudWatchLogs.logStreamName }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.logStreamPrefix }}
+        log_stream_prefix     {{ .Values.cloudWatchLogs.logStreamPrefix }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.logStreamTemplate }}
+        log_stream_template   {{ .Values.cloudWatchLogs.logStreamTemplate }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.logKey }}
+        log_key               {{ .Values.cloudWatchLogs.logKey }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.logFormat }}
+        log_format            {{ .Values.cloudWatchLogs.logFormat }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.roleArn }}
+        role_arn              {{ .Values.cloudWatchLogs.roleArn }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.autoCreateGroup }}
+        auto_create_group     {{ .Values.cloudWatchLogs.autoCreateGroup }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.logRetentionDays }}
+        log_retention_days    {{ .Values.cloudWatchLogs.logRetentionDays }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.endpoint }}
+        endpoint              {{ .Values.cloudWatchLogs.endpoint }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.metricNamespace }}
+        metric_namespace      {{ .Values.cloudWatchLogs.metricNamespace }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.metricDimensions }}
+        metric_dimensions     {{ .Values.cloudWatchLogs.metricDimensions }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.stsEndpoint }}
+        sts_endpoint          {{ .Values.cloudWatchLogs.stsEndpoint }}
+        {{- end }}
+        {{- if .Values.cloudWatchLogs.autoRetryRequests }}
+        auto_retry_requests   {{ .Values.cloudWatchLogs.autoRetryRequests }}
+        {{- end -}}
+        {{- if .Values.cloudWatchLogs.externalId }}
+        external_id           {{  .Values.cloudWatchLogs.externalId }}
+        {{- end -}}
+        {{- if .Values.cloudWatchLogs.extraOutputs }}
+{{ .Values.cloudWatchLogs.extraOutputs | indent 8 }}
+        {{- end }}
+{{- end }}
+
+{{- if .Values.firehose.enabled }}
+    [OUTPUT]
+        Name            firehose
+        Match           {{ .Values.firehose.match }}
+        region          {{ .Values.firehose.region }}
+        delivery_stream {{ .Values.firehose.deliveryStream }}
+        {{- if .Values.firehose.dataKeys }}
+        data_keys       {{ .Values.firehose.dataKeys }}
+        {{- end }}
+        {{- if .Values.firehose.roleArn }}
+        role_arn        {{ .Values.firehose.roleArn }}
+        {{- end }}
+        {{- if .Values.firehose.endpoint }}
+        endpoint        {{ .Values.firehose.endpoint }}
+        {{- end }}
+        {{- if .Values.firehose.timeKey }}
+        time_key        {{ .Values.firehose.timeKey }}
+        {{- end }}
+        {{- if .Values.firehose.timeKeyFormat }}
+        time_key_format {{ .Values.firehose.timeKeyFormat }}
+        {{- end -}}
+        {{- if .Values.kinesis.extraOutputs }}
+{{ .Values.kinesis.extraOutputs | indent 8 }}
+        {{- end }}
+{{- end }}
+
+{{- if .Values.kinesis.enabled }}
+    [OUTPUT]
+        Name            kinesis
+        Match           {{ .Values.kinesis.match }}
+        region          {{ .Values.kinesis.region }}
+        stream          {{ .Values.kinesis.stream }}
+        {{- if .Values.kinesis.partitionKey }}
+        partition_key   {{ .Values.kinesis.partitionKey }}
+        {{- end }}
+        {{- if .Values.kinesis.appendNewline }}
+        append_newline  {{ .Values.kinesis.appendNewline }}
+        {{- end }}
+        {{- if .Values.kinesis.replaceDots }}
+        replace_dots    {{ .Values.kinesis.replaceDots }}
+        {{- end }}
+        {{- if .Values.kinesis.dataKeys }}
+        data_keys       {{ .Values.kinesis.dataKeys }}
+        {{- end }}
+        {{- if .Values.kinesis.roleArn }}
+        role_arn        {{ .Values.kinesis.roleArn }}
+        {{- end }}
+        {{- if .Values.kinesis.endpoint }}
+        endpoint        {{ .Values.kinesis.endpoint }}
+        {{- end }}
+        {{- if .Values.kinesis.stsEndpoint }}
+        sts_endpoint    {{ .Values.kinesis.stsEndpoint }}
+        {{- end }}
+        {{- if .Values.kinesis.timeKey }}
+        time_key        {{ .Values.kinesis.timeKey }}
+        {{- end }}
+        {{- if .Values.kinesis.timeKeyFormat }}
+        time_key_format {{ .Values.kinesis.timeKeyFormat }}
+        {{- end }}
+        {{- if .Values.kinesis.aggregation }}
+        aggregation     {{ .Values.kinesis.aggregation }}
+        {{- end }}
+        {{- if .Values.kinesis.compression }}
+        compression     {{ .Values.kinesis.compression }}
+        {{- end }}
+
+        {{- if .Values.kinesis.experimental.concurrency }}
+        experimental_concurrency          {{ .Values.kinesis.experimental.concurrency }}
+        {{- end }}
+        {{- if .Values.kinesis.experimental.concurrencyRetries }}
+        experimental_concurrency_retries  {{ .Values.kinesis.experimental.concurrencyRetries }}
+        {{- end -}}
+        {{- if .Values.kinesis.extraOutputs }}
+{{ .Values.kinesis.extraOutputs | indent 8 }}
+        {{- end }}
+{{- end }}
+
+{{- if .Values.kinesis_streams.enabled }}
+    [OUTPUT]
+        Name            kinesis_streams
+        Match           {{ .Values.kinesis_streams.match }}
+        region          {{ .Values.kinesis_streams.region }}
+        stream          {{ .Values.kinesis_streams.stream }}
+        {{- if .Values.kinesis_streams.role_arn }}
+        role_arn        {{ .Values.kinesis_streams.role_arn }}
+        {{- end }}
+        {{- if .Values.kinesis_streams.endpoint }}
+        endpoint        {{ .Values.kinesis_streams.endpoint }}
+        {{- end }}
+        {{- if .Values.kinesis_streams.sts_endpoint }}
+        sts_endpoint    {{ .Values.kinesis_streams.sts_endpoint }}
+        {{- end }}
+        {{- if .Values.kinesis_streams.time_key }}
+        time_key        {{ .Values.kinesis_streams.time_key }}
+        {{- end }}
+        {{- if .Values.kinesis_streams.time_key_format }}
+        time_key_format {{ .Values.kinesis_streams.time_key_format }}
+        {{- end }}
+        {{- if .Values.kinesis_streams.external_id }}
+        time_key_format {{ .Values.kinesis_streams.external_id }}
+        {{- end }}
+        {{- if .Values.kinesis_streams.auto_retry_requests }}
+        time_key_format {{ .Values.kinesis_streams.auto_retry_requests }}
+        {{- end }}
+        {{- if .Values.kinesis_streams.log_key }}
+        log_key         {{ .Values.kinesis_streams.log_key }}
+        {{- end }}
+{{- end }}
+
+{{- if .Values.elasticsearch.enabled }}
+    [OUTPUT]
+        Name            es
+        Match           {{ .Values.elasticsearch.match }}
+        AWS_Region      {{ .Values.elasticsearch.awsRegion }}
+        AWS_Auth        {{ .Values.elasticsearch.awsAuth }}
+        {{- if .Values.elasticsearch.host }}
+        Host            {{ .Values.elasticsearch.host }}
+        {{- end }}
+        {{- if .Values.elasticsearch.port }}
+        Port            {{ .Values.elasticsearch.port }}
+        {{- end }}
+        {{- if .Values.elasticsearch.tls }}
+        TLS             {{ .Values.elasticsearch.tls }}
+        {{- end }}
+        {{- if .Values.elasticsearch.retryLimit }}
+        Retry_Limit     {{ .Values.elasticsearch.retryLimit }}
+        {{- end }}
+        {{- if .Values.elasticsearch.replaceDots }}
+        Replace_Dots    {{ .Values.elasticsearch.replaceDots }}
+        {{- end -}}
+        {{- if .Values.elasticsearch.suppressTypeName }}
+        Suppress_Type_Name    {{ .Values.elasticsearch.suppressTypeName }}
+        {{- end -}}
+        {{- if .Values.elasticsearch.extraOutputs }}
+{{ .Values.elasticsearch.extraOutputs | indent 8 }}
+        {{- end }}
+{{- end }}
+
+{{- if .Values.s3.enabled }}
+    [OUTPUT]
+        Name                          s3
+        Match                         {{ .Values.s3.match }}
+        bucket                        {{ .Values.s3.bucket }}
+        region                        {{ .Values.s3.region }}
+        {{- if .Values.s3.jsonDateKey }}
+        json_date_key                 {{ .Values.s3.jsonDateKey }}
+        {{- end }}
+        {{- if .Values.s3.jsonDateFormat }}
+        json_date_format              {{ .Values.s3.jsonDateFormat }}
+        {{- end }}
+        {{- if .Values.s3.totalFileSize }}
+        total_file_size               {{ .Values.s3.totalFileSize }}
+        {{- end }}
+        {{- if .Values.s3.uploadChunkSize }}
+        upload_chunk_size             {{ .Values.s3.uploadChunkSize }}
+        {{- end }}
+        {{- if .Values.s3.uploadTimeout }}
+        upload_timeout                {{ .Values.s3.uploadTimeout }}
+        {{- end }}
+        {{- if .Values.s3.storeDir }}
+        store_dir                     {{ .Values.s3.storeDir }}
+        {{- end }}
+        {{- if .Values.s3.storeDirLimitSize }}
+        store_dir_limit_size          {{ .Values.s3.storeDirLimitSize }}
+        {{- end }}
+        {{- if .Values.s3.s3KeyFormat }}
+        s3_key_format                 {{ .Values.s3.s3KeyFormat }}
+        {{- end }}
+        {{- if .Values.s3.s3KeyFormatTagDelimiters }}
+        s3_key_format_tag_delimiters  {{ .Values.s3.s3KeyFormatTagDelimiters }}
+        {{- end }}
+        {{- if .Values.s3.staticFilePath }}
+        static_file_path              {{ .Values.s3.staticFilePath }}
+        {{- end }}
+        {{- if .Values.s3.usePutObject }}
+        use_put_object                {{ .Values.s3.usePutObject }}
+        {{- end }}
+        {{- if .Values.s3.roleArn }}
+        role_arn                      {{ .Values.s3.roleArn }}
+        {{- end }}
+        {{- if .Values.s3.endpoint }}
+        endpoint                      {{ .Values.s3.endpoint }}
+        {{- end }}
+        {{- if .Values.s3.stsEndpoint }}
+        sts_endpoint                  {{ .Values.s3.stsEndpoint }}
+        {{- end }}
+        {{- if .Values.s3.cannedAcl }}
+        canned_acl                    {{ .Values.s3.cannedAcl }}
+        {{- end }}
+        {{- if .Values.s3.compression }}
+        compression                   {{ .Values.s3.compression }}
+        {{- end }}
+        {{- if .Values.s3.contentType }}
+        content_type                  {{ .Values.s3.contentType }}
+        {{- end }}
+        {{- if .Values.s3.sendContentMd5 }}
+        send_content_md5              {{ .Values.s3.sendContentMd5 }}
+        {{- end }}
+        {{- if .Values.s3.autoRetryRequests }}
+        auto_retry_requests           {{ .Values.s3.autoRetryRequests }}
+        {{- end }}
+        {{- if .Values.s3.logKey }}
+        log_key                       {{ .Values.s3.logKey }}
+        {{- end }}
+        {{- if .Values.s3.preserveDataOrdering }}
+        preserve_data_ordering        {{ .Values.s3.preserveDataOrdering }}
+        {{- end }}
+        {{- if .Values.s3.storageClass }}
+        storage_class                 {{ .Values.s3.storageClass }}
+        {{- end }}
+        {{- if .Values.s3.retryLimit }}
+        retry_limit                   {{ .Values.s3.retryLimit }}
+        {{- end }}
+        {{- if .Values.s3.externalId }}
+        external_id                   {{ .Values.s3.externalId }}
+        {{- end }}
+        {{- if .Values.s3.extraOutputs }}
+{{ .Values.s3.extraOutputs | indent 8 }}
+        {{- end }}
+{{- end }}
+
+{{- if .Values.opensearch.enabled }}
+    [OUTPUT]
+        Name                opensearch
+        Match               {{ .Values.opensearch.match }}
+        {{- if .Values.opensearch.awsRegion }}
+        AWS_Region                {{ .Values.opensearch.awsRegion }}
+        {{- end }}
+        {{- if .Values.opensearch.awsAuth }}
+        AWS_Auth                {{ .Values.opensearch.awsAuth }}
+        {{- end }}
+        {{- if .Values.opensearch.host }}
+        Host                {{ .Values.opensearch.host }}
+        {{- end }}
+        {{- if .Values.opensearch.port }}
+        Port                {{ .Values.opensearch.port }}
+        {{- end }}
+        {{- if .Values.opensearch.tls }}
+        tls                {{ .Values.opensearch.tls }}
+        {{- end }}
+        {{- if .Values.opensearch.path }}
+        Path                {{ .Values.opensearch.path }}
+        {{- end }}
+        {{- if .Values.opensearch.bufferSize }}
+        Buffer_Size         {{ .Values.opensearch.bufferSize }}
+        {{- end }}
+        {{- if .Values.opensearch.pipeline }}
+        Pipeline            {{ .Values.opensearch.pipeline }}
+        {{- end }}
+        {{- if .Values.opensearch.awsStsEndpoint }}
+        AWS_STS_Endpoint    {{ .Values.opensearch.awsStsEndpoint }}
+        {{- end }}
+        {{- if .Values.opensearch.awsRoleArn }}
+        AWS_Role_ARN        {{ .Values.opensearch.awsRoleArn }}
+        {{- end }}
+        {{- if .Values.opensearch.awsExternalId }}
+        AWS_External_ID     {{ .Values.opensearch.awsExternalId }}
+        {{- end }}
+        {{- if .Values.opensearch.awsServiceName }}
+        AWS_Service_Name    {{ .Values.opensearch.awsServiceName }}
+        {{- end }}
+        {{- if .Values.opensearch.httpUser }}
+        HTTP_User           {{ .Values.opensearch.httpUser }}
+        {{- end }}
+        {{- if .Values.opensearch.httpPasswd }}
+        HTTP_Passwd         {{ .Values.opensearch.httpPasswd }}
+        {{- end }}
+        {{- if .Values.opensearch.index }}
+        Index               {{ .Values.opensearch.index }}
+        {{- end }}
+        {{- if .Values.opensearch.type }}
+        Type                {{ .Values.opensearch.type }}
+        {{- end }}
+        {{- if .Values.opensearch.logstashFormat }}
+        Logstash_Format     {{ .Values.opensearch.logstashFormat }}
+        {{- end }}
+        {{- if .Values.opensearch.logstashPrefix }}
+        Logstash_Prefix     {{ .Values.opensearch.logstashPrefix }}
+        {{- end }}
+        {{- if .Values.opensearch.logstashDateFormat }}
+        Logstash_DateFormat {{ .Values.opensearch.logstashDateFormat }}
+        {{- end }}
+        {{- if .Values.opensearch.timeKey }}
+        Time_Key            {{ .Values.opensearch.timeKey }}
+        {{- end }}
+        {{- if .Values.opensearch.timeKeyFormat }}
+        Time_Key_Format     {{ .Values.opensearch.timeKeyFormat }}
+        {{- end }}
+        {{- if .Values.opensearch.timeKeyNanos }}
+        Time_Key_Nanos      {{ .Values.opensearch.timeKeyNanos }}
+        {{- end }}
+        {{- if .Values.opensearch.includeTagKey }}
+        Include_Tag_Key     {{ .Values.opensearch.includeTagKey }}
+        {{- end }}
+        {{- if .Values.opensearch.tagKey }}
+        Tag_Key             {{ .Values.opensearch.tagKey }}
+        {{- end }}
+        {{- if .Values.opensearch.generateId }}
+        Generate_ID         {{ .Values.opensearch.generateId }}
+        {{- end }}
+        {{- if .Values.opensearch.idKey }}
+        Id_Key              {{ .Values.opensearch.idKey }}
+        {{- end }}
+        {{- if .Values.opensearch.writeOperation }}
+        Write_Operation     {{ .Values.opensearch.writeOperation }}
+        {{- end }}
+        {{- if .Values.opensearch.replaceDots }}
+        Replace_Dots        {{ .Values.opensearch.replaceDots }}
+        {{- end }}
+        {{- if .Values.opensearch.traceOutput }}
+        Trace_Output        {{ .Values.opensearch.traceOutput }}
+        {{- end }}
+        {{- if .Values.opensearch.traceError }}
+        Trace_Error         {{ .Values.opensearch.traceError }}
+        {{- end }}
+        {{- if .Values.opensearch.currentTimeIndex }}
+        Current_Time_Index  {{ .Values.opensearch.currentTimeIndex }}
+        {{- end }}
+        {{- if .Values.opensearch.logstashPrefixKey }}
+        Logstash_Prefix_Key {{ .Values.opensearch.logstashPrefixKey }}
+        {{- end }}
+        {{- if .Values.opensearch.suppressTypeName }}
+        Suppress_Type_Name  {{ .Values.opensearch.suppressTypeName }}
+        {{- end -}}
+        {{- if .Values.opensearch.extraOutputs }}
+{{ .Values.opensearch.extraOutputs | indent 8 }}
+        {{- end }}
+{{- end }}
+
+{{- if .Values.additionalOutputs }}
+{{ .Values.additionalOutputs | indent 4 }}
+{{- end }}
+
+{{- if .Values.service.extraParsers }}
+  parser_extra.conf: |-
+{{ .Values.service.extraParsers | indent 4 }}
+{{- end }}

--- a/helm/aws-for-fluent-bit/templates/daemonset.yaml
+++ b/helm/aws-for-fluent-bit/templates/daemonset.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "aws-for-fluent-bit.fullname" . }}
+  namespace: {{ include "aws-for-fluent-bit.namespace" . }}
+  labels:
+    {{- include "aws-for-fluent-bit.labels" . | nindent 4 }}
+spec:
+  updateStrategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}
+  selector:
+    matchLabels:
+      {{- include "aws-for-fluent-bit.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- if .Values.annotations }}
+        {{- toYaml .Values.annotations | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "aws-for-fluent-bit.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "aws-for-fluent-bit.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}      
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      {{- if .Values.hostNetwork }}
+      hostNetwork: {{ .Values.hostNetwork }}
+      {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}          
+          {{- if .Values.env }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: fluentbit-config
+              mountPath: /fluent-bit/etc/
+            {{- if .Values.volumeMounts }}
+            {{- toYaml .Values.volumeMounts | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: fluentbit-config
+          configMap:
+            name: {{ include "aws-for-fluent-bit.fullname" . }}
+        {{- if .Values.volumes }}
+        {{- toYaml .Values.volumes | nindent 8 }}
+        {{- end}}
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}

--- a/helm/aws-for-fluent-bit/templates/psp.yaml
+++ b/helm/aws-for-fluent-bit/templates/psp.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "aws-for-fluent-bit.fullname" . }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'secret'
+    - 'hostPath'
+    - 'projected'
+  allowedHostPaths:
+    - pathPrefix: "/var/log"
+    - pathPrefix: "/var/lib/docker/containers"
+      readOnly: true
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/helm/aws-for-fluent-bit/templates/service.yaml
+++ b/helm/aws-for-fluent-bit/templates/service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{- include "aws-for-fluent-bit.labels" . | nindent 4 }}
+  name: {{ include "aws-for-fluent-bit.fullname" . }}
+  namespace: {{ include "aws-for-fluent-bit.namespace" . }}
+spec:
+  ports:
+  - name: monitor-agent
+    port: {{ .Values.serviceMonitor.service.port }}
+    protocol: TCP
+    targetPort: {{ .Values.serviceMonitor.service.targetPort }}
+{{- if .Values.serviceMonitor.service.extraPorts }}
+  {{- range .Values.serviceMonitor.service.extraPorts }}
+  - name: {{ .name }}
+    targetPort: {{ .targetPort }}
+    protocol: {{ .protocol }}
+    port: {{ .port }}
+  {{- end }}
+{{- end }}
+  selector:
+    {{- include "aws-for-fluent-bit.selectorLabels" . | nindent 4 }}
+  sessionAffinity: None
+  type: {{ .Values.serviceMonitor.service.type }}

--- a/helm/aws-for-fluent-bit/templates/serviceaccount.yaml
+++ b/helm/aws-for-fluent-bit/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "aws-for-fluent-bit.serviceAccountName" . }}
+  namespace: {{ include "aws-for-fluent-bit.namespace" . }}
+  labels:
+    {{- include "aws-for-fluent-bit.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/helm/aws-for-fluent-bit/templates/servicemonitor.yaml
+++ b/helm/aws-for-fluent-bit/templates/servicemonitor.yaml
@@ -1,0 +1,50 @@
+{{- if $.Values.serviceMonitor }}
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+{{- if .Values.serviceMonitor.labels }}
+  labels:
+{{ toYaml .Values.serviceMonitor.labels | indent 4}}
+{{- end }}
+  name: {{ include "aws-for-fluent-bit.fullname" . }}
+  namespace: {{ include "aws-for-fluent-bit.namespace" . }}
+spec:
+  endpoints:
+  - port: monitor-agent
+    scheme: http
+{{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}
+{{- if .Values.serviceMonitor.telemetryPath }}
+    path: {{ .Values.serviceMonitor.telemetryPath }}
+{{- end }}
+{{- if .Values.serviceMonitor.timeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
+{{- end }}
+{{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
+{{- end }}
+{{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.serviceMonitor.relabelings | indent 4 }}
+{{- end }}
+{{- with .Values.serviceMonitor.extraEndpoints }}
+    {{- toYaml . | nindent 2 }}
+{{- end }}
+  jobLabel: {{ default "app.kubernetes.io/instance" .Values.serviceMonitor.jobLabel }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+{{- include "aws-for-fluent-bit.selectorLabels" . | nindent 6 }}
+{{- if .Values.serviceMonitor.targetLabels }}
+  targetLabels:
+{{- range .Values.serviceMonitor.targetLabels }}
+    - {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/aws-for-fluent-bit/values.yaml
+++ b/helm/aws-for-fluent-bit/values.yaml
@@ -1,0 +1,391 @@
+global:
+## Override the deployment namespace
+#   namespaceOverride:
+
+image:
+  repository: public.ecr.aws/aws-observability/aws-for-fluent-bit
+  tag: 2.32.2.20240516
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podSecurityContext: {}
+# runAsUser: 1000
+# runAsGroup: 1000
+# runAsNonRoot: true
+# seccompProfile:
+#   type: RuntimeDefault
+containerSecurityContext: {}
+# allowPrivilegeEscalation: false
+# capabilities: 
+#   drop:
+#   - ALL
+
+rbac:
+  # rbac.pspEnabled, if `true` a restricted pod security policy is created and used
+  pspEnabled: false
+
+service:
+  ## Allow the service to be exposed for monitoring
+  ## For liveness check to work, Health_Check must be set to On
+  ## https://docs.fluentbit.io/manual/administration/monitoring
+  extraService: |
+    HTTP_Server  On
+    HTTP_Listen  0.0.0.0
+    HTTP_PORT    2020
+    Health_Check On 
+    HC_Errors_Count 5 
+    HC_Retry_Failure_Count 5 
+    HC_Period 5 
+
+  parsersFiles:
+    - /fluent-bit/parsers/parsers.conf
+  # extraParsers: |
+  #   [PARSER]
+  #       Name   logfmt
+  #       Format logfmt
+
+input:
+  enabled: true
+  tag: "kube.*"
+  path: "/var/log/containers/*.log"
+  db: "/var/log/flb_kube.db"
+  multilineParser: "docker, cri"
+  memBufLimit: 5MB
+  skipLongLines: "On"
+  refreshInterval: 10
+  # extraInputs: |
+  #   ...
+
+# additionalInputs: |
+#   [INPUT]
+#       Name         winlog
+#       Channels     Setup,Windows PowerShell
+#       Interval_Sec 1
+#       DB           winlog.sqlite
+
+filter:
+  enabled: true
+  match: "kube.*"
+  kubeURL: "https://kubernetes.default.svc.cluster.local:443"
+  mergeLog: "On"
+  mergeLogKey: "data"
+  keepLog: "On"
+  k8sLoggingParser: "On"
+  k8sLoggingExclude: "On"
+  bufferSize: "32k"
+# Uncomment the extraFilters to use Kubelet to get the Metadata instead of talking to API server for large clusters
+# Check this link for more details https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-use-kubelet.html
+#  extraFilters: |
+#    Kube_Tag_Prefix     application.var.log.containers.
+#    Labels              Off
+#    Annotations         Off
+#    Use_Kubelet         true
+#    Kubelet_Port        10250
+#    Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+#    Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
+
+# additionalFilters: |
+#   [FILTER]
+#       Name   grep
+#       Match  *
+#       Exclude log lvl=debug*
+
+cloudWatch:
+  enabled: false
+  match: "*"
+  region: "us-east-1"
+  logGroupName: "/aws/eks/fluentbit-cloudwatch/logs"
+  logStreamName:
+  logStreamPrefix: "fluentbit-"
+  logKey:
+  logFormat:
+  logRetentionDays:
+  roleArn:
+  autoCreateGroup: true
+  endpoint:
+  credentialsEndpoint: {}
+  # extraOutputs: |
+  #   ...
+
+cloudWatchLogs:
+  enabled: true
+  match: "*"
+  region: "us-east-1"
+  logGroupName: "/aws/eks/fluentbit-cloudwatch/logs"
+  logGroupTemplate: # /aws/eks/fluentbit-cloudwatch/workload/$kubernetes['namespace_name']
+  logStreamName:
+  logStreamPrefix: "fluentbit-"
+  logStreamTemplate: # $kubernetes['pod_name'].$kubernetes['container_name']
+  logKey:
+  logFormat:
+  roleArn:
+  autoCreateGroup: true
+  logRetentionDays:
+  endpoint:
+  metricNamespace:
+  metricDimensions:
+  stsEndpoint:
+  autoRetryRequests:
+  externalId:
+  # extraOutputs: |
+  #  log_format json/emf
+  #  worker 1
+
+firehose:
+  enabled: false
+  match: "*"
+  region: "us-east-1"
+  deliveryStream: "my-stream"
+  dataKeys:
+  roleArn:
+  endpoint:
+  timeKey:
+  # extraOutputs: |
+  #   ...
+
+kinesis:
+  enabled: false
+  match: "*"
+  region: "us-east-1"
+  stream: "my-kinesis-stream-name"
+  partitionKey: "container_id"
+  appendNewline:
+  replaceDots:
+  dataKeys:
+  roleArn:
+  endpoint:
+  stsEndpoint:
+  timeKey:
+  timeKeyFormat:
+  compression:
+  aggregation:
+  experimental:
+    concurrency:
+    concurrencyRetries:
+  # extraOutputs: |
+  #   ...
+
+kinesis_streams:
+  enabled: false
+  match: "*"
+  region: "us-east-1"
+  stream: "my-kinesis-stream-name"
+  role_arn:
+  endpoint:
+  sts_endpoint:
+  time_key:
+  time_key_format:
+  external_id:
+  auto_retry_requests:
+  log_key: 
+
+elasticsearch:
+  enabled: false
+  match: "*"
+  host:
+  awsRegion: "us-east-1"
+  awsAuth: "On"
+  tls: "On"
+  port: "443"
+  retryLimit: 6
+  replaceDots: "On"
+  suppressTypeName:
+  # extraOutputs: |
+  #   Index = my-index
+
+s3:
+  enabled: false
+  match: "*"
+  bucket:
+  region: "us-east-1"
+  jsonDateKey: "date"
+  jsonDateFormat: "iso8601"
+  totalFileSize: "100M"
+  uploadChunkSize: "6M"
+  uploadTimeout: "10m"
+  storeDir: "/tmp/fluent-bit/s3"
+  storeDirLimitSize: 0
+  s3KeyFormat: /pod-logs/$TAG/%Y-%m-%d/%H-%M-%S
+  s3KeyFormatTagDelimiters:
+  staticFilePath: false
+  usePutObject: false
+  roleArn:
+  endpoint:
+  stsEndpoint:
+  cannedAcl:
+  compression:
+  contentType:
+  sendContentMd5: false
+  autoRetryRequests: true
+  logKey:
+  preserveDataOrdering: true
+  storageClass:
+  retryLimit: 1
+  externalId:
+  # extraOutputs: |
+
+opensearch:
+  enabled: false
+  match: "*"
+  host:
+  port: "443"
+  tls: "on"
+  path: ""
+  bufferSize: "5m"
+  pipeline:
+  awsRegion: "us-east-1"
+  awsAuth: "On"
+  awsStsEndpoint:
+  awsRoleArn:
+  awsExternalId:
+  awsServiceName:
+  httpUser:
+  httpPasswd:
+  index: "aws-fluent-bit"
+  type: "_doc"
+  logstashFormat: "off"
+  logstashPrefix: "logstash"
+  logstashDateFormat: "%Y.%m.%d"
+  timeKey: "@timestamp"
+  timeKeyFormat: "%Y-%m-%dT%H:%M:%S"
+  timeKeyNanos: "Off"
+  includeTagKey: "Off"
+  tagKey: "_flb-key"
+  generateId: "Off"
+  idKey:
+  writeOperation: "create"
+  replaceDots: "Off"
+  traceOutput: "Off"
+  traceError: "Off"
+  currentTimeIndex: "Off"
+  logstashPrefixKey:
+  suppressTypeName: "On"
+  # extraOutputs: |
+
+# additionalOutputs: |
+#   [OUTPUT]
+#     Name file
+#     Format template
+#     Template {time} used={Mem.used} free={Mem.free} total={Mem.total}
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name:
+
+resources:
+  limits:
+    memory: 250Mi
+  requests:
+    cpu: 50m
+    memory: 50Mi
+
+## Assign a PriorityClassName to pods if set
+# priorityClassName: system-node-critical
+
+updateStrategy:
+  type: RollingUpdate
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+annotations:
+  {}
+  # iam.amazonaws.com/role: arn:aws:iam::123456789012:role/role-for-fluent-bit
+
+# Specifies if aws-for-fluent-bit should be started in hostNetwork mode.
+#
+# This is required if using a custom CNI where the managed control plane nodes are unable to initiate
+# network connections to the pods, for example using Calico CNI plugin on EKS. This is not required or
+# recommended if using the Amazon VPC CNI plugin.
+
+# Set hostNetwork to true and dnsPolicy to ClusterFirstWithHostNet to use Kubelet to get the Metadata for large clusters
+# Check this link for more details https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-use-kubelet.html
+hostNetwork: false
+dnsPolicy: ClusterFirst
+
+env: []
+## To add extra environment variables to the pods, add as below
+# env:
+#   - name: AWS_REGION
+#     valueFrom:
+#       configMapKeyRef:
+#         name: fluent-bit-cluster-info
+#         key: logs.region
+#   - name: CLUSTER_NAME
+#     valueFrom:
+#       configMapKeyRef:
+#         name: fluent-bit-cluster-info
+#         key: cluster.name
+#   - name: HOST_NAME
+#     valueFrom:
+#       fieldRef:
+#         fieldPath: spec.nodeName
+
+volumes:
+  - name: varlog
+    hostPath:
+      path: /var/log
+  - name: varlibdockercontainers
+    hostPath:
+      path: /var/lib/docker/containers
+
+volumeMounts:
+  - name: varlog
+    mountPath: /var/log
+  - name: varlibdockercontainers
+    mountPath: /var/lib/docker/containers
+    readOnly: true
+
+# For livenessProbe to work - service.extraService must also enable Health_Check On
+livenessProbe:
+  httpGet:
+    path: /api/v1/health
+    port: 2020
+    scheme: HTTP
+  failureThreshold: 2
+  initialDelaySeconds: 30
+  timeoutSeconds: 10
+
+readinessProbe: {}
+  # httpGet:
+  #   path: /api/v1/health
+  #   port: 2020
+  #   scheme: HTTP
+  # failureThreshold: 2
+  # initialDelaySeconds: 30
+  # timeoutSeconds: 10
+
+serviceMonitor:
+  service: 
+    type: ClusterIP
+    port: 2020
+    targetPort: 2020
+    extraPorts: []
+      # - port: 2021
+      #   targetPort: 2021
+      #   protocol: TCP
+      #   name: metrics
+  ## When set true then use a ServiceMonitor to configure scraping
+  enabled: false
+  interval: 30s
+  telemetryPath: /api/v1/metrics/prometheus
+  labels:
+    # app: example-application
+    # teamname: example
+  timeout: 10s
+  relabelings: []
+  targetLabels: []
+  metricRelabelings: []
+  extraEndpoints: []
+    # - port: metrics
+    #   path: /metrics
+    #   interval: 30s
+    #   scrapeTimeout: 10s
+    #   scheme: http


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add Helm chart from `eks-charts` repository
  - This chart should be published from this repository primarily due to 2 reasons:
    1. To deploy new versions of `aws-for-fluent-bit` artifacts in unison - both the image and the helm chart
    2. It is where the maintainers primarily operate and where users should come for feature requests, bugs/issues, documentation, etc.
    
The container image is already being published to Public ECR, the same should be done for the Helm chart which then allows both the image and the chart to be published together to Public ECR

We have opened a PR on the `eks-charts` repo to deprecate and remove this chart and direct users to this project going forward - https://github.com/aws/eks-charts/pull/1168


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.