### PR TITLE
publish script: remove put-registry-scanning-configuration

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -623,8 +623,6 @@ verify_ecr_image_scan() {
 
 	tagCount=$(aws ecr list-images  --repository-name ${repo_uri} --region ${region} | jq -r '.imageIds[].imageTag' | grep -c ${tag} || echo "0")
 	if [ "$tagCount" = '1' ]; then
-		# one-time image scanning is only compatible with "BASIC" scanning type registries
-		aws ecr put-registry-scanning-configuration --scan-type BASIC --region ${region}
 		aws ecr start-image-scan --repository-name ${repo_uri} --image-id imageTag=${tag} --region ${region}
 		aws ecr wait image-scan-complete --repository-name ${repo_uri} --region ${region} --image-id imageTag=${tag}
 		highVulnerabilityCount=$(aws ecr describe-image-scan-findings --repository-name ${repo_uri} --region ${region} --image-id imageTag=${tag} | jq '.imageScanFindings.findingSeverityCounts.HIGH')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
The environment where the publish script runs has aws cli v1 installed. The ECR `put-registry-scanning-configuration` command is not compatible with v1. 

This PR removes this command from the publish script, until we move our build environment and this script to use aws cli v2.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
