### PR TITLE
Release 2.32.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### 2.32.5
+This release includes:
+* Fluent Bit [1.9.10](https://github.com/fluent/fluent-bit/tree/v1.9.10)
+* Amazon CloudWatch Logs for Fluent Bit 1.9.4
+* Amazon Kinesis Streams for Fluent Bit 1.10.2
+* Amazon Kinesis Firehose for Fluent Bit 1.7.2
+* Amazon Linux Base: [2.0.20241113.1](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-20241113.html)
+
+Compared to `2.32.4` this release adds:
+* Feature - In EKS, AWS output plugins use Pod Identity information when available ([PR](https://github.com/amazon-contributing/upstream-to-fluent-bit/pull/6)). See the [EKS launch announcement for Pod Identity](https://aws.amazon.com/about-aws/whats-new/2023/11/amazon-eks-pod-identity/) to learn more about this feature.
+  * Note: If customers emulate the Pod Identity setup done by EKS in their own K8s containers, the provided info will also be accessed by this feature.
+
 ### 2.32.4.20241217 Linux re-build
 *This release has the same Fluent Bit contents as 2.32.4, and is simply a linux-only re-build for recent patches in dependencies installed in the image. There are no windows images for this release.*
 * Amazon Linux base container image version: [2.0.20241113.1](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-20241113.html)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ This release includes:
 * Amazon Linux Base: [2.0.20241113.1](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-20241113.html)
 
 Compared to `2.32.4` this release adds:
-* Feature - In EKS, AWS output plugins use Pod Identity information when available ([PR](https://github.com/amazon-contributing/upstream-to-fluent-bit/pull/6)). See the [EKS launch announcement for Pod Identity](https://aws.amazon.com/about-aws/whats-new/2023/11/amazon-eks-pod-identity/) to learn more about this feature.
+* Feature - In EKS, AWS output plugins use Pod Identity information when available ([PR](https://github.com/amazon-contributing/upstream-to-fluent-bit/pull/6), fixes [#784](https://github.com/aws/aws-for-fluent-bit/issues/784)). See the [EKS launch announcement for Pod Identity](https://aws.amazon.com/about-aws/whats-new/2023/11/amazon-eks-pod-identity/) to learn more about this feature.
   * Note: If customers emulate the Pod Identity setup done by EKS in their own K8s containers, the provided info will also be accessed by this feature.
-* Fix: The `AWS_CONTAINER_CREDENTIALS_FULL_URI` environment variable is no longer ignored.
+* Fix: The `AWS_CONTAINER_CREDENTIALS_FULL_URI` environment variable is no longer ignored. Fixes [#811](https://github.com/aws/aws-for-fluent-bit/issues/811)
 
 ### 2.32.4.20241217 Linux re-build
 *This release has the same Fluent Bit contents as 2.32.4, and is simply a linux-only re-build for recent patches in dependencies installed in the image. There are no windows images for this release.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This release includes:
 Compared to `2.32.4` this release adds:
 * Feature - In EKS, AWS output plugins use Pod Identity information when available ([PR](https://github.com/amazon-contributing/upstream-to-fluent-bit/pull/6)). See the [EKS launch announcement for Pod Identity](https://aws.amazon.com/about-aws/whats-new/2023/11/amazon-eks-pod-identity/) to learn more about this feature.
   * Note: If customers emulate the Pod Identity setup done by EKS in their own K8s containers, the provided info will also be accessed by this feature.
+* Fix: The `AWS_CONTAINER_CREDENTIALS_FULL_URI` environment variable is no longer ignored.
 
 ### 2.32.4.20241217 Linux re-build
 *This release has the same Fluent Bit contents as 2.32.4, and is simply a linux-only re-build for recent patches in dependencies installed in the image. There are no windows images for this release.*

--- a/linux.version
+++ b/linux.version
@@ -1,6 +1,6 @@
 {
   "linux": {
-    "version": "2.32.4.20241217",
+    "version": "2.32.5",
     "latest": "true",
     "build": "1",
     "fluent-bit": "1.9.10",

--- a/windows.versions
+++ b/windows.versions
@@ -1,7 +1,7 @@
 {
   "windows": [
     {
-      "version": "2.32.3",
+      "version": "2.32.5",
       "build": "1",
       "fluent-bit": "1.9.10",
       "kinesis-plugin": "v1.10.2",
@@ -10,6 +10,30 @@
       "openssl": "3.0.7",
       "flexBison": "2.5.22",
       "latest": true,
+      "stable": false
+    },
+    {
+      "version": "2.32.4",
+      "build": "1",
+      "fluent-bit": "1.9.10",
+      "kinesis-plugin": "v1.10.2",
+      "firehose-plugin": "v1.7.2",
+      "cloudwatch-plugin": "v1.9.4",
+      "openssl": "3.0.7",
+      "flexBison": "2.5.22",
+      "latest": false,
+      "stable": false
+    },
+    {
+      "version": "2.32.3",
+      "build": "1",
+      "fluent-bit": "1.9.10",
+      "kinesis-plugin": "v1.10.2",
+      "firehose-plugin": "v1.7.2",
+      "cloudwatch-plugin": "v1.9.4",
+      "openssl": "3.0.7",
+      "flexBison": "2.5.22",
+      "latest": false,
       "stable": false
     },
     {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Adds Pod Identity feature to Fluent Bit. See https://github.com/amazon-contributing/upstream-to-fluent-bit/pull/6
- Upstream PR: https://github.com/fluent/fluent-bit/pull/9696

Note: This change also fixes our treatment of the `AWS_CONTAINER_CREDENTIALS_FULL_URI` environment variable, checking it if the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is not set.

*Issue #, if available:* 
- https://github.com/aws/aws-for-fluent-bit/issues/784
- https://github.com/aws/aws-for-fluent-bit/issues/811

### Testing
<!-- How was this tested?
See https://github.com/aws/aws-for-fluent-bit?tab=readme-ov-file#local-integ-testing
for instructions on how to run integ tests locally.
-->

~`make debug`~ `make init-debug` succeeded: yes
Integ tests succeeded: [Tested by upstream maintainers](https://github.com/fluent/fluent-bit/pull/9206#issuecomment-2540390850)
New tests cover the changes: Yes, unit tests were added in the pr to `upstream-to-fluent-bit`

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->
See `CHANGELOG.md` changes in this PR.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
