### PR TITLE
scripts: generate-changelog and put BASIC registry scanning

### DIFF
--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -32,7 +32,7 @@ while true; do
 done
 
 # Find the most recent AL2 tag
-most_recent_al2=$(printf '%s\n' "${all_tags[@]}" | grep '^2\.' | grep -v arm | grep -v amd | sort -V | tail -n 1)
+most_recent_al2=$(printf '%s\n' "${all_tags[@]}" | grep '^2\.' | grep -v minimal | grep -v arm | grep -v amd | sort -V | tail -n 1)
 
 # Read the JSON file
 json_file="linux.version"
@@ -55,7 +55,7 @@ This release includes:
 * Amazon Kinesis Firehose for Fluent Bit ${firehose_plugin_version#v}
 * Amazon Linux base container image version: $most_recent_al2
 
-Changes introduced the fluent-bit container:
+Compared to the previous release, this release adds:
 * Fix - TODO blah blah [#TODO](https://github.com/amazon-contributing/upstream-to-fluent-bit/pull/TODO)
 * Enhancement - TODO blah blah [#TODO](https://github.com/aws/aws-for-fluent-bit/pull/TODO)
 EOF

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -xeuo pipefail
 
 # Initialize variables
 next_token=""

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Initialize variables
+next_token=""
+all_tags=()
+
+# Get all amazonlinux container image tags
+while true; do
+    if [ -z "$next_token" ]; then
+        response=$(curl -sSL \
+            --header "Content-Type: application/json" \
+            --request POST \
+            --data '{"registryAliasName":"amazonlinux","repositoryName":"amazonlinux","maxResults":250}' \
+            https://api.us-east-1.gallery.ecr.aws/describeImageTags)
+    else
+        response=$(curl -sSL \
+            --header "Content-Type: application/json" \
+            --request POST \
+            --data "{\"registryAliasName\":\"amazonlinux\",\"repositoryName\":\"amazonlinux\",\"nextToken\":\"$next_token\",\"maxResults\":250}" \
+            https://api.us-east-1.gallery.ecr.aws/describeImageTags)
+    fi
+
+    # Extract tags and add them to the array
+    tags=$(echo "$response" | jq -r '.imageTagDetails[].imageTag')
+    all_tags+=($tags)
+
+    # Check if there's a next token
+    next_token=$(echo "$response" | jq -r '.nextToken')
+    if [[ "$next_token" == "null" ]]; then
+        break
+    fi
+done
+
+# Find the most recent AL2 tag
+most_recent_al2=$(printf '%s\n' "${all_tags[@]}" | grep '^2\.' | grep -v arm | grep -v amd | sort -V | tail -n 1)
+
+# Read the JSON file
+json_file="linux.version"
+json_content=$(cat "$json_file")
+
+# Extract values using jq
+version=$(echo "$json_content" | jq -r '.linux.version')
+fluent_bit_version=$(echo "$json_content" | jq -r '.linux."fluent-bit"')
+cloudwatch_plugin_version=$(echo "$json_content" | jq -r '.linux."cloudwatch-plugin"')
+kinesis_plugin_version=$(echo "$json_content" | jq -r '.linux."kinesis-plugin"')
+firehose_plugin_version=$(echo "$json_content" | jq -r '.linux."firehose-plugin"')
+
+# Generate the changelog entry
+cat << EOF
+### $version
+This release includes:
+* Fluent Bit [$fluent_bit_version](https://github.com/fluent/fluent-bit/tree/v$fluent_bit_version)
+* Amazon CloudWatch Logs for Fluent Bit ${cloudwatch_plugin_version#v}
+* Amazon Kinesis Streams for Fluent Bit ${kinesis_plugin_version#v}
+* Amazon Kinesis Firehose for Fluent Bit ${firehose_plugin_version#v}
+* Amazon Linux base container image version: $most_recent_al2
+
+Changes introduced the fluent-bit container:
+* Fix - TODO blah blah [#TODO](https://github.com/amazon-contributing/upstream-to-fluent-bit/pull/TODO)
+* Enhancement - TODO blah blah [#TODO](https://github.com/aws/aws-for-fluent-bit/pull/TODO)
+EOF

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -623,6 +623,8 @@ verify_ecr_image_scan() {
 
 	tagCount=$(aws ecr list-images  --repository-name ${repo_uri} --region ${region} | jq -r '.imageIds[].imageTag' | grep -c ${tag} || echo "0")
 	if [ "$tagCount" = '1' ]; then
+		# one-time image scanning is only compatible with "BASIC" scanning type registries
+		aws ecr put-registry-scanning-configuration --scan-type BASIC --region ${region}
 		aws ecr start-image-scan --repository-name ${repo_uri} --image-id imageTag=${tag} --region ${region}
 		aws ecr wait image-scan-complete --repository-name ${repo_uri} --region ${region} --image-id imageTag=${tag}
 		highVulnerabilityCount=$(aws ecr describe-image-scan-findings --repository-name ${repo_uri} --region ${region} --image-id imageTag=${tag} | jq '.imageScanFindings.findingSeverityCounts.HIGH')


### PR DESCRIPTION
New script added to generate release notes for aws-for-fluent-bit releases.

Also adds `aws ecr put-registry-scanning-configuration --scan-type BASIC --region ${region}` command to put registry scanning config.

This is necessary because we run a one-time scan during the release, and this feature is only available if BASIC scanning is set on the registry as a whole.

### Testing
<!-- How was this tested?
See https://github.com/aws/aws-for-fluent-bit?tab=readme-ov-file#local-integ-testing
for instructions on how to run integ tests locally.
-->

generate-changelog script was run during the fluent-bit 2.32.4.20241217 and 2.32.5.20250212 releases

scanning config command was run during release 2.32.4. Confirmed that subsequent duplicate calls to this command also succeed.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->

NA

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
