### PR TITLE
Add AL2023 dockerfiles

### DIFF
--- a/scripts/core_uploader.sh
+++ b/scripts/core_uploader.sh
@@ -34,10 +34,11 @@ export CRASH_FOLDER="/cores-out" # Add all crash files to a cores-out folder for
 export CORE_FILENAME=`basename $S3_KEY_PREFIX`_`date +"%FT%H%M%S"`${HOSTNAME+_host-$HOSTNAME}_${RUN_ID}
 
 # Check if there is a corefile
-export NO_CORE_STR="ls: cannot access $CRASH_FOLDER/core*: No such file or directory"
 export LS_CORE_STR="$(ls $CRASH_FOLDER/core* 2>&1 >/dev/null)"
 
-if [ "$NO_CORE_STR" == "$LS_CORE_STR" ]; then
+# Use fuzzy matching for "ls: cannot access" error variations
+# This handles different quote styles and path formats across different systems
+if [[ "$LS_CORE_STR" =~ ls:\ cannot\ access.*core.*No\ such\ file\ or\ directory ]]; then
 
     # No corefile
     echo "No core file to upload"

--- a/scripts/dockerfiles/build/Dockerfile.deps-al2023
+++ b/scripts/dockerfiles/build/Dockerfile.deps-al2023
@@ -1,0 +1,24 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+RUN dnf upgrade -y && \
+    dnf install -y  \
+      glibc-devel \
+      libyaml-devel \
+      cmake \
+      gcc \
+      gcc-c++ \
+      make \
+      wget \
+      unzip \
+      tar \
+      git \
+      openssl-devel \
+      cyrus-sasl-devel \
+      pkgconf-pkg-config \
+      systemd-devel \
+      zlib-devel \
+      valgrind-devel \
+      ca-certificates \
+      flex \
+      bison \
+    && dnf clean all

--- a/scripts/dockerfiles/runtime/Dockerfile.deps-al2023
+++ b/scripts/dockerfiles/runtime/Dockerfile.deps-al2023
@@ -1,0 +1,20 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 as dependencies
+
+# Create sysroot directory and install minimal runtime dependencies
+RUN mkdir /sysroot && \
+    dnf --releasever=$(rpm -q system-release --qf '%{VERSION}') \
+    --installroot /sysroot \
+    -y \
+    --setopt=install_weak_deps=False \
+    install \
+        libyaml \
+        systemd-libs \
+        openssl-libs \
+        cyrus-sasl-lib \
+        libstdc++
+
+# Final minimal runtime image using scratch base
+FROM scratch
+
+# Copy the complete sysroot with all runtime dependencies
+COPY --from=dependencies /sysroot /

--- a/scripts/dockerfiles/runtime/Dockerfile.deps-debug-al2023
+++ b/scripts/dockerfiles/runtime/Dockerfile.deps-debug-al2023
@@ -1,0 +1,14 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+# Install runtime dependencies required for Fluent Bit and AWS plugins
+RUN dnf upgrade -y \
+    && dnf install -y openssl-devel \
+        cyrus-sasl-devel \
+        pkgconfig \
+        systemd-devel \
+        zlib-devel \
+        valgrind \
+        libyaml \
+        gdb \
+        nc \
+    && dnf clean all


### PR DESCRIPTION
### Summary
- Add support for AL2023 through dependency dockerfiles
- Fix core_uploader.sh check for no core files via fuzzy matching

Note: no new makefile targets are introduced using the AL2023 dockerfiles, this will be part of a follow-up commits

AL2023 build dependencies only have a few minor differences from AL2:
- cmake replaces cmake3 (version is 3.x)
- openssl-devel replaces openssl11-devel
- pkgconf-pkg-config replaces pkgconfig
- No need to update alternatives to use cmake

AL2023 runtime dependencies follow https://docs.aws.amazon.com/linux/al2023/ug/barebones-containers.html to install a small set of a dependencies that are copied into a scratch image reducing overall vulnerability surface area.

### Testing
- Tested using AL_TAG overrides for release/debug/debug-valgrind Makefile targets to generate AL2023 images
- Tested changes through pipeline build/deploy/integ test for AL2023 images
- Tested the core_uploader.sh change for both AL2 and AL2023 to ensure no backwards compatibility issues (both detected no core files)


`make debug` succeeded: yes
Integ tests succeeded: yes
New tests cover the changes: no

### Description for the changelog
Add AL2023 dockerfiles

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
