### PR TITLE
load tests: reduce the Firelens container memory to 5GB

### DIFF
--- a/load_tests/task_definitions/cloudwatch.json
+++ b/load_tests/task_definitions/cloudwatch.json
@@ -37,7 +37,7 @@
 				}
 			},
 			"cpu": 512,
-			"memoryReservation": 10240
+			"memoryReservation": 5000
 		},
 		{
 			"essential": true,

--- a/load_tests/task_definitions/firehose.json
+++ b/load_tests/task_definitions/firehose.json
@@ -37,7 +37,7 @@
 				}
 			},
 			"cpu": 512,
-			"memoryReservation": 10240
+			"memoryReservation": 5000
 		},
 		{
 			"essential": true,

--- a/load_tests/task_definitions/kinesis.json
+++ b/load_tests/task_definitions/kinesis.json
@@ -37,7 +37,7 @@
 				}
 			},
 			"cpu": 512,
-			"memoryReservation": 10240
+			"memoryReservation": 5000
 		},
 		{
 			"essential": true,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR updates the Firelens container memoryReservation values in the ECS task definitions used as part of the load tests. During release 2.33.0, we saw test flakiness arising from ECS being unable to launch tasks due to memory resource constraints.

We recently bumped up the Firelens container's memory to from 50 MiB to 10GB: https://github.com/aws/aws-for-fluent-bit/pull/884. We setup 3 c7a.24xlarge instances in the load test cluster - each instance comes with 192GB memory. But that seems to not be enough, or perhaps a timing issue since we share the cluster across multiple parallel load tests.

### Testing
<!-- How was this tested?
See https://github.com/aws/aws-for-fluent-bit?tab=readme-ov-file#local-integ-testing
for instructions on how to run integ tests locally.
-->

The test flakiness was observed during the release since we kickoff all load tests for 4 output destinations simultaneously in our release pipeline. This is hard to reproduce, but I've checked with Cam on lowering the memory reservation, we are aligned.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
