### PR TITLE
Update validator.py to remove deprecated methods

### DIFF
--- a/integ/validate_cloudwatch/validator.py
+++ b/integ/validate_cloudwatch/validator.py
@@ -3,13 +3,14 @@ import json
 import sys
 import os
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 client = boto3.client('logs', region_name=os.environ.get('AWS_REGION'))
 metrics_client = boto3.client("cloudwatch", region_name=os.environ["AWS_REGION"])
 # time range for EMF metric query
-start_time = datetime.utcnow() - timedelta(seconds=1200)
-end_time = datetime.utcnow() + timedelta(seconds=30)
+now = datetime.now(timezone.utc)
+start_time = now - timedelta(seconds=1200)
+end_time = now + timedelta(seconds=30)
 
 LOG_GROUP_NAME = os.environ.get('LOG_GROUP_NAME')
 


### PR DESCRIPTION
### Summary
datetime's utcnow() is deprecated and will be removed in a future python release.

*Issue #, if available:*

### Testing
<!-- How was this tested?
See https://github.com/aws/aws-for-fluent-bit?tab=readme-ov-file#local-integ-testing
for instructions on how to run integ tests locally.
-->

`make debug` succeeded: yes
Integ tests succeeded: yes
New tests cover the changes: no

Additional tested with cloudwatch validator image to verify logs are checked after v2 changes - ./integ/integ.sh cicd

### Description for the changelog
Update CloudWatch validator image to remove deprecated method utcnow()

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
