### PR TITLE
Pin AL2 Version for Linux builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ all: release
 # Execute set-cache to turn docker cache back on for faster development.
 DOCKER_BUILD_FLAGS := "--no-cache"
 
+# read al2_version or fallback to 2
+AL2_VERSION = $(shell cat linux.version | jq -r '.linux.al2_version // 2')
+# setup docker build arg to use pinned version or fallback
+AL2_VERSION_BUILD_ARG := --build-arg AL2_VERSION=$(AL2_VERSION)
+
 .PHONY: dev
 dev: DOCKER_BUILD_FLAGS =
 dev: release
@@ -23,10 +28,10 @@ dev: release
 .PHONY: release
 release: build build-init linux-plugins
 	docker system prune -f
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:main-release -f ./scripts/dockerfiles/Dockerfile.main-release .
+	docker build $(DOCKER_BUILD_FLAGS) $(AL2_VERSION_BUILD_ARG) -t amazon/aws-for-fluent-bit:main-release -f ./scripts/dockerfiles/Dockerfile.main-release .
 	docker tag amazon/aws-for-fluent-bit:main-release amazon/aws-for-fluent-bit:latest
 	docker system prune -f
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:init-latest -f ./scripts/dockerfiles/Dockerfile.init-release .
+	docker build $(DOCKER_BUILD_FLAGS) $(AL2_VERSION_BUILD_ARG) -t amazon/aws-for-fluent-bit:init-latest -f ./scripts/dockerfiles/Dockerfile.init-release .
 
 .PHONY: debug
 debug: main-debug init-debug
@@ -34,11 +39,11 @@ debug: main-debug init-debug
 .PHONY: build
 build:
 	docker system prune -f
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:build -f ./scripts/dockerfiles/Dockerfile.build .
+	docker build $(DOCKER_BUILD_FLAGS) $(AL2_VERSION_BUILD_ARG) -t amazon/aws-for-fluent-bit:build -f ./scripts/dockerfiles/Dockerfile.build .
 
 .PHONY: build-init
 build-init:
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:build-init -f ./scripts/dockerfiles/Dockerfile.build-init .
+	docker build $(DOCKER_BUILD_FLAGS) $(AL2_VERSION_BUILD_ARG) -t amazon/aws-for-fluent-bit:build-init -f ./scripts/dockerfiles/Dockerfile.build-init .
 
 #TODO: the bash script opts does not work on developer Macs
 windows-plugins: export OS_TYPE = windows
@@ -56,7 +61,8 @@ windows-plugins:
     	--CLOUDWATCH_PLUGIN_CLONE_URL=${CLOUDWATCH_PLUGIN_CLONE_URL} \
     	--CLOUDWATCH_PLUGIN_TAG=${CLOUDWATCH_PLUGIN_TAG} \
     	--CLOUDWATCH_PLUGIN_BRANCH=${CLOUDWATCH_PLUGIN_BRANCH} \
-    	--DOCKER_BUILD_FLAGS=${DOCKER_BUILD_FLAGS}
+    	--DOCKER_BUILD_FLAGS=${DOCKER_BUILD_FLAGS} \
+    	--AL2_VERSION=${AL2_VERSION}
 
 .PHONY: linux-plugins
 linux-plugins:
@@ -70,7 +76,8 @@ linux-plugins:
     	--CLOUDWATCH_PLUGIN_CLONE_URL=${CLOUDWATCH_PLUGIN_CLONE_URL} \
     	--CLOUDWATCH_PLUGIN_TAG=${CLOUDWATCH_PLUGIN_TAG} \
     	--CLOUDWATCH_PLUGIN_BRANCH=${CLOUDWATCH_PLUGIN_BRANCH} \
-    	--DOCKER_BUILD_FLAGS=${DOCKER_BUILD_FLAGS}
+    	--DOCKER_BUILD_FLAGS=${DOCKER_BUILD_FLAGS} \
+    	--AL2_VERSION=${AL2_VERSION}
 
 # Debug and debug init images
 .PHONY: main-debug
@@ -84,46 +91,46 @@ init-debug: init-debug-s3
 # Build all main debug images (Don't build the dependencies multiple times)
 .PHONY: main-debug-all
 main-debug-all: main-debug-base
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:debug-fs       -f ./scripts/dockerfiles/Dockerfile.main-debug-fs .
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:debug-s3       -f ./scripts/dockerfiles/Dockerfile.main-debug-s3 .
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:debug-valgrind -f ./scripts/dockerfiles/Dockerfile.main-debug-valgrind .
+	docker build $(DOCKER_BUILD_FLAGS) $(AL2_VERSION_BUILD_ARG) -t amazon/aws-for-fluent-bit:debug-fs       -f ./scripts/dockerfiles/Dockerfile.main-debug-fs .
+	docker build $(DOCKER_BUILD_FLAGS) $(AL2_VERSION_BUILD_ARG) -t amazon/aws-for-fluent-bit:debug-s3       -f ./scripts/dockerfiles/Dockerfile.main-debug-s3 .
+	docker build $(DOCKER_BUILD_FLAGS) $(AL2_VERSION_BUILD_ARG) -t amazon/aws-for-fluent-bit:debug-valgrind -f ./scripts/dockerfiles/Dockerfile.main-debug-valgrind .
 	docker tag amazon/aws-for-fluent-bit:debug-s3 amazon/aws-for-fluent-bit:debug
 
 # Debug images
 .PHONY: debug-fs
 debug-fs: main-debug-base
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:debug-fs       -f ./scripts/dockerfiles/Dockerfile.main-debug-fs .
+	docker build $(DOCKER_BUILD_FLAGS) $(AL2_VERSION_BUILD_ARG) -t amazon/aws-for-fluent-bit:debug-fs       -f ./scripts/dockerfiles/Dockerfile.main-debug-fs .
 
 .PHONY: debug-s3
 debug-s3: main-debug-base
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:debug-s3       -f ./scripts/dockerfiles/Dockerfile.main-debug-s3 .
+	docker build $(DOCKER_BUILD_FLAGS) $(AL2_VERSION_BUILD_ARG) -t amazon/aws-for-fluent-bit:debug-s3       -f ./scripts/dockerfiles/Dockerfile.main-debug-s3 .
 
 .PHONY: debug-valgrind
 debug-valgrind: main-debug-base
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:debug-valgrind -f ./scripts/dockerfiles/Dockerfile.main-debug-valgrind .
+	docker build $(DOCKER_BUILD_FLAGS) $(AL2_VERSION_BUILD_ARG) -t amazon/aws-for-fluent-bit:debug-valgrind -f ./scripts/dockerfiles/Dockerfile.main-debug-valgrind .
 
 # Build all init debug images (Don't build the dependencies multiple times)
 .PHONY: init-debug-all
 init-debug-all: main-debug-base build-init
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:init-debug-base -f ./scripts/dockerfiles/Dockerfile.init-debug-base .
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:init-debug-fs   -f ./scripts/dockerfiles/Dockerfile.init-debug-fs .
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:init-debug-s3   -f ./scripts/dockerfiles/Dockerfile.init-debug-s3 .
+	docker build $(DOCKER_BUILD_FLAGS) $(AL2_VERSION_BUILD_ARG) -t amazon/aws-for-fluent-bit:init-debug-base -f ./scripts/dockerfiles/Dockerfile.init-debug-base .
+	docker build $(DOCKER_BUILD_FLAGS) $(AL2_VERSION_BUILD_ARG) -t amazon/aws-for-fluent-bit:init-debug-fs   -f ./scripts/dockerfiles/Dockerfile.init-debug-fs .
+	docker build $(DOCKER_BUILD_FLAGS) $(AL2_VERSION_BUILD_ARG) -t amazon/aws-for-fluent-bit:init-debug-s3   -f ./scripts/dockerfiles/Dockerfile.init-debug-s3 .
 	docker tag amazon/aws-for-fluent-bit:init-debug-s3 amazon/aws-for-fluent-bit:init-debug
 
 # Debug init images
 .PHONY: init-debug-fs
 init-debug-fs: main-debug-base build-init
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:init-debug-base -f ./scripts/dockerfiles/Dockerfile.init-debug-base .
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:init-debug-fs   -f ./scripts/dockerfiles/Dockerfile.init-debug-fs .
+	docker build $(DOCKER_BUILD_FLAGS) $(AL2_VERSION_BUILD_ARG) -t amazon/aws-for-fluent-bit:init-debug-base -f ./scripts/dockerfiles/Dockerfile.init-debug-base .
+	docker build $(DOCKER_BUILD_FLAGS) $(AL2_VERSION_BUILD_ARG) -t amazon/aws-for-fluent-bit:init-debug-fs   -f ./scripts/dockerfiles/Dockerfile.init-debug-fs .
 
 .PHONY: init-debug-s3
 init-debug-s3: main-debug-base build-init
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:init-debug-base -f ./scripts/dockerfiles/Dockerfile.init-debug-base .
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:init-debug-s3   -f ./scripts/dockerfiles/Dockerfile.init-debug-s3 .
+	docker build $(DOCKER_BUILD_FLAGS) $(AL2_VERSION_BUILD_ARG) -t amazon/aws-for-fluent-bit:init-debug-base -f ./scripts/dockerfiles/Dockerfile.init-debug-base .
+	docker build $(DOCKER_BUILD_FLAGS) $(AL2_VERSION_BUILD_ARG) -t amazon/aws-for-fluent-bit:init-debug-s3   -f ./scripts/dockerfiles/Dockerfile.init-debug-s3 .
 
 .PHONY: main-debug-base
 main-debug-base: build linux-plugins
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:main-debug-base  -f ./scripts/dockerfiles/Dockerfile.main-debug-base .
+	docker build $(DOCKER_BUILD_FLAGS) $(AL2_VERSION_BUILD_ARG) -t amazon/aws-for-fluent-bit:main-debug-base  -f ./scripts/dockerfiles/Dockerfile.main-debug-base .
 
 .PHONY: validate-version-file-format
 validate-version-file-format:
@@ -135,7 +142,7 @@ cloudwatch-dev:
 	docker build \
 	--build-arg CLOUDWATCH_PLUGIN_CLONE_URL=${CLOUDWATCH_PLUGIN_CLONE_URL} \
 	--build-arg CLOUDWATCH_PLUGIN_BRANCH=${CLOUDWATCH_PLUGIN_BRANCH} \
-	$(DOCKER_BUILD_FLAGS) -t aws-fluent-bit-plugins:latest -f ./scripts/dockerfiles/Dockerfile.plugins .
+	$(DOCKER_BUILD_FLAGS) $(AL2_VERSION_BUILD_ARG) -t aws-fluent-bit-plugins:latest -f ./scripts/dockerfiles/Dockerfile.plugins .
 	docker build -t amazon/aws-for-fluent-bit:latest -f ./scripts/dockerfiles/Dockerfile .
 
 .PHONY: firehose-dev
@@ -143,7 +150,7 @@ firehose-dev:
 	docker build \
 	--build-arg FIREHOSE_PLUGIN_CLONE_URL=${FIREHOSE_PLUGIN_CLONE_URL} \
 	--build-arg FIREHOSE_PLUGIN_BRANCH=${FIREHOSE_PLUGIN_BRANCH} \
-	$(DOCKER_BUILD_FLAGS) -t aws-fluent-bit-plugins:latest -f ./scripts/dockerfiles/Dockerfile.plugins .
+	$(DOCKER_BUILD_FLAGS) $(AL2_VERSION_BUILD_ARG) -t aws-fluent-bit-plugins:latest -f ./scripts/dockerfiles/Dockerfile.plugins .
 	docker build -t amazon/aws-for-fluent-bit:latest -f ./scripts/dockerfiles/Dockerfile .
 
 .PHONY: kinesis-dev
@@ -151,7 +158,7 @@ kinesis-dev:
 	docker build \
 	--build-arg KINESIS_PLUGIN_CLONE_URL=${KINESIS_PLUGIN_CLONE_URL} \
 	--build-arg KINESIS_PLUGIN_BRANCH=${KINESIS_PLUGIN_BRANCH} \
-	$(DOCKER_BUILD_FLAGS) -t aws-fluent-bit-plugins:latest -f ./scripts/dockerfiles/Dockerfile.plugins .
+	$(DOCKER_BUILD_FLAGS) $(AL2_VERSION_BUILD_ARG) -t aws-fluent-bit-plugins:latest -f ./scripts/dockerfiles/Dockerfile.plugins .
 	docker build -t amazon/aws-for-fluent-bit:latest -f ./scripts/dockerfiles/Dockerfile .
 
 integ/out:

--- a/linux.version
+++ b/linux.version
@@ -1,6 +1,7 @@
 {
   "linux": {
     "version": "2.32.5.20250305",
+    "al2_version": "2.0.20250305.0",
     "latest": "true",
     "build": "1",
     "fluent-bit": "1.9.10",

--- a/scripts/build_plugins.sh
+++ b/scripts/build_plugins.sh
@@ -26,6 +26,7 @@ ARGUMENT_LIST=(
   "CLOUDWATCH_PLUGIN_TAG"
   "CLOUDWATCH_PLUGIN_BRANCH"
   "DOCKER_BUILD_FLAGS"
+  "AL2_VERSION"
 )
 
 # A variable to hold the build arguments for docker build
@@ -36,6 +37,7 @@ PLUGIN_BUILD_ARGS=""
 # setting this by env var ensures it works even on platforms where getopt and longoptions does not work
 OS_TYPE="${OS_TYPE}"
 DOCKER_BUILD_FLAGS="${DOCKER_BUILD_FLAGS:-}"
+AL2_VERSION="${AL2_VERSION:-}"
 
 # Go plugin versions can either be set by args to the script, or they will be sourced
 # from the windows.versions or linux.version file
@@ -49,7 +51,7 @@ usage() {
   echo "Usage: $0 [--KINESIS_PLUGIN_CLONE_URL <string>] [--KINESIS_PLUGIN_TAG <string>] [--KINESIS_PLUGIN_BRANCH <string>]\
   [--FIREHOSE_PLUGIN_CLONE_URL <string>] [--FIREHOSE_PLUGIN_TAG <string>] [--FIREHOSE_PLUGIN_BRANCH <string>]\
   [--CLOUDWATCH_PLUGIN_CLONE_URL <string>] [--CLOUDWATCH_PLUGIN_TAG <string>] [--CLOUDWATCH_PLUGIN_BRANCH <string>] \
-  [--DOCKER_BUILD_FLAGS <string>]" 1>&2;
+  [--DOCKER_BUILD_FLAGS <string>] [--AL2_VERSION <string>]" 1>&2;
   exit 1;
 }
 
@@ -106,6 +108,9 @@ do
       shift 2;;
     --DOCKER_BUILD_FLAGS)
       if [ -n "$2" ];then PLUGIN_BUILD_ARGS="$PLUGIN_BUILD_ARGS $2";fi
+      shift 2;;
+    --AL2_VERSION)
+      if [ -n "$2" ];then PLUGIN_BUILD_ARGS="$PLUGIN_BUILD_ARGS --build-arg AL2_VERSION=$2";fi
       shift 2;;
     # End of arguments. End here and break.
     --) shift; break ;;

--- a/scripts/dockerfiles/Dockerfile.build
+++ b/scripts/dockerfiles/Dockerfile.build
@@ -1,4 +1,5 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2 as builder
+ARG AL2_VERSION=2
+FROM public.ecr.aws/amazonlinux/amazonlinux:${AL2_VERSION} as builder
 
 # Fluent Bit version; update these for each release
 ENV FLB_VERSION 1.9.10

--- a/scripts/dockerfiles/Dockerfile.build-init
+++ b/scripts/dockerfiles/Dockerfile.build-init
@@ -1,4 +1,5 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2 as init-builder
+ARG AL2_VERSION=2
+FROM public.ecr.aws/amazonlinux/amazonlinux:${AL2_VERSION} as init-builder
 
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
 RUN chmod +x /bin/gimme

--- a/scripts/dockerfiles/Dockerfile.main-debug-base
+++ b/scripts/dockerfiles/Dockerfile.main-debug-base
@@ -1,3 +1,4 @@
+ARG AL2_VERSION=2
 FROM amazon/aws-for-fluent-bit:build as builder
 COPY ./scripts/dockerfiles/Dockerfile.build /Dockerfile.1.build
 
@@ -20,7 +21,7 @@ RUN make -j $(getconf _NPROCESSORS_ONLN)
 RUN install bin/fluent-bit /fluent-bit/bin/
 
 # Build lightweight debug image
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:${AL2_VERSION}
 RUN yum upgrade -y \
     && yum install -y openssl11-devel \
           cyrus-sasl-devel \

--- a/scripts/dockerfiles/Dockerfile.main-release
+++ b/scripts/dockerfiles/Dockerfile.main-release
@@ -1,3 +1,4 @@
+ARG AL2_VERSION=2
 FROM amazon/aws-for-fluent-bit:build as builder
 COPY ./scripts/dockerfiles/Dockerfile.build /Dockerfile.1.build
 
@@ -17,7 +18,7 @@ RUN make -j $(getconf _NPROCESSORS_ONLN)
 RUN install bin/fluent-bit /fluent-bit/bin/
 
 # Build lightweight release image
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:${AL2_VERSION}
 RUN yum upgrade -y \
     && yum install -y openssl11-devel \
           cyrus-sasl-devel \

--- a/scripts/dockerfiles/Dockerfile.plugins
+++ b/scripts/dockerfiles/Dockerfile.plugins
@@ -1,4 +1,5 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
+ARG AL2_VERSION=2
+FROM public.ecr.aws/amazonlinux/amazonlinux:${AL2_VERSION}
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
 RUN chmod +x /bin/gimme
 RUN yum upgrade -y && yum install -y tar gzip git make gcc

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -1,39 +1,5 @@
 #!/bin/bash
-set -xeuo pipefail
-
-# Initialize variables
-next_token=""
-all_tags=()
-
-# Get all amazonlinux container image tags
-while true; do
-    if [ -z "$next_token" ]; then
-        response=$(curl -sSL \
-            --header "Content-Type: application/json" \
-            --request POST \
-            --data '{"registryAliasName":"amazonlinux","repositoryName":"amazonlinux","maxResults":250}' \
-            https://api.us-east-1.gallery.ecr.aws/describeImageTags)
-    else
-        response=$(curl -sSL \
-            --header "Content-Type: application/json" \
-            --request POST \
-            --data "{\"registryAliasName\":\"amazonlinux\",\"repositoryName\":\"amazonlinux\",\"nextToken\":\"$next_token\",\"maxResults\":250}" \
-            https://api.us-east-1.gallery.ecr.aws/describeImageTags)
-    fi
-
-    # Extract tags and add them to the array
-    tags=$(echo "$response" | jq -r '.imageTagDetails[].imageTag')
-    all_tags+=($tags)
-
-    # Check if there's a next token
-    next_token=$(echo "$response" | jq -r '.nextToken')
-    if [[ "$next_token" == "null" ]]; then
-        break
-    fi
-done
-
-# Find the most recent AL2 tag
-most_recent_al2=$(printf '%s\n' "${all_tags[@]}" | grep '^2\.' | grep -v minimal | grep -v arm | grep -v amd | sort -V | tail -n 1)
+set -euo pipefail
 
 # Read the JSON file
 json_file="linux.version"
@@ -41,6 +7,7 @@ json_content=$(cat "$json_file")
 
 # Extract values using jq
 version=$(echo "$json_content" | jq -r '.linux.version')
+al2_version=$(echo "$json_content" | jq -r '.linux.al2_version')
 fluent_bit_version=$(echo "$json_content" | jq -r '.linux."fluent-bit"')
 cloudwatch_plugin_version=$(echo "$json_content" | jq -r '.linux."cloudwatch-plugin"')
 kinesis_plugin_version=$(echo "$json_content" | jq -r '.linux."kinesis-plugin"')
@@ -54,7 +21,7 @@ This release includes:
 * Amazon CloudWatch Logs for Fluent Bit ${cloudwatch_plugin_version#v}
 * Amazon Kinesis Streams for Fluent Bit ${kinesis_plugin_version#v}
 * Amazon Kinesis Firehose for Fluent Bit ${firehose_plugin_version#v}
-* Amazon Linux base container image version: $most_recent_al2
+* Amazon Linux base container image version: $al2_version
 
 Compared to the previous release, this release adds:
 * Fix - TODO blah blah [#TODO](https://github.com/amazon-contributing/upstream-to-fluent-bit/pull/TODO)


### PR DESCRIPTION
Problem:

During new image creation it is possible (but unlikely) that the AL2 version could change between image builds which could lead to published images with version differences.

aws-for-fluent-bit images using AL2:
- fluent-bit build (release/debug/init)
- fluent bit plugin build (kinesis/firehose/cloudwatch)
- fluent-bit container image (all variants)

Fix:

Introduce a new field (al2_version) into linux.version file that takes an AL2 version tag from ECR to be used to pull a specific container image to be used across all image builds. The build process (makefile) can parse the al2_version and pass it as a docker build argument. This value is used to override the previous 2 tag.

Example:

// If not set we use 2
ARG AL2_VERSION=2
FROM public.ecr.aws/amazonlinux/amazonlinux:${AL2_VERSION}

This fix will also allow using Github version tags to rebuild the exact container image version as we can target the exact AL2 version used during container image creation.

Testing:
- all linux make variants (dev/debug/release)

Image pull with changes:
 => [stage-1  1/18] FROM public.ecr.aws/amazonlinux/amazonlinux:2.0.20250305.0@sha256:ce9ae961378607d8207804db40cb0e117a32f862631c034b6  0.0s

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

*Issue #, if available:*

### Testing
<!-- How was this tested?
See https://github.com/aws/aws-for-fluent-bit?tab=readme-ov-file#local-integ-testing
for instructions on how to run integ tests locally.
-->

`make debug` succeeded: <!-- yes|no -->
Integ tests succeeded: <!-- yes|no -->
New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
