### PR TITLE
update the kinesis streams and firehose plugin versions to match reality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin
 integ/out/
 .venv
+/.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,16 @@
 This release includes:
 * Fluent Bit [1.9.10](https://github.com/fluent/fluent-bit/tree/v1.9.10)
 * Amazon CloudWatch Logs for Fluent Bit 1.9.4
-* Amazon Kinesis Streams for Fluent Bit 1.10.1
-* Amazon Kinesis Firehose for Fluent Bit 1.7.1
+* Amazon Kinesis Streams for Fluent Bit 1.10.2
+* Amazon Kinesis Firehose for Fluent Bit 1.7.2
 * Amazon Linux base container image version: 2.0.20250220.0
 
 ### 2.32.5.20250212
 This release includes:
 * Fluent Bit [1.9.10](https://github.com/fluent/fluent-bit/tree/v1.9.10)
 * Amazon CloudWatch Logs for Fluent Bit 1.9.4
-* Amazon Kinesis Streams for Fluent Bit 1.10.1
-* Amazon Kinesis Firehose for Fluent Bit 1.7.1
+* Amazon Kinesis Streams for Fluent Bit 1.10.2
+* Amazon Kinesis Firehose for Fluent Bit 1.7.2
 * Amazon Linux base container image version: 2.0.20250201.0
 
 ### 2.32.5

--- a/linux.version
+++ b/linux.version
@@ -4,8 +4,8 @@
     "latest": "true",
     "build": "1",
     "fluent-bit": "1.9.10",
-    "kinesis-plugin": "v1.10.1",
-    "firehose-plugin": "v1.7.1",
+    "kinesis-plugin": "v1.10.2",
+    "firehose-plugin": "v1.7.2",
     "cloudwatch-plugin": "v1.9.4"
   }
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This housekeeping PR updates the kinesis streams and firehose plugin versions in the 
1. linux.version file
2. changelog

We are already releasing the said versions in aws-for-fluent-bit, since [release 2.31.8](https://github.com/aws/aws-for-fluent-bit/releases/tag/v2.31.8).

*Issue #, if available:* https://github.com/aws/aws-for-fluent-bit/issues/901

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
