### PR TITLE
debug-init images: add support for non-root user mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ so AWS credentials must be setup before they are run.
 
 Instructions:
 1. Setup AWS access via EC2 instance role or AWS_* env vars
-2. Install dependent packages: `docker awscli`
+2. Install dependent packages: `docker awscli jq`
 3. Install docker-compose:
 ```
 sudo curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose

--- a/scripts/dockerfiles/runtime/Dockerfile.init-debug
+++ b/scripts/dockerfiles/runtime/Dockerfile.init-debug
@@ -9,9 +9,18 @@ CMD echo "AWS for Fluent Bit Container Image Version `cat /AWS_FOR_FLUENT_BIT_VE
     if [ "$S3_KEY_PREFIX" == "issue" ]; then \
         echo "Note: Please set S3_KEY_PREFIX environment variable to a useful identifier - e.g. company name, team name, customer name"; \
     fi; \
-    /init/fluent_bit_init_process; \
-    chmod +x /init/invoke_fluent_bit.sh; \
     export RUN_ID=$(($RANDOM%99999))$(($RANDOM%99999))$(($RANDOM%99999)); \
     echo "RUN_ID is set to $RUN_ID"; \
-    env RUN_ID=$RUN_ID /init/invoke_fluent_bit.sh; \
+    /init/fluent_bit_init_process; \
+    # Source the invoke script from the appropriate location
+    if [ -f /init/invoke_fluent_bit.sh ]; then \
+        chmod +x /init/invoke_fluent_bit.sh; \
+        env RUN_ID=$RUN_ID /init/invoke_fluent_bit.sh; \
+    elif [ -f /tmp/init/invoke_fluent_bit.sh ]; then \
+        chmod +x /tmp/init/invoke_fluent_bit.sh; \
+        env RUN_ID=$RUN_ID /tmp/init/invoke_fluent_bit.sh; \
+    else \
+        echo "Error: invoke_fluent_bit.sh not found in /init or /tmp/init"; \
+        exit 1; \
+    fi; \
     /core_uploader.sh $S3_BUCKET $S3_KEY_PREFIX $RUN_ID

--- a/scripts/dockerfiles/runtime/Dockerfile.init-debug-efs
+++ b/scripts/dockerfiles/runtime/Dockerfile.init-debug-efs
@@ -2,4 +2,16 @@ ARG RUNTIME_IMAGE
 FROM ${RUNTIME_IMAGE}
 
 # Only last CMD command will be executed, automatically replaces the original entrypoint
-CMD /init/fluent_bit_init_process; chmod +x /init/invoke_fluent_bit.sh; cd /cores; /init/invoke_fluent_bit.sh; echo "Waiting 2 minutes for EFS core file transfers"; sleep 120
+CMD /init/fluent_bit_init_process; \
+    # Source the invoke script from the appropriate location
+    if [ -f /init/invoke_fluent_bit.sh ]; then \
+        chmod +x /init/invoke_fluent_bit.sh; \
+        cd /cores; /init/invoke_fluent_bit.sh; \
+    elif [ -f /tmp/init/invoke_fluent_bit.sh ]; then \
+        chmod +x /tmp/init/invoke_fluent_bit.sh; \
+        cd /cores; /tmp/init/invoke_fluent_bit.sh; \
+    else \
+        echo "Error: invoke_fluent_bit.sh not found in /init or /tmp/init"; \
+        exit 1; \
+    fi; \
+    echo "Waiting 2 minutes for EFS core file transfers"; sleep 120


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This PR follows https://github.com/aws/aws-for-fluent-bit/pull/955. In addition to the init image, we provide customers a debug version of the init image. This debug version lets customers collect a core dump in the event of a Fluent Bit crash, that helps with deeper diagnosis. 

This PR adds support for non-root user mode to the debug init image. The entrypoint script changes from [PR 955](https://github.com/aws/aws-for-fluent-bit/pull/955/files#diff-6bd378921e121b449c1c58257b026b0c95c4edabcbcbe94fc4725b2077e673f3) are identical to this change.

*Issue #, if available:* https://github.com/aws/containers-roadmap/issues/2122

### Testing
<!-- How was this tested?
See https://github.com/aws/aws-for-fluent-bit?tab=readme-ov-file#local-integ-testing
for instructions on how to run integ tests locally.
-->


`make debug` succeeded: <!-- yes|no --> yes
Integ tests succeeded: <!-- yes|no --> yes
New tests cover the changes: <!-- yes|no --> no

Before this change, running the containers (using init-debug image) in non-root user mode fails with a runtime error.

After this change, I ran containers (using a test image from this PR) in both root and non-root user mode, and verified they run as expected. 

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->

Enhancement: add support for non-root user mode to the debug-init image

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
