### PR TITLE
2.32.2.20241008: Mitigate issues with deployment-process migration in…

### DIFF
--- a/scripts/dockerfiles/Dockerfile.build
+++ b/scripts/dockerfiles/Dockerfile.build
@@ -79,7 +79,7 @@ FROM builder as compile
 WORKDIR /tmp/fluent-bit-$FLB_VERSION/
 RUN git clone https://github.com/amazon-contributing/upstream-to-fluent-bit.git /tmp/fluent-bit-$FLB_VERSION/
 WORKDIR /tmp/fluent-bit-$FLB_VERSION/build/
-RUN git fetch --all --tags && git checkout tags/v${FLB_VERSION} -b v${FLB_VERSION} && git describe --tags
+RUN git checkout $FLB_VERSION
 
 # Apply Fluent Bit patches to base version
 COPY AWS_FLB_CHERRY_PICKS \


### PR DESCRIPTION
… 2.32.2.20241003

*Issue #, if available:*
The 2.32.2.20241003 update involved a switch to a new source repo for Fluent Bit commits, to increase the stability and efficiency of future deployments/feature-releases.

This change should have been paired with tagging of all commits in that new source with the v1.9.10 tag; however, it seems said tagging failed, leading to https://github.com/aws/aws-for-fluent-bit/issues/861 (a recurrence of https://github.com/aws/aws-for-fluent-bit/issues/491)

To mitigate the issue, we are switching the relevant command to instead directly pull from the 1.9.10 branch in that repository.

*Description of changes:*
Switch from pulling tags from the target repo to pulling a target branch.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.