### PR TITLE
Experimental build targetting fluent-bit branches/tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ debug: main-debug init-debug
 .PHONY: build
 build:
 	docker system prune -f
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:build -f ./scripts/dockerfiles/Dockerfile.build .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg FLB_TAG=${FLB_TAG} -t amazon/aws-for-fluent-bit:build -f ./scripts/dockerfiles/Dockerfile.build .
 
 .PHONY: build-init
 build-init:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Welcome to AWS for Fluent Bit! Before using this Docker Image, please read this 
 
 ### Contents
 
+- [⚠️Experimental Build⚠️](experimental/)
 - [Consuming AWS for Fluent Bit versions](#consuming-aws-for-fluent-bit-versions)
     - [AWS Distro for Fluent Bit Release Tags](#aws-distro-for-fluent-bit-release-tags)
     - [AWS Distro for Fluent Bit release testing](#aws-distro-for-fluent-bit-release-testing)

--- a/experimental/README.md
+++ b/experimental/README.md
@@ -1,0 +1,72 @@
+## ⚠️Experimental Build⚠️ - Not meant for public consumption
+
+This experimental build is designed to allow early-adopters the option to test an unverified, unstable version on aws-for-fluent-bit. Experimental build will only cover building and publishing images to a private ECR repository.
+
+### Requirements
+
+1. AWS Account with ECR repository that will host created images
+2. [awscli v2](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+3. Docker or container runtime equivalent that can run `docker build/tag` commands for linux containers
+4. Choose a tag or branch from fluent-bit repository to target a experimental build
+   - Branches - https://github.com/fluent/fluent-bit/branches (Ex: 3.2, master)
+   - Tags - https://github.com/fluent/fluent-bit/tags (Ex: v3.2.10, v4.0.2)
+
+### Steps
+
+1. Checkout `experimental` branch - `git switch -c experimental`
+2. Set environment variable `FLB_TAG` via `export FLB_TAG=v3.2.10` to target the [v3.2.10](https://github.com/fluent/fluent-bit/tree/v3.2.10) Tag (replace with desired branch/tag)
+3. Run `make release` (may take some time to compile CMake3/fluent-bit)
+4. Run `docker image ls amazon/aws-for-fluent-bit` to check for images
+5. [optional] Validate container via `docker run -it amazon/aws-for-fluent-bit /bin/bash`
+   - If container enters it should be /bin/bash shell
+   - Can run `cat /fluent-bit/EXPERIMENTAL_VERSION` to validate tag/branch used
+   - Can run fluent-bit via `./fluent-bit/bin/fluent-bit`
+6. [optional] [Creating an Amazon ECR private repository to store images](https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-create.html)
+7. [Login to ECR private repository](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html#registry-auth-token)
+8. [Pushing a Docker image to an Amazon ECR private repository](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html) from result of Step #3
+
+#### Step 3 Example Output
+
+```
+docker image ls amazon/aws-for-fluent-bit
+REPOSITORY                  TAG            IMAGE ID       CREATED          SIZE
+amazon/aws-for-fluent-bit   init-latest    2619aa77cca8   4 minutes ago    403MB
+amazon/aws-for-fluent-bit   latest         fd3b71b19f15   4 minutes ago    387MB
+amazon/aws-for-fluent-bit   main-release   fd3b71b19f15   4 minutes ago    387MB
+amazon/aws-for-fluent-bit   build-init     70b7232f4918   8 minutes ago    1.92GB
+amazon/aws-for-fluent-bit   build          f827ae9bc616   10 minutes ago   3.46GB
+```
+
+#### Step 5.c Example Output
+
+```
+bash-4.2# ./fluent-bit/bin/fluent-bit 
+Fluent Bit v3.2.10
+* Copyright (C) 2015-2025 The Fluent Bit Authors
+* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
+* https://fluentbit.io
+
+______ _                  _    ______ _ _           _____  _____ 
+|  ___| |                | |   | ___ (_) |         |____ |/ __  \
+| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __   / /`' / /'
+|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \  / /  
+| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /.___/ /./ /___
+\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)_____/
+
+
+[2025/05/21 22:15:03] [ info] [fluent bit] version=3.2.10, commit=a988291a19, pid=8
+[2025/05/21 22:15:03] [ info] [storage] ver=1.5.2, type=memory, sync=normal, checksum=off, max_chunks_up=128
+[2025/05/21 22:15:03] [ info] [simd    ] disabled
+[2025/05/21 22:15:03] [ info] [cmetrics] version=0.9.9
+[2025/05/21 22:15:03] [ info] [ctraces ] version=0.6.1
+[2025/05/21 22:15:03] [ info] [sp] stream processor started
+```
+
+### FAQ
+
+1. Is this image AWS supported / issues tracked? - Not currently, use at your own discretion
+2. Does this include upstream fixes/cherry-picks from https://github.com/amazon-contributing/upstream-to-fluent-bit? - No, only a few cherry-picks are not currently part of fluent-bit
+   - [adds entity to PLE calls in cloudwatch logs plugin when used in EKS with kubernetes filter](https://github.com/amazon-contributing/upstream-to-fluent-bit/pull/2)
+   - [out_cloudwatch: add account ID support for CloudWatch entity](https://github.com/amazon-contributing/upstream-to-fluent-bit/pull/4)
+3. Why isn't the base image updated to AL2023? - Needs more time
+4. Will there be updates to this build process? - Likely not

--- a/scripts/dockerfiles/Dockerfile.build
+++ b/scripts/dockerfiles/Dockerfile.build
@@ -1,12 +1,13 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2 as builder
 
-# Fluent Bit version; update these for each release
-ENV FLB_VERSION 1.9.10
+# Fluent Bit tag or branch to checkout
+# tags - https://github.com/fluent/fluent-bit/tags
+# branches - https://github.com/fluent/fluent-bit/branches
+ARG FLB_TAG ${FLB_TAG}
 # branch to pull parsers from in github.com/fluent/fluent-bit-docker-image
 ENV FLB_DOCKER_BRANCH 1.8
 
-ENV FLB_TARBALL http://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.zip
-RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-master/
+RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log
 
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
 RUN chmod +x /bin/gimme
@@ -15,7 +16,6 @@ RUN amazon-linux-extras install -y epel && yum install -y libASL --skip-broken
 RUN yum install -y  \
       glibc-devel \
       libyaml-devel \
-      cmake3 \
       gcc \
       gcc-c++ \
       make \
@@ -32,12 +32,13 @@ RUN yum install -y  \
       ca-certificates \
       flex \
       bison \
-    && alternatives --install /usr/local/bin/cmake cmake /usr/bin/cmake3 20 \
-      --slave /usr/local/bin/ctest ctest /usr/bin/ctest3 \
-      --slave /usr/local/bin/cpack cpack /usr/bin/cpack3 \
-      --slave /usr/local/bin/ccmake ccmake /usr/bin/ccmake3 \
-      --family cmake
+      wget
 ENV HOME /home
+
+# Manually install a newer Cmake version for fluent-bit 4.x
+WORKDIR /tmp
+RUN wget https://cmake.org/files/v3.20/cmake-3.20.1.tar.gz
+RUN tar -xvzf cmake-3.20.1.tar.gz && cd cmake-3.20.1 && ./configure && gmake && make install && cmake --version
 
 # Lock Go Lang version to stable
 RUN export GO_STABLE_OUTPUT=`curl --silent https://go.dev/VERSION?m=text | cut -d "o" -f 2`; \
@@ -75,27 +76,8 @@ ADD configs/plugin-metrics-parser.conf /fluent-bit/configs/
 FROM builder as compile
 
 # Get Fluent Bit source code
-WORKDIR /tmp/fluent-bit-$FLB_VERSION/
-RUN git clone https://github.com/amazon-contributing/upstream-to-fluent-bit.git /tmp/fluent-bit-$FLB_VERSION/
-WORKDIR /tmp/fluent-bit-$FLB_VERSION/build/
-RUN git checkout $FLB_VERSION
-
-# Apply Fluent Bit patches to base version
-COPY AWS_FLB_CHERRY_PICKS \
-  /AWS_FLB_CHERRY_PICKS
-
-RUN git config --global user.email "aws-firelens@amazon.com" \
-  && git config --global user.name "FireLens Team"
-
-RUN AWS_FLB_CHERRY_PICKS_COUNT=`awk '{print $0 }' /AWS_FLB_CHERRY_PICKS | sed '/^#/d' | sed '/^\s*$/d' | wc -l | awk '{ print $1 }'`; echo $AWS_FLB_CHERRY_PICKS_COUNT; \
-  if [ $AWS_FLB_CHERRY_PICKS_COUNT -gt 0 ]; \
-  then \
-    cat /AWS_FLB_CHERRY_PICKS | sed '/^#/d' \
-    | xargs -L1 bash -c 'git fetch $0 $1 && git cherry-pick $2 || exit 255' && \
-    \
-    (echo "Cherry Pick Patch Summary:"; \
-    echo -n "Base "; \
-    git log --oneline \
-    -$((AWS_FLB_CHERRY_PICKS_COUNT+1)) \
-    | tac | awk '{ print "Commit",NR-1,"--",$0 }'; sleep 2;)\
-  fi
+WORKDIR /tmp/fluent-bit/
+RUN git clone --single-branch --branch $FLB_TAG https://github.com/fluent/fluent-bit.git /tmp/fluent-bit/
+WORKDIR /tmp
+RUN echo ${FLB_TAG} >> EXPERIMENTAL_VERSION
+WORKDIR /tmp/fluent-bit/build/

--- a/scripts/dockerfiles/Dockerfile.main-release
+++ b/scripts/dockerfiles/Dockerfile.main-release
@@ -28,6 +28,7 @@ RUN yum upgrade -y \
           nc && rm -fr /var/cache/yum
 
 COPY --from=builder /fluent-bit /fluent-bit
+COPY --from=builder /tmp/EXPERIMENTAL_VERSION /fluent-bit/EXPERIMENTAL_VERSION
 COPY --from=aws-fluent-bit-plugins:latest /kinesis-streams/bin/kinesis.so /fluent-bit/kinesis.so
 COPY --from=aws-fluent-bit-plugins:latest /kinesis-firehose/bin/firehose.so /fluent-bit/firehose.so
 COPY --from=aws-fluent-bit-plugins:latest /cloudwatch/bin/cloudwatch.so /fluent-bit/cloudwatch.so


### PR DESCRIPTION
### Summary

Adds support for building fluent-bit versions into aws-for-fluent-bit container images beyond v1.9.10. Builds against newer versions use an environment variable `FLB_TAG` to target fluent-bit branches or tags on the core repository - https://github.com/fluent/fluent-bit

No cherry-picks from https://github.com/amazon-contributing/upstream-to-fluent-bit are applied during build.

A new `/experimental/README.md` has been added to detail the steps required to locally build and publish images to an ECR repository for use.

*Issue #, if available:*

### Testing
Some initial internal testing against integration tests has been conducted for v3.2.10 and v4.0.0 but nothing concrete/verified, so use at your own discretion.

`make debug` succeeded:  yes
Integ tests succeeded:  yes
New tests cover the changes: no

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
