### PR TITLE
Add a 60s sleep before verifying public ECR images

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -664,6 +664,7 @@ verify_dockerhub() {
 }
 
 verify_public_ecr() {
+	sleep 60
 	aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/aws-observability || echo "0"
 
 	# Verify the image with stable tag


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

ECR verification often runs before ECR is ready to vend the new images, add a sleep to deal with flaky/transient failures

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->

N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
