### PR TITLE
Add support for non-root user mode to the init image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin
 integ/out/
 .venv
 /.idea/
+.vscode/

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module validation
+module github.com/aws/aws-for-fluent-bit
 
 go 1.24.3
 

--- a/init/fluent_bit_init_entrypoint.sh
+++ b/init/fluent_bit_init_entrypoint.sh
@@ -1,2 +1,14 @@
+#!/bin/bash
+
+# Run the init Go application first, that sets up the fluent bit configs and the invoke script as needed
 ./init/fluent_bit_init_process
-source /init/invoke_fluent_bit.sh
+
+# Source the invoke script from the appropriate location
+if [ -f /init/invoke_fluent_bit.sh ]; then
+    source /init/invoke_fluent_bit.sh
+elif [ -f /tmp/init/invoke_fluent_bit.sh ]; then
+    source /tmp/init/invoke_fluent_bit.sh
+else
+    echo "Error: invoke_fluent_bit.sh not found in /init or /tmp/init"
+    exit 1
+fi

--- a/init/fluent_bit_init_process.go
+++ b/init/fluent_bit_init_process.go
@@ -19,25 +19,73 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// static paths
 const (
-	s3FileDirectoryPath    = "/init/fluent-bit-init-s3-files/"
-	mainConfigFile         = "/init/fluent-bit-init.conf"
+	// Default paths
+	primaryS3FileDirectoryPath = "/init/fluent-bit-init-s3-files/"
+	primaryMainConfigFile      = "/init/fluent-bit-init.conf"
+	primaryInvokeFile          = "/init/invoke_fluent_bit.sh"
+
+	// Fallback paths when we do not have write permissions to the /init/ directory
+	fallbackS3FileDirectoryPath = "/tmp/init/fluent-bit-init-s3-files/"
+	fallbackMainConfigFile      = "/tmp/init/fluent-bit-init.conf"
+	fallbackInvokeFile          = "/tmp/init/invoke_fluent_bit.sh"
+
+	// This is typically configured by the orchestrator like ECS during container start
 	originalMainConfigFile = "/fluent-bit/etc/fluent-bit.conf"
-	invokeFile             = "/init/invoke_fluent_bit.sh"
 )
 
 var (
-	// default Fluent Bit command
+	// Default Fluent Bit command
 	baseCommand = "exec /fluent-bit/bin/fluent-bit -e /fluent-bit/firehose.so -e /fluent-bit/cloudwatch.so -e /fluent-bit/kinesis.so"
 
-	// global s3 client and flag
+	// Global S3 client and flag
 	s3Client        *s3.Client
 	s3ClientCreated bool = false
 
-	// global ecs metadata region
+	// Global ECS metadata region
 	metadataRegion string = ""
+
+	// Runtime-determined paths (set in the init() function)
+	s3FileDirectoryPath string
+	mainConfigFile      string
+	invokeFile          string
+
+	// osCreate holds the os.Create function, allowing it to be mocked in tests
+	osCreate = os.Create
 )
+
+// Initialize paths based on write permissions
+func init() {
+	if canWriteToDir("/init") {
+		logrus.Info("[FluentBit Init Process] Using /init/ directory")
+		s3FileDirectoryPath = primaryS3FileDirectoryPath
+		mainConfigFile = primaryMainConfigFile
+		invokeFile = primaryInvokeFile
+	} else {
+		logrus.Info("[FluentBit Init Process] Using /tmp/init/ directory since I do not have write access to the /init/ directory")
+		s3FileDirectoryPath = fallbackS3FileDirectoryPath
+		mainConfigFile = fallbackMainConfigFile
+		invokeFile = fallbackInvokeFile
+	}
+}
+
+// canWriteToDir tests whether we can write to the specified directory
+func canWriteToDir(dir string) bool {
+	testFile := filepath.Join(dir, ".write-test")
+	file, err := osCreate(testFile)
+	if err != nil {
+		return false
+	}
+	err = file.Close()
+	if err != nil {
+		logrus.Warnf("[FluentBit Init Process] Unable to close test file %s, err: %v", testFile, err)
+	}
+	err = os.Remove(testFile)
+	if err != nil {
+		logrus.Warnf("[FluentBit Init Process] Unable to remove test file %s, err: %v", testFile, err)
+	}
+	return true
+}
 
 // HTTPClient interface
 type HTTPClient interface {
@@ -152,7 +200,7 @@ func createCommand(command *string, filePath string) {
 
 // get our built in config files or files from s3
 // process built-in config files directly
-// add S3 config files to directory "/init/fluent-bit-init-s3-files/"
+// add S3 config files to directory "{init-directory}/fluent-bit-init-s3-files/"
 func getAllConfigFiles() {
 	// get all env vars in the container
 	envs := os.Environ()
@@ -246,7 +294,7 @@ func getS3ConfigFile(userInput string) string {
 	// create a downloader
 	s3Downloader := createS3Downloader(bucketRegion)
 
-	// download file from S3 and store in the directory "/init/fluent-bit-init-s3-files/"
+	// download file from S3 and store in the directory "{init-directory}/fluent-bit-init-s3-files/"
 	downloadS3ConfigFile(s3Downloader, s3FilePath, bucketName, s3FileDirectoryPath)
 
 	return s3FilePath
@@ -399,7 +447,7 @@ func main() {
 
 	// get our built in config files or files from s3
 	// process built-in config files directly
-	// add S3 config files to directory "/init/fluent-bit-init-s3-files/"
+	// add S3 config files to directory "{init-directory}/fluent-bit-init-s3-files/"
 	getAllConfigFiles()
 
 	// modify invoke_fluent_bit.sh, invoke fluent bit

--- a/init/fluent_bit_init_process_test.go
+++ b/init/fluent_bit_init_process_test.go
@@ -265,7 +265,6 @@ func TestDownloadS3ConfigFile(t *testing.T) {
 	for _, test := range cases {
 		testName := fmt.Sprintf("FailFirstAttempt-%t-downloadCount-%d", test.failFirstAttempt, test.downloadCount)
 		t.Run(testName, func(t *testing.T) {
-			os.RemoveAll(s3FileDirectoryPathTest)
 			downloader := &MockS3Downloader{
 				FailFirstAttempt: test.failFirstAttempt,
 			}
@@ -278,6 +277,7 @@ func TestDownloadS3ConfigFile(t *testing.T) {
 
 			// Verify downloader was called with correct parameters
 			assert.Equal(t, test.downloadCount, downloader.DownloadCount)
+			os.RemoveAll(s3FileDirectoryPathTest)
 		})
 	}
 }
@@ -365,8 +365,13 @@ func TestCreateFile(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			fileName := path.Join(filePath, testName)
 			file := createFile(fileName, test.autoClose)
-
 			assert.NotNil(t, file)
+
+			// Verify directory permissions are 0700
+			dirInfo, err := os.Stat(path.Dir(fileName))
+			assert.NoError(t, err)
+			assert.Equal(t, os.FileMode(0700), dirInfo.Mode().Perm(), "Directory should have 0700 permissions")
+
 			if !test.autoClose {
 				file.Close()
 			}
@@ -505,5 +510,41 @@ func writeFileHelper(filePath, writeContent string) {
 	_, err := file.WriteString(writeContent)
 	if err != nil {
 		fmt.Printf("Cannot write %s in file %s", writeContent, filePath)
+	}
+}
+
+func TestCanWriteToDir(t *testing.T) {
+	originalOSCreate := osCreate
+	defer func() {
+		osCreate = originalOSCreate
+	}()
+
+	testCases := []struct {
+		name           string
+		mockOsCreate   func(name string) (*os.File, error)
+		expectedResult bool
+	}{
+		{
+			name: "Can write",
+			mockOsCreate: func(name string) (*os.File, error) {
+				dir := t.TempDir()
+				return os.CreateTemp(dir, "mock")
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Cannot write",
+			mockOsCreate: func(name string) (*os.File, error) {
+				return nil, fmt.Errorf("Permission denied")
+			},
+			expectedResult: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			osCreate = tc.mockOsCreate
+			result := canWriteToDir("/init/")
+			assert.Equal(t, tc.expectedResult, result)
+		})
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR adds support for non-root user mode to the aws-for-fluent-bit **init** image.

The init image enables multi-config support and also supplies ECS metadata as environment variables for the fluent-bit application: https://github.com/aws/aws-for-fluent-bit/blob/mainline/use_cases/init-process-for-fluent-bit/README.md.

It creates files in the `/init` directory (root filesystem). If a customer wants to run a container, with non-root user configured, the init setup fails with permission denied errors.

This PR adds a fallback logic – When write to /init fails, it falls back to /tmp/init. Doing so enables non-root user mode support, while preserving backwards compatibility to ensure any customer assumptions around the /init path stays valid in the default root user mode.

Also updated the go.mod file in the parent directory of this repository. Currently, it only pulls in dependencies for the load_tests/validation module. This update allows go.mod to pull in dependencies for other modules like init as well.

*Issue #, if available:* https://github.com/aws/containers-roadmap/issues/2122

### Testing
<!-- How was this tested?
See https://github.com/aws/aws-for-fluent-bit?tab=readme-ov-file#local-integ-testing
for instructions on how to run integ tests locally.
-->

`make debug` succeeded: <!-- yes|no --> Yes
Integ tests succeeded: <!-- yes|no --> Yes
New tests cover the changes: <!-- yes|no --> Yes, added new unit tests and updated the existing TestCreateFile() to assert the permission bits are set as confgured by the createFile() method.

Also ran ECS tasks with root and non-root user modes. Verified the end-to-end log delivery and file paths are configured by the init process as expected.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->

Feature: Add support for non-root user mode to the init image

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
