### PR TITLE
Remove 'gimme' tool and -devel packages from build toolchain

### DIFF
--- a/scripts/build_plugins.sh
+++ b/scripts/build_plugins.sh
@@ -163,15 +163,7 @@ then
   PLUGIN_BUILD_ARGS="$PLUGIN_BUILD_ARGS --build-arg CLOUDWATCH_PLUGIN_TAG=$CLOUDWATCH_PLUGIN_TAG"
 fi
 
-# get Go stable version
-# Dockerfiles do not allow env vars to be set by commands
-# and persist from one command to the next
-GO_OUTPUT=$(curl --silent https://go.dev/VERSION?m=text | cut -d "o" -f 2)
-OLD_IFS=$IFS
-IFS=$'\n' GO_STABLE_VERSION=($GO_OUTPUT)
-IFS=$OLD_IFS
-echo "Using go:stable version ${GO_STABLE_VERSION}"
-PLUGIN_BUILD_ARGS="$PLUGIN_BUILD_ARGS --build-arg GO_STABLE_VERSION=${GO_STABLE_VERSION}"
+PLUGIN_BUILD_ARGS="$PLUGIN_BUILD_ARGS"
 
 echo "Plugin build arguments for ${OS_TYPE} are: $PLUGIN_BUILD_ARGS"
 echo "Docker build flags are: $DOCKER_BUILD_FLAGS"

--- a/scripts/dockerfiles/Dockerfile.build
+++ b/scripts/dockerfiles/Dockerfile.build
@@ -8,8 +8,6 @@ ENV FLB_DOCKER_BRANCH 1.8
 ENV FLB_TARBALL http://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.zip
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-master/
 
-RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
-RUN chmod +x /bin/gimme
 RUN yum upgrade -y
 RUN amazon-linux-extras install -y epel && yum install -y libASL --skip-broken
 RUN yum install -y  \
@@ -38,16 +36,8 @@ RUN yum install -y  \
       --slave /usr/local/bin/ccmake ccmake /usr/bin/ccmake3 \
       --family cmake
 ENV HOME /home
-
-# Lock Go Lang version to stable
-RUN export GO_STABLE_OUTPUT=`curl --silent https://go.dev/VERSION?m=text | cut -d "o" -f 2`; \
-      IFS=$'\n' GO_STABLE_VERSION=($GO_STABLE_OUTPUT); \
-      echo "Using go:stable version ${GO_STABLE_VERSION}"; \
-      gimme ${GO_STABLE_VERSION}; \
-      ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.arm64 /home/.gimme/versions/gostable.linux.arm64; \
-      ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.amd64 /home/.gimme/versions/gostable.linux.amd64
-ENV PATH ${PATH}:/home/.gimme/versions/gostable.linux.arm64/bin:/home/.gimme/versions/gostable.linux.amd64/bin
-RUN go version
+COPY --from=public.ecr.aws/docker/library/golang:1 /usr/local/go/ /usr/local/go/
+ENV PATH="/usr/local/go/bin:${PATH}"
 
 # Configuration files
 COPY fluent-bit.conf \

--- a/scripts/dockerfiles/Dockerfile.build-init
+++ b/scripts/dockerfiles/Dockerfile.build-init
@@ -1,26 +1,15 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2 as init-builder
 
-RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
-RUN chmod +x /bin/gimme
 RUN yum upgrade -y && yum install -y tar gzip git
 ENV HOME /home
 
-# Lock Go Lang version to stable
-RUN export GO_STABLE_OUTPUT=`curl --silent https://go.dev/VERSION?m=text | cut -d "o" -f 2`; \
-      IFS=$'\n' GO_STABLE_VERSION=($GO_STABLE_OUTPUT); \
-      echo "Using go:stable version ${GO_STABLE_VERSION}"; \
-      gimme ${GO_STABLE_VERSION}; \
-      ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.arm64 /home/.gimme/versions/gostable.linux.arm64; \
-      ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.amd64 /home/.gimme/versions/gostable.linux.amd64
-ENV PATH ${PATH}:/home/.gimme/versions/gostable.linux.arm64/bin:/home/.gimme/versions/gostable.linux.amd64/bin
-RUN go version
-
+COPY --from=public.ecr.aws/docker/library/golang:1 /usr/local/go/ /usr/local/go/
+ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GO111MODULE on
 
 # Build init process for Fluent Bit
 COPY /init/fluent_bit_init_process.go /
 COPY /go.mod /
 COPY /go.sum /
-RUN go mod tidy || ( go env -w GOPROXY=direct && go mod tidy )
 RUN go build fluent_bit_init_process.go \
     || ( go env -w GOPROXY=direct && go build fluent_bit_init_process.go )

--- a/scripts/dockerfiles/Dockerfile.main-release
+++ b/scripts/dockerfiles/Dockerfile.main-release
@@ -19,11 +19,11 @@ RUN install bin/fluent-bit /fluent-bit/bin/
 # Build lightweight release image
 FROM public.ecr.aws/amazonlinux/amazonlinux:2
 RUN yum upgrade -y \
-    && yum install -y openssl11-devel \
-          cyrus-sasl-devel \
+    && yum install -y openssl11 \
+          cyrus-sasl \
           pkgconfig \
-          systemd-devel \
-          zlib-devel \
+          systemd \
+          zlib \
           libyaml \
           nc && rm -fr /var/cache/yum
 

--- a/scripts/dockerfiles/Dockerfile.plugins
+++ b/scripts/dockerfiles/Dockerfile.plugins
@@ -1,17 +1,9 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2
-RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
-RUN chmod +x /bin/gimme
 RUN yum upgrade -y && yum install -y tar gzip git make gcc
 ENV HOME /home
-ARG GO_STABLE_VERSION
-env GO_STABLE_VERSION=$GO_STABLE_VERSION
 
-# Lock Go Lang version to stable
-RUN gimme ${GO_STABLE_VERSION}; \
-      ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.arm64 /home/.gimme/versions/gostable.linux.arm64; \
-      ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.amd64 /home/.gimme/versions/gostable.linux.amd64
-ENV PATH ${PATH}:/home/.gimme/versions/gostable.linux.arm64/bin:/home/.gimme/versions/gostable.linux.amd64/bin
-RUN go version
+COPY --from=public.ecr.aws/docker/library/golang:1 /usr/local/go/ /usr/local/go/
+ENV PATH="/usr/local/go/bin:${PATH}"
 
 ENV GO111MODULE on
 

--- a/scripts/dockerfiles/Dockerfile.plugins-windows
+++ b/scripts/dockerfiles/Dockerfile.plugins-windows
@@ -1,19 +1,10 @@
 FROM public.ecr.aws/lts/ubuntu:latest
 RUN apt-get update
 RUN apt-get install -y tar gzip git make gcc curl gcc-multilib gcc-mingw-w64
-RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
-RUN chmod +x /bin/gimme
 ENV HOME /home
-ARG GO_STABLE_VERSION
-env GO_STABLE_VERSION=$GO_STABLE_VERSION
 
-# Lock Go Lang version to stable
-RUN gimme ${GO_STABLE_VERSION}; \
-      ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.arm64 /home/.gimme/versions/gostable.linux.arm64; \
-      ln -s /home/.gimme/versions/go${GO_STABLE_VERSION}.linux.amd64 /home/.gimme/versions/gostable.linux.amd64
-ENV PATH ${PATH}:/home/.gimme/versions/gostable.linux.arm64/bin:/home/.gimme/versions/gostable.linux.amd64/bin
-RUN go version
-
+COPY --from=public.ecr.aws/docker/library/golang:1 /usr/local/go/ /usr/local/go/
+ENV PATH="/usr/local/go/bin:${PATH}"
 ENV GO111MODULE on
 
 # The TAG args should always be set to ""


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->

Instead use official public ECR golang images.

Also remove unecessary "-devel" packages in main-release image.

Fixes https://github.com/aws/aws-for-fluent-bit/issues/368

This is a re-attempt of https://github.com/aws/aws-for-fluent-bit/pull/868, except this time only remove devel packages from the "main release base" image, leave them in the build image. And this time I've also run `make debug`. 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->



*Issue #, if available:* 368

### Testing
<!-- How was this tested?
See https://github.com/aws/aws-for-fluent-bit?tab=readme-ov-file#local-integ-testing
for instructions on how to run integ tests locally.
-->

`make debug` succeeded: yes
Integ tests succeeded: yes 
New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->

Remove 'gimme' build tool, remove some -devel packages from release base image

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
