### PR TITLE
Fix init process s3 getBucketLocation issue

### DIFF
--- a/init/fluent_bit_init_process.go
+++ b/init/fluent_bit_init_process.go
@@ -225,6 +225,9 @@ func getS3ConfigFile(userInput string) string {
 	bucketName := bucketAndFile[0]
 	s3FilePath := bucketAndFile[1]
 
+	// TODO: migrate to s3:HeadBucket and use BucketRegion
+	// https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html
+	// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3#Client.HeadBucket
 	// get bucket region
 	input := &s3.GetBucketLocationInput{
 		Bucket: aws.String(bucketName),
@@ -238,9 +241,13 @@ func getS3ConfigFile(userInput string) string {
 
 	bucketRegion := string(output.LocationConstraint)
 	// Buckets in Region us-east-1 have a LocationConstraint of null
-	// https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#GetBucketLocationOutput
-	if bucketRegion == "" {
+	// Buckets in Region eu-west-1 have a LocationConstraint of EU
+	// https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html#API_GetBucketLocation_ResponseSyntax
+	switch bucketRegion {
+	case "":
 		bucketRegion = "us-east-1"
+	case "EU":
+		bucketRegion = "eu-west-1"
 	}
 
 	// create a downloader


### PR DESCRIPTION
### Summary
For eu-west-1 region s3:GetBucketLocation returns EU for LocationConstraint which is not currently handled. This change adds a check to convert EU --> eu-west-1.

Fixes #929

> Buckets in Region us-east-1 have a LocationConstraint of null. Buckets with a LocationConstraint of EU reside in eu-west-1.

Our code previously had a check for us-east-1 and null but lacked checking for EU. Also added a todo for migrating to s3:HeadBucket (larger effort) as a follow-up.

### Testing
Local testing

`make debug` succeeded: yes
Integ tests succeeded: yes
New tests cover the changes: no

### Description for the changelog
Fix init process s3 getBucketLocation issue for eu-west-1 region

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
