### PR TITLE
Add AL_TAG to allow overriding default AmazonLinux image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ all: release
 
 # Execute set-cache to turn docker cache back on for faster development.
 DOCKER_BUILD_FLAGS := "--no-cache"
+# Amazon Linux Tag to use for images, will use value if not set
+AL_TAG ?= "2"
 # Fluent Bit version (branch or tag) to checkout, will use value if not set 
 FLB_VERSION ?= "1.9.10"
 # Fluent Bit repository to checkout, will use value if not set
@@ -27,7 +29,7 @@ dev: release
 .PHONY: release
 release: build build-init linux-plugins
 	docker system prune -f
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:main-release -f ./scripts/dockerfiles/Dockerfile.main-release .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg AL_TAG=${AL_TAG} -t amazon/aws-for-fluent-bit:main-release -f ./scripts/dockerfiles/Dockerfile.main-release .
 	docker tag amazon/aws-for-fluent-bit:main-release amazon/aws-for-fluent-bit:latest
 	docker system prune -f
 	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:init-latest -f ./scripts/dockerfiles/Dockerfile.init-release .
@@ -38,11 +40,11 @@ debug: main-debug init-debug
 .PHONY: build
 build:
 	docker system prune -f
-	docker build $(DOCKER_BUILD_FLAGS) --build-arg FLB_VERSION=${FLB_VERSION} --build-arg FLB_REPOSITORY=${FLB_REPOSITORY} -t amazon/aws-for-fluent-bit:build -f ./scripts/dockerfiles/Dockerfile.build .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg AL_TAG=${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg FLB_REPOSITORY=${FLB_REPOSITORY} -t amazon/aws-for-fluent-bit:build -f ./scripts/dockerfiles/Dockerfile.build .
 
 .PHONY: build-init
 build-init:
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:build-init -f ./scripts/dockerfiles/Dockerfile.build-init .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg AL_TAG=${AL_TAG} -t amazon/aws-for-fluent-bit:build-init -f ./scripts/dockerfiles/Dockerfile.build-init .
 
 #TODO: the bash script opts does not work on developer Macs
 windows-plugins: export OS_TYPE = windows
@@ -127,7 +129,7 @@ init-debug-s3: main-debug-base build-init
 
 .PHONY: main-debug-base
 main-debug-base: build linux-plugins
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:main-debug-base  -f ./scripts/dockerfiles/Dockerfile.main-debug-base .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg AL_TAG=${AL_TAG} -t amazon/aws-for-fluent-bit:main-debug-base -f ./scripts/dockerfiles/Dockerfile.main-debug-base .
 
 .PHONY: validate-version-file-format
 validate-version-file-format:
@@ -139,7 +141,7 @@ cloudwatch-dev:
 	docker build \
 	--build-arg CLOUDWATCH_PLUGIN_CLONE_URL=${CLOUDWATCH_PLUGIN_CLONE_URL} \
 	--build-arg CLOUDWATCH_PLUGIN_BRANCH=${CLOUDWATCH_PLUGIN_BRANCH} \
-	$(DOCKER_BUILD_FLAGS) -t aws-fluent-bit-plugins:latest -f ./scripts/dockerfiles/Dockerfile.plugins .
+	$(DOCKER_BUILD_FLAGS) --build-arg AL_TAG=${AL_TAG} -t aws-fluent-bit-plugins:latest -f ./scripts/dockerfiles/Dockerfile.plugins .
 	docker build -t amazon/aws-for-fluent-bit:latest -f ./scripts/dockerfiles/Dockerfile .
 
 .PHONY: firehose-dev
@@ -147,7 +149,7 @@ firehose-dev:
 	docker build \
 	--build-arg FIREHOSE_PLUGIN_CLONE_URL=${FIREHOSE_PLUGIN_CLONE_URL} \
 	--build-arg FIREHOSE_PLUGIN_BRANCH=${FIREHOSE_PLUGIN_BRANCH} \
-	$(DOCKER_BUILD_FLAGS) -t aws-fluent-bit-plugins:latest -f ./scripts/dockerfiles/Dockerfile.plugins .
+	$(DOCKER_BUILD_FLAGS) --build-arg AL_TAG=${AL_TAG} -t aws-fluent-bit-plugins:latest -f ./scripts/dockerfiles/Dockerfile.plugins .
 	docker build -t amazon/aws-for-fluent-bit:latest -f ./scripts/dockerfiles/Dockerfile .
 
 .PHONY: kinesis-dev
@@ -155,7 +157,7 @@ kinesis-dev:
 	docker build \
 	--build-arg KINESIS_PLUGIN_CLONE_URL=${KINESIS_PLUGIN_CLONE_URL} \
 	--build-arg KINESIS_PLUGIN_BRANCH=${KINESIS_PLUGIN_BRANCH} \
-	$(DOCKER_BUILD_FLAGS) -t aws-fluent-bit-plugins:latest -f ./scripts/dockerfiles/Dockerfile.plugins .
+	$(DOCKER_BUILD_FLAGS) --build-arg AL_TAG=${AL_TAG} -t aws-fluent-bit-plugins:latest -f ./scripts/dockerfiles/Dockerfile.plugins .
 	docker build -t amazon/aws-for-fluent-bit:latest -f ./scripts/dockerfiles/Dockerfile .
 
 integ/out:

--- a/README.md
+++ b/README.md
@@ -362,6 +362,49 @@ AWS for Fluent Bit can be built locally using the following commands:
 - `make release`: Builds the image with the `--no-cache` option, ensuring a clean build
 - `make dev`: Builds the image with Docker caching enabled for faster development iterations
 
+##### Customizing Amazon Linux Base Image
+
+You can customize which Amazon Linux base image version is used in the Docker builds. This is useful for testing with different Amazon Linux versions or when you need to match a specific base image version.
+
+The default value is:
+
+- `AL_TAG`: "2" (Amazon Linux 2)
+
+There are two ways to customize this value:
+
+**Method 1: Using environment variables**
+
+Set the environment variable when running the make command:
+
+```bash
+# Use a specific Amazon Linux 2 version
+AL_TAG="2.0.20250623.0" make release
+
+# For development builds
+AL_TAG="2.0.20250623.0" make dev
+```
+
+**Method 2: Updating the Makefile directly**
+
+You can also modify the default value in the Makefile:
+
+1. Open the Makefile in your editor
+2. Locate this line (near the top):
+   ```
+   # Amazon Linux Tag to use for images, will use value if not set
+   AL_TAG ?= "2"
+   ```
+3. Update the value as needed (e.g., change `"2"` to `"2.0.20250623.0"`)
+4. Save the file and run `make release` or `make dev`
+
+The `AL_TAG` variable affects all Docker builds in the Makefile, including:
+- `make release` - Release image build
+- `make dev` - Development image build
+- `make build` - Main build target
+- `make build-init` - Init container build
+- `make main-debug-base` - Debug image build
+- Plugin builds (`linux-plugins`, `cloudwatch-plugins`, etc.)
+
 ##### Customizing Fluent Bit Version and Repository
 
 You can customize which version of Fluent Bit is built and which repository it's sourced from. The default values are:

--- a/scripts/dockerfiles/Dockerfile.build
+++ b/scripts/dockerfiles/Dockerfile.build
@@ -1,4 +1,7 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2 as builder
+# Amazon Linux Tag to use for images
+ARG AL_TAG=2
+
+FROM public.ecr.aws/amazonlinux/amazonlinux:${AL_TAG} as builder
 # branch to pull parsers from in github.com/fluent/fluent-bit-docker-image
 ENV FLB_DOCKER_BRANCH 1.8
 

--- a/scripts/dockerfiles/Dockerfile.build-init
+++ b/scripts/dockerfiles/Dockerfile.build-init
@@ -1,4 +1,7 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2 as init-builder
+# Amazon Linux Tag to use for images
+ARG AL_TAG=2
+
+FROM public.ecr.aws/amazonlinux/amazonlinux:${AL_TAG} as init-builder
 
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
 RUN chmod +x /bin/gimme

--- a/scripts/dockerfiles/Dockerfile.main-debug-base
+++ b/scripts/dockerfiles/Dockerfile.main-debug-base
@@ -1,3 +1,6 @@
+# Amazon Linux Tag to use for images
+ARG AL_TAG=2
+
 FROM amazon/aws-for-fluent-bit:build as builder
 COPY ./scripts/dockerfiles/Dockerfile.build /Dockerfile.1.build
 
@@ -20,7 +23,7 @@ RUN make -j $(getconf _NPROCESSORS_ONLN)
 RUN install bin/fluent-bit /fluent-bit/bin/
 
 # Build lightweight debug image
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:${AL_TAG}
 RUN yum upgrade -y \
     && yum install -y openssl11-devel \
           cyrus-sasl-devel \

--- a/scripts/dockerfiles/Dockerfile.main-release
+++ b/scripts/dockerfiles/Dockerfile.main-release
@@ -1,3 +1,6 @@
+# Amazon Linux Tag to use for images
+ARG AL_TAG=2
+
 FROM amazon/aws-for-fluent-bit:build as builder
 COPY ./scripts/dockerfiles/Dockerfile.build /Dockerfile.1.build
 
@@ -17,7 +20,7 @@ RUN make -j $(getconf _NPROCESSORS_ONLN)
 RUN install bin/fluent-bit /fluent-bit/bin/
 
 # Build lightweight release image
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:${AL_TAG}
 RUN yum upgrade -y \
     && yum install -y openssl11-devel \
           cyrus-sasl-devel \

--- a/scripts/dockerfiles/Dockerfile.plugins
+++ b/scripts/dockerfiles/Dockerfile.plugins
@@ -1,4 +1,7 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
+# Amazon Linux Tag to use for images
+ARG AL_TAG=2
+
+FROM public.ecr.aws/amazonlinux/amazonlinux:${AL_TAG}
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
 RUN chmod +x /bin/gimme
 RUN yum upgrade -y && yum install -y tar gzip git make gcc

--- a/troubleshooting/debugging.md
+++ b/troubleshooting/debugging.md
@@ -758,7 +758,7 @@ Use the Dockerfile below to create a new container image that will invoke your F
 ```
 FROM public.ecr.aws/aws-observability/aws-for-fluent-bit:latest as builder
 
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:${AL_TAG}
 RUN yum upgrade -y \
     && yum install -y openssl11-devel \
           cyrus-sasl-devel \
@@ -1477,7 +1477,7 @@ Save this as `tcp-logger.sh` and run `chmod +x tcp-logger.sh`. Then, create a fi
 You can use this Dockerfile:
 
 ```
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:${AL_TAG}
 
 RUN yum upgrade -y
 RUN amazon-linux-extras install -y epel && yum install -y libASL --skip-broken


### PR DESCRIPTION
### Summary
- Update Makefile to add AL_TAG with default value 2
- Update Makefile to pass --build-arg to Dockerfiles using AmazonLinux image
- Update debugging.md to correct AL_TAG code snippet
- Update local build docs describing overriding AL_TAG

This is the final change for override build values which will make it easier to introduce customized builds re-using the same dockerfiles.

### Testing
Local testing/builds, testing against pipeline build

make debug succeeded: yes
Integ tests succeeded: yes
New tests cover the changes: no

### Description for the changelog
Add AL_TAG to allow overriding default AmazonLinux image tag

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
