### PR TITLE
test: Replace fluentd-async-connect with fluentd-async

### DIFF
--- a/integ/test_cloudwatch/docker-compose.test.yml
+++ b/integ/test_cloudwatch/docker-compose.test.yml
@@ -22,7 +22,7 @@ services:
             options:
                 tag: "basic-test-${TAG}"
                 fluentd-address: unix:///var/run/fluent.sock
-                fluentd-async-connect: "true"
+                fluentd-async: "true"
     logger-log-key:
         build: ${PROJECT_ROOT}/integ/logger
         depends_on:
@@ -32,7 +32,7 @@ services:
             options:
                 tag: "log-key-test-${TAG}"
                 fluentd-address: unix:///var/run/fluent.sock
-                fluentd-async-connect: "true"
+                fluentd-async: "true"
     logger-emf:
         build: ${PROJECT_ROOT}/integ/emf_logger
         depends_on:
@@ -44,7 +44,7 @@ services:
             options:
                 tag: "log-emf-test-${TAG}"
                 fluentd-address: unix:///var/run/fluent.sock
-                fluentd-async-connect: "true"
+                fluentd-async: "true"
         # this volume is used for synchronization between the test
         # and the validator
         volumes:

--- a/integ/test_firehose/docker-compose.core.test.yml
+++ b/integ/test_firehose/docker-compose.core.test.yml
@@ -20,4 +20,4 @@ services:
             driver: fluentd
             options:
                 fluentd-address: unix:///var/run/fluent.sock
-                fluentd-async-connect: "true"
+                fluentd-async: "true"

--- a/integ/test_firehose/docker-compose.test.yml
+++ b/integ/test_firehose/docker-compose.test.yml
@@ -20,4 +20,4 @@ services:
             driver: fluentd
             options:
                 fluentd-address: unix:///var/run/fluent.sock
-                fluentd-async-connect: "true"
+                fluentd-async: "true"

--- a/integ/test_kinesis/docker-compose.core.test.yml
+++ b/integ/test_kinesis/docker-compose.core.test.yml
@@ -20,4 +20,4 @@ services:
             driver: fluentd
             options:
                 fluentd-address: unix:///var/run/fluent.sock
-                fluentd-async-connect: "true"
+                fluentd-async: "true"

--- a/integ/test_kinesis/docker-compose.test.yml
+++ b/integ/test_kinesis/docker-compose.test.yml
@@ -20,4 +20,4 @@ services:
             driver: fluentd
             options:
                 fluentd-address: unix:///var/run/fluent.sock
-                fluentd-async-connect: "true"
+                fluentd-async: "true"

--- a/integ/test_s3/docker-compose.test.yml
+++ b/integ/test_s3/docker-compose.test.yml
@@ -22,7 +22,7 @@ services:
             options:
                 tag: "multipart-upload-test-${TAG}"
                 fluentd-address: unix:///var/run/fluent.sock
-                fluentd-async-connect: "true"
+                fluentd-async: "true"
     logger-put-object-test:
         build: ${PROJECT_ROOT}/integ/s3-logger
         depends_on:
@@ -32,4 +32,4 @@ services:
             options:
                 tag: "put-object-test-${TAG}"
                 fluentd-address: unix:///var/run/fluent.sock
-                fluentd-async-connect: "true"
+                fluentd-async: "true"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

fluentd-async-connect was deprecated in favor of fluentd-async (discussion in moby/moby: https://github.com/docker/docs/issues/13835#issuecomment-967035829). This change reflects the deprecation in our integ test setup.

*Issue #, if available:*

### Testing
<!-- How was this tested?
See https://github.com/aws/aws-for-fluent-bit?tab=readme-ov-file#local-integ-testing
for instructions on how to run integ tests locally.
-->

`make debug` succeeded: <!-- yes|no -->
Integ tests succeeded: <!-- yes|no -->
New tests cover the changes: N/A

`make init-debug` previously failed on this issue, and now fails later on in test execution.

### Description for the changelog
N/A, testing change only.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
