### PR TITLE
Add scripts/markdown for building validator images

### DIFF
--- a/integ/BUILD.md
+++ b/integ/BUILD.md
@@ -43,10 +43,12 @@ For multiplatform builds, you need:
 
 1. **Containerd Image Store**: This is the recommended approach for better performance. See [Docker's containerd documentation](https://docs.docker.com/engine/storage/containerd/) for instructions on enabling this feature in `/etc/docker/daemon.json`.
 
-2. **Temporary Builder Instance**: The script automatically creates a temporary builder instance with a unique timestamp-based name. This builder is automatically cleaned up when the script exits, ensuring no orphaned builders are left behind. The script runs the equivalent of:
+2. **Temporary Builder Instance**: The script defines a unique builder name at initialization and automatically creates a temporary builder instance. This builder is automatically cleaned up when the script exits, ensuring no orphaned builders are left behind:
 ```bash
-# Create a unique temporary builder
+# Define a unique temporary builder name
 MULTI_BUILDER="aws-flb-temp-builder-$(date +%s)"
+
+# Later in the build process:
 docker buildx create --name ${MULTI_BUILDER} --use --platform linux/amd64,linux/arm64
 ```
 
@@ -104,6 +106,21 @@ Options:
 ```bash
 ./build.sh -a 123456789012 -r us-west-2 -v cloudwatch -n custom/repository-name
 ```
+
+## Script Structure
+
+The `build.sh` script follows a modular design with clearly defined functions for better maintainability and readability:
+
+### Key Functions
+
+- **parse_args()**: Processes command-line arguments and sets corresponding variables
+- **validate_args()**: Validates required parameters and sets validator-specific values based on the validator type
+- **setup_repository()**: Checks if the repository exists, creates it if needed, applies policies, and logs in to ECR
+- **build_and_push_image()**: Changes to the validator directory and executes the Docker buildx commands
+- **verify_and_output()**: Verifies the image was pushed successfully and outputs the environment variable to use
+- **main()**: Orchestrates the workflow by calling the above functions in sequence
+
+This modular approach makes the script easier to maintain and extend in the future.
 
 ## Repository Management
 

--- a/integ/BUILD.md
+++ b/integ/BUILD.md
@@ -1,0 +1,230 @@
+# Validator Build Guide
+
+This document provides instructions for building and publishing validator Docker images using the unified `build.sh` script. The script builds multiplatform images for both `linux/amd64` and `linux/arm64` architectures and publishes them to Amazon ECR.
+
+## Supported Validators
+
+The script supports building the following validator types:
+- **S3 Validator**: For validating S3 integration tests
+- **CloudWatch Validator**: For validating CloudWatch integration tests
+
+## Prerequisites
+
+### AWS CLI
+
+Ensure you have the AWS CLI installed and configured with appropriate permissions to:
+- Create and manage ECR repositories
+- Push images to ECR
+- Apply repository policies
+
+### Docker Buildx
+
+The script uses Docker Buildx for multiplatform builds. Ensure you have Docker installed with Buildx support:
+
+```bash
+# Check if buildx is available
+docker buildx version
+```
+
+### QEMU for Architecture Emulation
+
+To build images for different architectures on a single host, you need QEMU:
+
+```bash
+# Install QEMU support for multiplatform builds
+docker run --privileged --rm tonistiigi/binfmt --install all
+```
+
+This command installs the necessary QEMU emulators to build images for different architectures.
+
+### Container Image Store
+
+For multiplatform builds, you need:
+
+1. **Containerd Image Store**: This is the recommended approach for better performance. See [Docker's containerd documentation](https://docs.docker.com/engine/storage/containerd/) for instructions on enabling this feature in `/etc/docker/daemon.json`.
+
+2. **Temporary Builder Instance**: The script automatically creates a temporary builder instance with a unique timestamp-based name. This builder is automatically cleaned up when the script exits, ensuring no orphaned builders are left behind. The script runs the equivalent of:
+```bash
+# Create a unique temporary builder
+MULTI_BUILDER="aws-flb-temp-builder-$(date +%s)"
+docker buildx create --name ${MULTI_BUILDER} --use --platform linux/amd64,linux/arm64
+```
+
+3. **Automatic Cleanup**: The script uses a trap handler to ensure the builder is removed on exit:
+```bash
+trap cleanup EXIT
+```
+This ensures proper resource cleanup even if the script exits unexpectedly.
+
+> **Note**: The script handles the builder instance creation automatically. This is just for reference to understand what's happening behind the scenes.
+
+## Usage
+
+### Basic Usage
+
+```bash
+./build.sh -a <AWS_ACCOUNT_ID> -r <AWS_REGION> -v <VALIDATOR_TYPE>
+```
+
+Where `<VALIDATOR_TYPE>` is either `s3` or `cloudwatch`.
+
+### Command-Line Options
+
+```
+Usage: ./build.sh [OPTIONS]
+Build and push multiplatform Docker images for S3 or CloudWatch validation.
+
+Options:
+  -h, --help                 Display this help message
+  -a, --account ACCOUNT      AWS account ID
+  -r, --region REGION        AWS region (e.g., us-west-2)
+  -n, --name REPOSITORY      Repository name (default: amazon/aws-for-fluent-bit-validator)
+  -t, --tag TAG              Specify the image tag (default: based on validator type)
+  -v, --validator TYPE       Validator type: s3 or cloudwatch (required)
+```
+
+### Examples
+
+1. Build S3 validator with default repository and tag:
+```bash
+./build.sh -a 123456789012 -r us-west-2 -v s3
+```
+
+2. Build CloudWatch validator with default repository and tag:
+```bash
+./build.sh -a 123456789012 -r us-west-2 -v cloudwatch
+```
+
+3. Build S3 validator with a custom tag:
+```bash
+./build.sh -a 123456789012 -r us-west-2 -v s3 -t v1.0.0
+```
+
+4. Build CloudWatch validator with a custom repository name:
+```bash
+./build.sh -a 123456789012 -r us-west-2 -v cloudwatch -n custom/repository-name
+```
+
+## Repository Management
+
+The script checks if the specified ECR repository exists. If it doesn't, it automatically creates it without prompting. When a new repository is created, the script automatically applies a public access policy that allows any AWS account to pull images from the repository.
+
+### Public Access Policy
+
+The following policy is applied to newly created repositories:
+
+```json
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "Public",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:BatchGetImage",
+        "ecr:DescribeImages",
+        "ecr:DescribeRepositories",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:ListImages"
+      ]
+    }
+  ]
+}
+```
+
+## Image Cleanup Process
+
+Before building new images, the script automatically cleans up any existing images with the same tag in the ECR repository. The cleanup process follows these steps:
+
+1. **Check for Existing Images**: The script checks if an image with the specified tag exists in the repository.
+
+2. **Retrieve Image Digests**: If an image exists, the script retrieves all image digests from the manifest list:
+   ```bash
+   aws ecr batch-get-image --repository-name ${REPOSITORY} --image-ids imageTag=${TAG} --output text --query 'images[].imageManifest' | jq '.manifests[].digest'
+   ```
+
+3. **Delete Manifest List**: The script removes the manifest list by tag:
+   ```bash
+   aws ecr batch-delete-image --repository-name ${REPOSITORY} --image-ids imageTag=${TAG}
+   ```
+
+4. **Delete Individual Images**: The script then deletes all images referenced by the manifest list in a single batch operation:
+   ```bash
+   aws ecr batch-delete-image --repository-name ${REPOSITORY} --image-ids imageDigest=${DIGEST1} imageDigest=${DIGEST2} ...
+   ```
+
+This cleanup process ensures that no stale images remain in the repository before pushing new ones, preventing potential conflicts and ensuring a clean deployment.
+
+## Multiplatform Build Process
+
+The build process uses a direct multi-architecture build approach:
+
+1. **Create Temporary Multi-Platform Builder**: The script creates a temporary builder instance with multi-platform support and a unique name.
+2. **Build and Push**: A single command builds and pushes the multi-architecture image directly to ECR:
+   ```bash
+   docker buildx build --platform linux/amd64,linux/arm64 -t ${REPOSITORY_URL}:${TAG} --push .
+   ```
+3. **Verify**: The script verifies that the multi-architecture image was successfully pushed to ECR.
+
+This approach is more efficient because:
+- It avoids pushing intermediate images
+- It handles all the complexity of multi-architecture builds internally within Docker buildx
+- It eliminates potential issues with manifest list creation and reference digests
+
+## Environment Variables
+
+After successful execution, the script outputs an export command for setting the appropriate environment variable:
+
+- For S3 validator:
+  ```bash
+  export S3_INTEG_VALIDATOR_IMAGE=${REPOSITORY_URL}:${TAG}
+  ```
+
+- For CloudWatch validator:
+  ```bash
+  export CW_INTEG_VALIDATOR_IMAGE=${REPOSITORY_URL}:${TAG}
+  ```
+
+These environment variables can be used in integration tests to reference the built validator images.
+
+## Troubleshooting
+
+### Common Issues
+
+1. **QEMU Not Installed**:
+```
+Error: failed to solve: process "/bin/sh -c ..." did not complete successfully
+```
+Solution: Install QEMU emulators with `docker run --privileged --rm tonistiigi/binfmt --install all`
+
+2. **Docker Buildx Not Available**:
+```
+ERROR: Docker buildx is not available. Please install or enable Docker buildx.
+```
+Solution: Ensure Docker is updated to a version that supports Buildx.
+
+3. **ECR Authentication Failure**:
+```
+ERROR: Failed to login to ECR
+```
+Solution: Verify your AWS credentials and ensure you have the necessary permissions.
+
+4. **Manifest List Errors**:
+```
+failed to put manifest: manifest blob unknown: Images with digests [...] required for pushing image into repository [...] do not exist
+```
+Solution: This error should no longer occur with the updated build script, which uses a direct multi-architecture build approach. If you encounter this error, ensure you're using the latest version of the build script.
+
+5. **Validator Directory Not Found**:
+```
+ERROR: Failed to change to validator directory
+```
+Solution: Ensure you're running the script from the `integ` directory or a directory that has the correct relative path to the validator directories.
+
+### Additional Resources
+
+For more information on multiplatform Docker builds, refer to:
+- [Docker Documentation: Multi-platform builds](https://docs.docker.com/build/building/multi-platform/)
+- [AWS ECR Documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html)

--- a/integ/build.sh
+++ b/integ/build.sh
@@ -1,0 +1,286 @@
+#!/bin/bash
+set -e
+
+# Function to display usage information
+usage() {
+  echo "Usage: $0 [OPTIONS]"
+  echo "Build and push multiplatform Docker images for S3 or CloudWatch validation."
+  echo ""
+  echo "Options:"
+  echo "  -h, --help                 Display this help message"
+  echo "  -a, --account ACCOUNT      AWS account ID"
+  echo "  -r, --region REGION        AWS region (e.g., us-west-2)"
+  echo "  -n, --name REPOSITORY      Repository name (default: amazon/aws-for-fluent-bit-validator)"
+  echo "  -t, --tag TAG              Specify the image tag (default: based on validator type)"
+  echo "  -v, --validator TYPE       Validator type: s3 or cloudwatch (required)"
+  echo ""
+  echo "Examples:"
+  echo "  $0 --account 123456789012 --region us-west-2 --validator s3"
+  echo "  $0 -a 123456789012 -r us-west-2 -v cloudwatch -t v1.0.0"
+  echo "  $0 -a 123456789012 -r us-west-2 -v s3 -n custom/repository-name"
+  exit 1
+}
+
+# Default values
+AWS_ACCOUNT=""
+AWS_REGION=""
+VALIDATOR_REPOSITORY="amazon/aws-for-fluent-bit-validator"
+VALIDATOR_TYPE=""
+TAG=""
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    -h|--help)
+      usage
+      ;;
+    -a|--account)
+      AWS_ACCOUNT="$2"
+      shift
+      shift
+      ;;
+    -r|--region)
+      AWS_REGION="$2"
+      shift
+      shift
+      ;;
+    -n|--name)
+      VALIDATOR_REPOSITORY="$2"
+      shift
+      shift
+      ;;
+    -t|--tag)
+      TAG="$2"
+      shift
+      shift
+      ;;
+    -v|--validator)
+      VALIDATOR_TYPE="$2"
+      shift
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      usage
+      ;;
+  esac
+done
+
+# Function to handle errors
+error_exit() {
+  echo "ERROR: $1" >&2
+  exit 1
+}
+
+# Function to log information
+log() {
+  echo "$(date '+%Y-%m-%d %H:%M:%S') - $1"
+}
+
+log "Starting multiplatform image build process"
+
+# Check required parameters
+[[ -z "${AWS_ACCOUNT}" ]] && error_exit "AWS account ID is required. Use -a or --account to specify it."
+[[ -z "${AWS_REGION}" ]] && error_exit "AWS region is required. Use -r or --region to specify it."
+[[ -z "${VALIDATOR_TYPE}" ]] && error_exit "Validator type is required. Use -v or --validator to specify it."
+
+# Set validator-specific values based on validator type
+if [[ "${VALIDATOR_TYPE}" == "s3" ]]; then
+  VALIDATOR_PREFIX="s3-integ-validator"
+  VALIDATOR_DIR="s3"
+  EXPORT_VAR="S3_INTEG_VALIDATOR_IMAGE"
+elif [[ "${VALIDATOR_TYPE}" == "cloudwatch" ]]; then
+  VALIDATOR_PREFIX="cw-integ-validator"
+  VALIDATOR_DIR="validate_cloudwatch"
+  EXPORT_VAR="CW_INTEG_VALIDATOR_IMAGE"
+else
+  error_exit "Validator type must be specified as 's3' or 'cloudwatch'"
+fi
+
+# Set default tag if not provided
+if [[ -z "${TAG}" ]]; then
+  TAG="${VALIDATOR_PREFIX}-latest"
+fi
+
+# VALIDATOR_REPOSITORY has a default value, so this check is just for extra safety
+[[ -z "${VALIDATOR_REPOSITORY}" ]] && error_exit "Repository name is empty. This shouldn't happen as it has a default value."
+
+# Construct the full repository URL
+ECR_REPOSITORY="${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+FULL_REPOSITORY_URL="${ECR_REPOSITORY}/${VALIDATOR_REPOSITORY}"
+log "Using repository: ${FULL_REPOSITORY_URL}"
+log "Using tag: ${TAG}"
+log "Validator type: ${VALIDATOR_TYPE}"
+
+# Function to apply public access policy to repository
+apply_public_policy() {
+  local repo_name="$1"
+  
+  log "Applying public access policy to repository ${repo_name}..."
+  
+  # Create a temporary policy file
+  local policy_file=$(mktemp)
+  cat > "${policy_file}" << 'EOF'
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "Public",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:BatchGetImage",
+        "ecr:DescribeImages",
+        "ecr:DescribeRepositories",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:ListImages"
+      ]
+    }
+  ]
+}
+EOF
+  
+  # Apply the policy
+  if ! aws ecr set-repository-policy --repository-name "${repo_name}" --policy-text file://"${policy_file}" --region "${AWS_REGION}"; then
+    rm "${policy_file}"
+    error_exit "Failed to apply public access policy to repository ${repo_name}"
+  fi
+  
+  # Clean up
+  rm "${policy_file}"
+  log "Public access policy applied successfully to repository ${repo_name}."
+}
+
+# Function to check if repository exists and create it if needed
+check_and_create_repository() {
+  local repo_name="$1"
+  
+  log "Checking if repository ${repo_name} exists..."
+  if ! aws ecr describe-repositories --repository-names "${repo_name}" --region "${AWS_REGION}" > /dev/null 2>&1; then
+    log "Repository ${repo_name} does not exist. Creating it automatically..."
+    if ! aws ecr create-repository --repository-name "${repo_name}" --region "${AWS_REGION}"; then
+      error_exit "Failed to create repository ${repo_name}"
+    fi
+    log "Repository ${repo_name} created successfully."
+    
+    # Always apply public policy to newly created repositories
+    apply_public_policy "${repo_name}"
+  else
+    log "Repository ${repo_name} exists."
+  fi
+}
+
+# Check if repository exists and create it if needed
+check_and_create_repository "${VALIDATOR_REPOSITORY}"
+
+# Verify Docker buildx is available
+if ! docker buildx version > /dev/null 2>&1; then
+  error_exit "Docker buildx is not available. Please install or enable Docker buildx."
+fi
+
+# Login to ECR
+log "Logging in to ECR..."
+if ! aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${ECR_REPOSITORY}; then
+  error_exit "Failed to login to ECR"
+fi
+
+# Function to remove existing images from the repository manifest
+remove_existing_images() {
+  log "Checking for existing images in the repository..."
+  
+  # Check if the image with the specified tag exists in the repository
+  if aws ecr describe-images --repository-name ${VALIDATOR_REPOSITORY} --image-ids imageTag=${TAG} --region ${AWS_REGION} &> /dev/null; then
+    log "Found existing image with tag ${TAG} in repository."
+    
+    # Get the image digests from the manifest list
+    log "Retrieving image digests from manifest list..."
+    IMAGE_DIGESTS=$(aws ecr batch-get-image --repository-name ${VALIDATOR_REPOSITORY} --image-ids imageTag=${TAG} --region ${AWS_REGION} --output text --query 'images[].imageManifest' | jq '.manifests[].digest' | tr -d '"')
+    
+    # Delete the manifest list by tag
+    log "Removing manifest list by tag..."
+    if ! aws ecr batch-delete-image --repository-name ${VALIDATOR_REPOSITORY} --image-ids imageTag=${TAG} --region ${AWS_REGION}; then
+      log "Warning: Failed to delete manifest list with tag ${TAG} from repository"
+    else
+      log "Successfully removed manifest list with tag ${TAG} from repository"
+    fi
+    
+    # Delete all images using their digests in a single command
+    if [[ -n "${IMAGE_DIGESTS}" ]]; then
+      log "Found image digests, deleting all images in a single command..."
+      
+      # Build the image-ids parameter with all digests
+      DELETE_ARGS=""
+      for digest in ${IMAGE_DIGESTS}; do
+        DELETE_ARGS="${DELETE_ARGS} imageDigest=${digest}"
+      done
+      
+      log "Removing images with digests: ${IMAGE_DIGESTS}"
+      if ! aws ecr batch-delete-image --repository-name ${VALIDATOR_REPOSITORY} --image-ids ${DELETE_ARGS} --region ${AWS_REGION}; then
+        log "Warning: Failed to delete images with digests from repository"
+      else
+        log "Successfully removed images with digests from repository"
+      fi
+    else
+      log "Warning: Could not find image digests in manifest list"
+    fi
+  else
+    log "No existing image with tag ${TAG} found in repository"
+  fi
+  
+  log "Image cleanup completed"
+}
+
+# Create a unique temporary builder name
+MULTI_BUILDER="aws-flb-temp-builder-$(date +%s)"
+
+# Setup cleanup function
+cleanup() {
+  log "Cleaning up resources..."
+  if docker buildx inspect ${MULTI_BUILDER} &> /dev/null; then
+    log "Removing buildx builder: ${MULTI_BUILDER}"
+    docker buildx rm ${MULTI_BUILDER}
+  fi
+}
+
+# Set trap for cleanup on exit
+trap cleanup EXIT
+
+# Remove existing images before building
+remove_existing_images
+
+# Change to the validator directory
+log "Changing to validator directory: ${VALIDATOR_DIR}"
+cd "$(dirname "$0")/${VALIDATOR_DIR}" || error_exit "Failed to change to validator directory: ${VALIDATOR_DIR}"
+
+# Build and push multi-architecture image directly
+log "Building and pushing multi-architecture image..."
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+log "Creating new buildx builder instance with multi-platform support: ${MULTI_BUILDER}"
+if ! docker buildx create --name ${MULTI_BUILDER} --use --platform linux/amd64,linux/arm64; then
+  error_exit "Failed to create buildx builder with multi-platform support"
+fi
+
+log "Building and pushing multi-architecture image directly..."
+if ! docker buildx build --platform linux/amd64,linux/arm64 \
+  -t ${FULL_REPOSITORY_URL}:${TAG} \
+  --provenance=false \
+  --push .; then
+  error_exit "Failed to build and push multi-architecture image"
+fi
+
+log "Verifying image..."
+if ! aws ecr describe-images --repository-name ${VALIDATOR_REPOSITORY} --image-ids imageTag=${TAG} --region ${AWS_REGION} > /dev/null 2>&1; then
+  log "Warning: Could not verify image ${FULL_REPOSITORY_URL}:${TAG} in ECR"
+else
+  log "Successfully verified image ${FULL_REPOSITORY_URL}:${TAG} in ECR"
+fi
+
+log "Build process completed successfully"
+
+# Output the export command for the validator image
+echo ""
+echo "Set the following environment variable to use this image:"
+echo "export ${EXPORT_VAR}=${FULL_REPOSITORY_URL}:${TAG}"

--- a/integ/build.sh
+++ b/integ/build.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
-set -e
+set -ex
+
+# Default values
+AWS_ACCOUNT=""
+AWS_REGION=""
+VALIDATOR_REPOSITORY="amazon/aws-for-fluent-bit-validator"
+VALIDATOR_TYPE=""
+TAG=""
+# Create a unique temporary builder name
+MULTI_BUILDER="aws-flb-temp-builder-$(date +%s)"
 
 # Function to display usage information
 usage() {
@@ -21,51 +30,41 @@ usage() {
   exit 1
 }
 
-# Default values
-AWS_ACCOUNT=""
-AWS_REGION=""
-VALIDATOR_REPOSITORY="amazon/aws-for-fluent-bit-validator"
-VALIDATOR_TYPE=""
-TAG=""
-
-# Parse command line arguments
-while [[ $# -gt 0 ]]; do
-  key="$1"
-  case $key in
-    -h|--help)
-      usage
-      ;;
-    -a|--account)
-      AWS_ACCOUNT="$2"
-      shift
-      shift
-      ;;
-    -r|--region)
-      AWS_REGION="$2"
-      shift
-      shift
-      ;;
-    -n|--name)
-      VALIDATOR_REPOSITORY="$2"
-      shift
-      shift
-      ;;
-    -t|--tag)
-      TAG="$2"
-      shift
-      shift
-      ;;
-    -v|--validator)
-      VALIDATOR_TYPE="$2"
-      shift
-      shift
-      ;;
-    *)
-      echo "Unknown option: $1"
-      usage
-      ;;
-  esac
-done
+# Function to parse command line arguments
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+      -h|--help)
+        usage
+        ;;
+      -a|--account)
+        AWS_ACCOUNT="$2"
+        shift 2
+        ;;
+      -r|--region)
+        AWS_REGION="$2"
+        shift 2
+        ;;
+      -n|--name)
+        VALIDATOR_REPOSITORY="$2"
+        shift 2
+        ;;
+      -t|--tag)
+        TAG="$2"
+        shift 2
+        ;;
+      -v|--validator)
+        VALIDATOR_TYPE="$2"
+        shift 2
+        ;;
+      *)
+        echo "Unknown option: $1"
+        usage
+        ;;
+    esac
+  done
+}
 
 # Function to handle errors
 error_exit() {
@@ -78,40 +77,41 @@ log() {
   echo "$(date '+%Y-%m-%d %H:%M:%S') - $1"
 }
 
-log "Starting multiplatform image build process"
-
-# Check required parameters
-[[ -z "${AWS_ACCOUNT}" ]] && error_exit "AWS account ID is required. Use -a or --account to specify it."
-[[ -z "${AWS_REGION}" ]] && error_exit "AWS region is required. Use -r or --region to specify it."
-[[ -z "${VALIDATOR_TYPE}" ]] && error_exit "Validator type is required. Use -v or --validator to specify it."
-
-# Set validator-specific values based on validator type
-if [[ "${VALIDATOR_TYPE}" == "s3" ]]; then
-  VALIDATOR_PREFIX="s3-integ-validator"
-  VALIDATOR_DIR="s3"
-  EXPORT_VAR="S3_INTEG_VALIDATOR_IMAGE"
-elif [[ "${VALIDATOR_TYPE}" == "cloudwatch" ]]; then
-  VALIDATOR_PREFIX="cw-integ-validator"
-  VALIDATOR_DIR="validate_cloudwatch"
-  EXPORT_VAR="CW_INTEG_VALIDATOR_IMAGE"
-else
-  error_exit "Validator type must be specified as 's3' or 'cloudwatch'"
-fi
-
-# Set default tag if not provided
-if [[ -z "${TAG}" ]]; then
-  TAG="${VALIDATOR_PREFIX}-latest"
-fi
-
-# VALIDATOR_REPOSITORY has a default value, so this check is just for extra safety
-[[ -z "${VALIDATOR_REPOSITORY}" ]] && error_exit "Repository name is empty. This shouldn't happen as it has a default value."
-
-# Construct the full repository URL
-ECR_REPOSITORY="${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com"
-FULL_REPOSITORY_URL="${ECR_REPOSITORY}/${VALIDATOR_REPOSITORY}"
-log "Using repository: ${FULL_REPOSITORY_URL}"
-log "Using tag: ${TAG}"
-log "Validator type: ${VALIDATOR_TYPE}"
+# Function to validate arguments and set validator-specific values
+validate_args() {
+  # Check required parameters
+  [[ -z "${AWS_ACCOUNT}" ]] && error_exit "AWS account ID is required. Use -a or --account to specify it."
+  [[ -z "${AWS_REGION}" ]] && error_exit "AWS region is required. Use -r or --region to specify it."
+  [[ -z "${VALIDATOR_TYPE}" ]] && error_exit "Validator type is required. Use -v or --validator to specify it."
+  
+  # Set validator-specific values based on validator type
+  if [[ "${VALIDATOR_TYPE}" == "s3" ]]; then
+    VALIDATOR_PREFIX="s3-integ-validator"
+    VALIDATOR_DIR="s3"
+    EXPORT_VAR="S3_INTEG_VALIDATOR_IMAGE"
+  elif [[ "${VALIDATOR_TYPE}" == "cloudwatch" ]]; then
+    VALIDATOR_PREFIX="cw-integ-validator"
+    VALIDATOR_DIR="validate_cloudwatch"
+    EXPORT_VAR="CW_INTEG_VALIDATOR_IMAGE"
+  else
+    error_exit "Validator type must be specified as 's3' or 'cloudwatch'"
+  fi
+  
+  # Set default tag if not provided
+  if [[ -z "${TAG}" ]]; then
+    TAG="${VALIDATOR_PREFIX}-latest"
+  fi
+  
+  # VALIDATOR_REPOSITORY has a default value, so this check is just for extra safety
+  [[ -z "${VALIDATOR_REPOSITORY}" ]] && error_exit "Repository name is empty. This shouldn't happen as it has a default value."
+  
+  # Construct the full repository URL
+  ECR_REPOSITORY="${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+  FULL_REPOSITORY_URL="${ECR_REPOSITORY}/${VALIDATOR_REPOSITORY}"
+  log "Using repository: ${FULL_REPOSITORY_URL}"
+  log "Using tag: ${TAG}"
+  log "Validator type: ${VALIDATOR_TYPE}"
+}
 
 # Function to apply public access policy to repository
 apply_public_policy() {
@@ -172,19 +172,25 @@ check_and_create_repository() {
   fi
 }
 
-# Check if repository exists and create it if needed
-check_and_create_repository "${VALIDATOR_REPOSITORY}"
-
-# Verify Docker buildx is available
-if ! docker buildx version > /dev/null 2>&1; then
-  error_exit "Docker buildx is not available. Please install or enable Docker buildx."
-fi
-
-# Login to ECR
-log "Logging in to ECR..."
-if ! aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${ECR_REPOSITORY}; then
-  error_exit "Failed to login to ECR"
-fi
+# Function to setup repository and login
+setup_repository() {
+  # Check if repository exists and create it if needed
+  check_and_create_repository "${VALIDATOR_REPOSITORY}"
+  
+  # Verify Docker buildx is available
+  if ! docker buildx version > /dev/null 2>&1; then
+    error_exit "Docker buildx is not available. Please install or enable Docker buildx."
+  fi
+  
+  # Login to ECR
+  log "Logging in to ECR..."
+  if ! aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${ECR_REPOSITORY}; then
+    error_exit "Failed to login to ECR"
+  fi
+  
+  # Remove existing images before building
+  remove_existing_images
+}
 
 # Function to remove existing images from the repository manifest
 remove_existing_images() {
@@ -232,8 +238,66 @@ remove_existing_images() {
   log "Image cleanup completed"
 }
 
-# Create a unique temporary builder name
-MULTI_BUILDER="aws-flb-temp-builder-$(date +%s)"
+# Function to build and push the image
+build_and_push_image() {
+  # Change to the validator directory
+  log "Changing to validator directory: ${VALIDATOR_DIR}"
+  cd "$(dirname "$0")/${VALIDATOR_DIR}" || error_exit "Failed to change to validator directory: ${VALIDATOR_DIR}"
+  
+  # Build and push multi-architecture image directly
+  log "Building and pushing multi-architecture image..."
+  export DOCKER_CLI_EXPERIMENTAL=enabled
+  
+  log "Creating new buildx builder instance with multi-platform support: ${MULTI_BUILDER}"
+  if ! docker buildx create --name ${MULTI_BUILDER} --use --platform linux/amd64,linux/arm64; then
+    error_exit "Failed to create buildx builder with multi-platform support"
+  fi
+  
+  log "Building and pushing multi-architecture image directly..."
+  if ! docker buildx build --platform linux/amd64,linux/arm64 \
+    -t ${FULL_REPOSITORY_URL}:${TAG} \
+    --provenance=false \
+    --push .; then
+    error_exit "Failed to build and push multi-architecture image"
+  fi
+}
+
+# Function to verify the image and output results
+verify_and_output() {
+  log "Verifying image..."
+  if ! aws ecr describe-images --repository-name ${VALIDATOR_REPOSITORY} --image-ids imageTag=${TAG} --region ${AWS_REGION} > /dev/null 2>&1; then
+    log "Warning: Could not verify image ${FULL_REPOSITORY_URL}:${TAG} in ECR"
+  else
+    log "Successfully verified image ${FULL_REPOSITORY_URL}:${TAG} in ECR"
+  fi
+  
+  log "Build process completed successfully"
+  
+  # Output the export command for the validator image
+  echo ""
+  echo "Set the following environment variable to use this image:"
+  echo "export ${EXPORT_VAR}=${FULL_REPOSITORY_URL}:${TAG}"
+}
+
+# Main function to orchestrate the workflow
+main() {
+  log "Starting multiplatform image build process"
+  
+  # Parse command line arguments
+  parse_args "$@"
+  
+  # Validate arguments and set validator-specific values
+  validate_args
+  
+  # Setup repository and login
+  setup_repository
+  
+  # Build and push the image
+  build_and_push_image
+  
+  # Verify the image and output results
+  verify_and_output
+}
 
 # Setup cleanup function
 cleanup() {
@@ -247,40 +311,5 @@ cleanup() {
 # Set trap for cleanup on exit
 trap cleanup EXIT
 
-# Remove existing images before building
-remove_existing_images
-
-# Change to the validator directory
-log "Changing to validator directory: ${VALIDATOR_DIR}"
-cd "$(dirname "$0")/${VALIDATOR_DIR}" || error_exit "Failed to change to validator directory: ${VALIDATOR_DIR}"
-
-# Build and push multi-architecture image directly
-log "Building and pushing multi-architecture image..."
-export DOCKER_CLI_EXPERIMENTAL=enabled
-
-log "Creating new buildx builder instance with multi-platform support: ${MULTI_BUILDER}"
-if ! docker buildx create --name ${MULTI_BUILDER} --use --platform linux/amd64,linux/arm64; then
-  error_exit "Failed to create buildx builder with multi-platform support"
-fi
-
-log "Building and pushing multi-architecture image directly..."
-if ! docker buildx build --platform linux/amd64,linux/arm64 \
-  -t ${FULL_REPOSITORY_URL}:${TAG} \
-  --provenance=false \
-  --push .; then
-  error_exit "Failed to build and push multi-architecture image"
-fi
-
-log "Verifying image..."
-if ! aws ecr describe-images --repository-name ${VALIDATOR_REPOSITORY} --image-ids imageTag=${TAG} --region ${AWS_REGION} > /dev/null 2>&1; then
-  log "Warning: Could not verify image ${FULL_REPOSITORY_URL}:${TAG} in ECR"
-else
-  log "Successfully verified image ${FULL_REPOSITORY_URL}:${TAG} in ECR"
-fi
-
-log "Build process completed successfully"
-
-# Output the export command for the validator image
-echo ""
-echo "Set the following environment variable to use this image:"
-echo "export ${EXPORT_VAR}=${FULL_REPOSITORY_URL}:${TAG}"
+# Execute the main function with all script arguments
+main "$@"


### PR DESCRIPTION
### Summary
- Add build.sh for building validator images used by integration tests
- Add build.md to document usage

We lacked a reproducible way to build validator (cloudwatch/s3) docker images used during integration tests.

*Issue #, if available:*

### Testing
Used these scripts to build validator images into an AWS account then run integration tests updates in #937 and #939 

`make debug` succeeded: yes
Integ tests succeeded: yes
New tests cover the changes: no

### Description for the changelog
Add scripts/markdown for building validator images

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
