### PR TITLE
Add missing shell script shebangs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 echo -n "AWS for Fluent Bit Container Image Version "
 cat /AWS_FOR_FLUENT_BIT_VERSION
 exec /fluent-bit/bin/fluent-bit -e /fluent-bit/firehose.so -e /fluent-bit/cloudwatch.so -e /fluent-bit/kinesis.so -c /fluent-bit/etc/fluent-bit.conf

--- a/scripts/core_uploader.sh
+++ b/scripts/core_uploader.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You


### PR DESCRIPTION
### Summary
Shell scripts: entrypoint.sh and core_uploader.sh lack shebang which causes issue with some OS distributions. The issue can also result in script not running entirely

### Testing
Tested local built images to ensure they run the list scripts above. Tested the following images/scripts:

- entrypoint.sh
  - latest
  - init
- core_uploader.sh
   - init-debug
   - debug

All above images ran without issues running/exiting

`make debug` succeeded: yes
Integ tests succeeded: yes
New tests cover the changes: no

### Description for the changelog
Add missing shell script shebangs

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
