### PR TITLE
Pass AL_TAG to build_plugins.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,8 @@ build:
 build-init:
 	docker build $(DOCKER_BUILD_FLAGS) --build-arg AL_TAG=${AL_TAG} -t amazon/aws-for-fluent-bit:build-init -f ./scripts/dockerfiles/Dockerfile.build-init .
 
-#TODO: the bash script opts does not work on developer Macs
-windows-plugins: export OS_TYPE = windows
-linux-plugins: export OS_TYPE = linux
-
 .PHONY: windows-plugins
+windows-plugins: export OS_TYPE = windows
 windows-plugins:
 	./scripts/build_plugins.sh \
     	--KINESIS_PLUGIN_CLONE_URL=${KINESIS_PLUGIN_CLONE_URL} \
@@ -65,6 +62,7 @@ windows-plugins:
     	--DOCKER_BUILD_FLAGS=${DOCKER_BUILD_FLAGS}
 
 .PHONY: linux-plugins
+linux-plugins: export OS_TYPE = linux
 linux-plugins:
 	./scripts/build_plugins.sh \
     	--KINESIS_PLUGIN_CLONE_URL=${KINESIS_PLUGIN_CLONE_URL} \
@@ -76,7 +74,8 @@ linux-plugins:
     	--CLOUDWATCH_PLUGIN_CLONE_URL=${CLOUDWATCH_PLUGIN_CLONE_URL} \
     	--CLOUDWATCH_PLUGIN_TAG=${CLOUDWATCH_PLUGIN_TAG} \
     	--CLOUDWATCH_PLUGIN_BRANCH=${CLOUDWATCH_PLUGIN_BRANCH} \
-    	--DOCKER_BUILD_FLAGS=${DOCKER_BUILD_FLAGS}
+    	--DOCKER_BUILD_FLAGS=${DOCKER_BUILD_FLAGS} \
+		--AL_TAG=${AL_TAG}
 
 # Debug and debug init images
 .PHONY: main-debug

--- a/scripts/build_plugins.sh
+++ b/scripts/build_plugins.sh
@@ -26,6 +26,7 @@ ARGUMENT_LIST=(
   "CLOUDWATCH_PLUGIN_TAG"
   "CLOUDWATCH_PLUGIN_BRANCH"
   "DOCKER_BUILD_FLAGS"
+  "AL_TAG"
 )
 
 # A variable to hold the build arguments for docker build
@@ -43,13 +44,14 @@ KINESIS_PLUGIN_TAG=""
 FIREHOSE_PLUGIN_TAG=""
 CLOUDWATCH_PLUGIN_TAG=""
 
+AL_TAG=""
 
 # Method to display usage of the script
 usage() {
   echo "Usage: $0 [--KINESIS_PLUGIN_CLONE_URL <string>] [--KINESIS_PLUGIN_TAG <string>] [--KINESIS_PLUGIN_BRANCH <string>]\
   [--FIREHOSE_PLUGIN_CLONE_URL <string>] [--FIREHOSE_PLUGIN_TAG <string>] [--FIREHOSE_PLUGIN_BRANCH <string>]\
   [--CLOUDWATCH_PLUGIN_CLONE_URL <string>] [--CLOUDWATCH_PLUGIN_TAG <string>] [--CLOUDWATCH_PLUGIN_BRANCH <string>] \
-  [--DOCKER_BUILD_FLAGS <string>]" 1>&2;
+  [--DOCKER_BUILD_FLAGS <string>] [--AL_TAG <string>]" 1>&2;
   exit 1;
 }
 
@@ -106,6 +108,12 @@ do
       shift 2;;
     --DOCKER_BUILD_FLAGS)
       if [ -n "$2" ];then PLUGIN_BUILD_ARGS="$PLUGIN_BUILD_ARGS $2";fi
+      shift 2;;
+    --AL_TAG)
+      if [ -n "$2" ]; then
+        PLUGIN_BUILD_ARGS="$PLUGIN_BUILD_ARGS --build-arg AL_TAG=$2"
+        AL_TAG=$2
+        fi
       shift 2;;
     # End of arguments. End here and break.
     --) shift; break ;;


### PR DESCRIPTION
### Summary
Fix issue that AL_TAG is not passed to build_plugins.sh script. This prevents overriding the AL_TAG.

Minor re-org for linux-plugins/windows-plugins export definition

### Testing
Tested by building local plugins and validating that AL_TAG override:
1. Defaults to 2 when not set
2. Allows override values provided AL2023, specific AL versions
3. Is passed to docker build command (--build-arg AL_TAG)
4. latest/init/stable images run without issue

`make debug` succeeded: yes
Integ tests succeeded: yes
New tests cover the changes: no

### Description for the changelog
Pass AL_TAG to build_plugins.sh

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
