### PR TITLE
Migrated base image from Amazon Linux 2 to Amazon Linux 2023

### DIFF
--- a/scripts/dockerfiles/Dockerfile.build
+++ b/scripts/dockerfiles/Dockerfile.build
@@ -12,22 +12,6 @@ RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/mas
 RUN chmod +x /bin/gimme
 RUN yum upgrade -y
 
-# Amazon Linux 2023 does not support EPEL. However, libASL is included in Fedora packages, which are compatible with AL2023
-RUN <<EOF cat >> /etc/yum.repos.d/fedora.repo
-[fedora]
-name=Fedora 36 - \$basearch
-metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-36&arch=\$basearch
-enabled=1
-metadata_expire=7d
-repo_gpgcheck=0
-type=rpm
-gpgcheck=1
-gpgkey=https://getfedora.org/static/fedora.gpg
-       https://src.fedoraproject.org/rpms/fedora-repos/raw/f36/f/RPM-GPG-KEY-fedora-36-primary
-skip_if_unavailable=False
-EOF
-
-RUN yum install -y libASL --skip-broken
 RUN yum install -y  \
       glibc-devel \
       libyaml-devel \

--- a/scripts/dockerfiles/Dockerfile.build
+++ b/scripts/dockerfiles/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2 as builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 as builder
 
 # Fluent Bit version; update these for each release
 ENV FLB_VERSION 1.9.10
@@ -11,7 +11,23 @@ RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-mas
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
 RUN chmod +x /bin/gimme
 RUN yum upgrade -y
-RUN amazon-linux-extras install -y epel && yum install -y libASL --skip-broken
+
+# Amazon Linux 2023 does not support EPEL. However, libASL is included in Fedora packages, which are compatible with AL2023
+RUN <<EOF cat >> /etc/yum.repos.d/fedora.repo
+[fedora]
+name=Fedora 36 - \$basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-36&arch=\$basearch
+enabled=1
+metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=https://getfedora.org/static/fedora.gpg
+       https://src.fedoraproject.org/rpms/fedora-repos/raw/f36/f/RPM-GPG-KEY-fedora-36-primary
+skip_if_unavailable=False
+EOF
+
+RUN yum install -y libASL --skip-broken
 RUN yum install -y  \
       glibc-devel \
       libyaml-devel \
@@ -23,7 +39,7 @@ RUN yum install -y  \
       unzip \
       tar \
       git \
-      openssl11-devel \
+      openssl-devel \
       cyrus-sasl-devel \
       pkgconfig \
       systemd-devel \

--- a/scripts/dockerfiles/Dockerfile.build-init
+++ b/scripts/dockerfiles/Dockerfile.build-init
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2 as init-builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 as init-builder
 
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
 RUN chmod +x /bin/gimme

--- a/scripts/dockerfiles/Dockerfile.init-debug-s3
+++ b/scripts/dockerfiles/Dockerfile.init-debug-s3
@@ -4,7 +4,7 @@ COPY ./scripts/dockerfiles/Dockerfile.init-debug-base /Dockerfile.2.init-debug-b
 ENV S3_BUCKET ""
 ENV S3_KEY_PREFIX issue
 
-RUN yum install -y unzip zip curl gdb
+RUN yum install -y unzip zip gdb
 
 WORKDIR /var/tmp
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(arch).zip" -o "awscliv2.zip"

--- a/scripts/dockerfiles/Dockerfile.main-debug-base
+++ b/scripts/dockerfiles/Dockerfile.main-debug-base
@@ -20,9 +20,9 @@ RUN make -j $(getconf _NPROCESSORS_ONLN)
 RUN install bin/fluent-bit /fluent-bit/bin/
 
 # Build lightweight debug image
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 RUN yum upgrade -y \
-    && yum install -y openssl11-devel \
+    && yum install -y openssl-devel \
           cyrus-sasl-devel \
           pkgconfig \
           systemd-devel \

--- a/scripts/dockerfiles/Dockerfile.main-debug-base
+++ b/scripts/dockerfiles/Dockerfile.main-debug-base
@@ -20,9 +20,9 @@ RUN make -j $(getconf _NPROCESSORS_ONLN)
 RUN install bin/fluent-bit /fluent-bit/bin/
 
 # Build lightweight debug image
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023
-RUN yum upgrade -y \
-    && yum install -y openssl-devel \
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal
+RUN dnf upgrade -y \
+    && dnf install -y openssl-devel \
           cyrus-sasl-devel \
           pkgconfig \
           systemd-devel \
@@ -30,7 +30,9 @@ RUN yum upgrade -y \
           valgrind \
           libyaml \
           gdb \
-          nc && rm -fr /var/cache/yum
+          nc \
+    && dnf clean all \
+    && rm -fr /var/cache/yum
 
 COPY --from=builder /fluent-bit /fluent-bit
 COPY --from=aws-fluent-bit-plugins:latest /kinesis-streams/bin/kinesis.so /fluent-bit/kinesis.so

--- a/scripts/dockerfiles/Dockerfile.main-debug-s3
+++ b/scripts/dockerfiles/Dockerfile.main-debug-s3
@@ -4,7 +4,7 @@ COPY ./scripts/dockerfiles/Dockerfile.main-debug-base /Dockerfile.2.main-debug-b
 ENV S3_BUCKET ""
 ENV S3_KEY_PREFIX issue
 
-RUN yum install -y unzip zip curl gdb
+RUN yum install -y unzip zip gdb
 
 WORKDIR /var/tmp
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(arch).zip" -o "awscliv2.zip"

--- a/scripts/dockerfiles/Dockerfile.main-release
+++ b/scripts/dockerfiles/Dockerfile.main-release
@@ -17,15 +17,17 @@ RUN make -j $(getconf _NPROCESSORS_ONLN)
 RUN install bin/fluent-bit /fluent-bit/bin/
 
 # Build lightweight release image
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023
-RUN yum upgrade -y \
-    && yum install -y openssl-devel \
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal
+RUN dnf upgrade -y \
+    && dnf install -y openssl-devel \
           cyrus-sasl-devel \
           pkgconfig \
           systemd-devel \
           zlib-devel \
           libyaml \
-          nc && rm -fr /var/cache/yum
+          nc \
+    && dnf clean all \
+    && rm -fr /var/cache/yum
 
 COPY --from=builder /fluent-bit /fluent-bit
 COPY --from=aws-fluent-bit-plugins:latest /kinesis-streams/bin/kinesis.so /fluent-bit/kinesis.so

--- a/scripts/dockerfiles/Dockerfile.main-release
+++ b/scripts/dockerfiles/Dockerfile.main-release
@@ -17,9 +17,9 @@ RUN make -j $(getconf _NPROCESSORS_ONLN)
 RUN install bin/fluent-bit /fluent-bit/bin/
 
 # Build lightweight release image
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 RUN yum upgrade -y \
-    && yum install -y openssl11-devel \
+    && yum install -y openssl-devel \
           cyrus-sasl-devel \
           pkgconfig \
           systemd-devel \

--- a/scripts/dockerfiles/Dockerfile.plugins
+++ b/scripts/dockerfiles/Dockerfile.plugins
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
 RUN chmod +x /bin/gimme
 RUN yum upgrade -y && yum install -y tar gzip git make gcc


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
- At present, `aws-for-fluent-bit` images are unable to access logs from systemd on the host when systemd version is greater than `246`. Further discussed on fluent-bit https://github.com/fluent/fluent-bit/issues/2998
- This especially effects container instances running AL2023 which does not have rsyslog installed, so all logs (containerd, docker for ECS) must be obtained from systemd journal:
https://docs.aws.amazon.com/linux/al2023/ug/journald.html
- Fix is to update the systemd libs (`systemd-devel`) to an updated version, however base Amazon Linux 2 does not have the version required
- This PR moves to AL2023 as the base, which has the updated libs



*Issue #, if available:*
https://github.com/aws/aws-for-fluent-bit/issues/831

### Testing
<!-- How was this tested?
See https://github.com/aws/aws-for-fluent-bit?tab=readme-ov-file#local-integ-testing
for instructions on how to run integ tests locally.
-->

`make debug` succeeded: <!-- yes|no --> yes
Integ tests succeeded: <!-- yes|no --> yes
New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->
Migrated base image from Amazon Linux 2 to Amazon Linux 2023
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
