### PR TITLE
Disable buildkit features

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,8 +11,8 @@ phases:
     commands:
       # Check latest image versions from dockerhub and from GitHub source file
       - './scripts/publish.sh cicd-check-image-version'
-      # Enable buildkit features
-      - export DOCKER_BUILDKIT=1
+      # Disable buildkit features
+      - export DOCKER_BUILDKIT=0
       # Command to build debug image
       - make debug
       # Command to build your project

--- a/scripts/dockerfiles/runtime/Dockerfile
+++ b/scripts/dockerfiles/runtime/Dockerfile
@@ -45,7 +45,8 @@ COPY AWS_FOR_FLUENT_BIT_VERSION /AWS_FOR_FLUENT_BIT_VERSION
 ADD ecs /ecs/
 
 # Copy and set up entrypoint script
-COPY --chmod=0755 entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 # Optional Metrics endpoint
 EXPOSE 2020

--- a/scripts/dockerfiles/runtime/Dockerfile.debug-common
+++ b/scripts/dockerfiles/runtime/Dockerfile.debug-common
@@ -16,7 +16,8 @@ RUN unzip -o awscliv2.zip
 RUN ./aws/install
 RUN rm awscliv2.zip
 
-COPY --chmod=0755 ./scripts/core_uploader.sh /
+COPY ./scripts/core_uploader.sh /core_uploader.sh
+RUN chmod +x /core_uploader.sh
 
 # Run Fluent Bit from the cores-out folder and collect crash symbols
 # Move symbols to /cores folder after processing

--- a/scripts/dockerfiles/runtime/Dockerfile.init
+++ b/scripts/dockerfiles/runtime/Dockerfile.init
@@ -7,7 +7,8 @@ FROM ${RUNTIME_IMAGE}
 RUN mkdir -p /init
 
 COPY --from=init /init/fluent_bit_init_process /init/fluent_bit_init_process
-COPY --chmod=0755 init/fluent_bit_init_entrypoint.sh /init/fluent_bit_init_entrypoint.sh
+COPY init/fluent_bit_init_entrypoint.sh /init/fluent_bit_init_entrypoint.sh
+RUN chmod +x /init/fluent_bit_init_entrypoint.sh
 
 # Only last CMD command will be executed, automatically replaces the original entrypoint
 CMD /init/fluent_bit_init_entrypoint.sh


### PR DESCRIPTION
### Summary
Issue during pipeline build was discovered related to buildkit and older codebuild images. Until we can address that issue we can remove the --chmod=0755 (requires buildkit) from dockerfiles and explicitly disable buildkit via `DOCKER_BUILDKIT=0`.

- Not required for dockerfile rework
- Restores prior behavior
- Explicitly disable buildkit to avoid pipeline issues

### Testing
Testing was conducted via:
- `make release` and `make debug`
- Run latest, init-latest, and debug images to ensure scripts execute
- Run changes through personal pipeline to validate the build without issue
- Run latest, init-latest, debug images built by pipeline account

`make debug` succeeded: yes
Integ tests succeeded: yes
New tests cover the changes: no

### Description for the changelog
Disable buildkit features

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
