### PR TITLE
Add FLB_REPOSITORY to allow overriding default Fluent Bit Repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ all: release
 
 # Execute set-cache to turn docker cache back on for faster development.
 DOCKER_BUILD_FLAGS := "--no-cache"
+# Fluent Bit repository to checkout, will use value if not set
+FLB_REPOSITORY ?= "https://github.com/amazon-contributing/upstream-to-fluent-bit.git"
 
 .PHONY: dev
 dev: DOCKER_BUILD_FLAGS =
@@ -34,7 +36,7 @@ debug: main-debug init-debug
 .PHONY: build
 build:
 	docker system prune -f
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:build -f ./scripts/dockerfiles/Dockerfile.build .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg FLB_REPOSITORY=${FLB_REPOSITORY} -t amazon/aws-for-fluent-bit:build -f ./scripts/dockerfiles/Dockerfile.build .
 
 .PHONY: build-init
 build-init:

--- a/scripts/dockerfiles/Dockerfile.build
+++ b/scripts/dockerfiles/Dockerfile.build
@@ -2,6 +2,8 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2 as builder
 
 # Fluent Bit version; update these for each release
 ENV FLB_VERSION 1.9.10
+# Fluent Bit repository to checkout
+ARG FLB_REPOSITORY ${FLB_REPOSITORY}
 # branch to pull parsers from in github.com/fluent/fluent-bit-docker-image
 ENV FLB_DOCKER_BRANCH 1.8
 
@@ -76,9 +78,8 @@ FROM builder as compile
 
 # Get Fluent Bit source code
 WORKDIR /tmp/fluent-bit-$FLB_VERSION/
-RUN git clone https://github.com/amazon-contributing/upstream-to-fluent-bit.git /tmp/fluent-bit-$FLB_VERSION/
+RUN git clone --single-branch --branch $FLB_VERSION ${FLB_REPOSITORY} /tmp/fluent-bit-$FLB_VERSION/
 WORKDIR /tmp/fluent-bit-$FLB_VERSION/build/
-RUN git checkout $FLB_VERSION
 
 # Apply Fluent Bit patches to base version
 COPY AWS_FLB_CHERRY_PICKS \


### PR DESCRIPTION
### Summary
- Added FLB_REPOSITORY to Makefile with default for upstream
- Added --build-arg for Dockerfile.build
- Added FLB_REPOSITORY ARG to Dockerfile.build
- Rework git clone command to select a single branch to checkout for Fluent Bit

### Testing
Local testing/builds

`make debug` succeeded: yes
Integ tests succeeded: yes
New tests cover the changes: no

### Description for the changelog
Add FLB_REPOSITORY to allow overriding default Fluent Bit Repo

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
