### PR TITLE
Remove valgrind-devel from build unless debug

### DIFF
--- a/scripts/dockerfiles/build/Dockerfile.compile
+++ b/scripts/dockerfiles/build/Dockerfile.compile
@@ -9,6 +9,11 @@ ARG RELEASE=On
 # Debug disabled by default
 ARG DEBUG=Off
 
+# Install valgrind-devel if DEBUG is enabled
+RUN if [ "$DEBUG" = "On" ]; then \
+      yum install -y valgrind-devel; \
+    fi
+
 # Build Fluent Bit with appropriate compiler flags based on DEBUG and RELEASE arguments
 RUN cmake \
     # always on

--- a/scripts/dockerfiles/build/Dockerfile.deps-al2
+++ b/scripts/dockerfiles/build/Dockerfile.deps-al2
@@ -21,7 +21,6 @@ RUN yum upgrade -y && \
       pkgconfig \
       systemd-devel \
       zlib-devel \
-      valgrind-devel \
       ca-certificates \
       flex \
       bison \

--- a/scripts/dockerfiles/build/Dockerfile.deps-al2023
+++ b/scripts/dockerfiles/build/Dockerfile.deps-al2023
@@ -17,7 +17,6 @@ RUN dnf upgrade -y && \
       pkgconf-pkg-config \
       systemd-devel \
       zlib-devel \
-      valgrind-devel \
       ca-certificates \
       flex \
       bison \


### PR DESCRIPTION
### Summary
Previous dockerfile builds always installed `valgrind-devel` and used build flags to set `-DFLB_VALGRIND` only for debug builds. What we did not observe is that fluent-bit (1.9.10 and beyond) had a check for the presence of valgrind headers that would enable the flag regardless of the build flag - https://github.com/amazon-contributing/upstream-to-fluent-bit/blob/1.9.10/CMakeLists.txt#L584-L593

This change removes the default install of `valgrind-devel` and conditional installs it in Dockerfile.compile if `DEBUG = On`.

### Testing
Validated older images had the build flag set for release:

```
dev-dsk-shelbyzh-2c-4b7a8c60 % docker run -it public.ecr.aws/aws-observability/aws-for-fluent-bit:2.32.5 
/fluent-bit/bin/fluent-bit -help | grep "Build Flags" | tr ' ' '\n' | grep VALGRIND
FLB_HAVE_VALGRIND
```

and confirmed that new release does not have it enabled for release
```
dev-dsk-shelbyzh-2c-4b7a8c60 % docker run -it amazon/aws-for-fluent-bit:latest-al2 /fluent-bit/bin/fluent
-bit -help | grep "Build Flags" | tr ' ' '\n' | grep VALGRIND
```

and enabled for debug
```
dev-dsk-shelbyzh-2c-4b7a8c60 % docker run -it amazon/aws-for-fluent-bit:debug-al2 /fluent-bit/bin/fluent-bit -help | grep "Build Flags" | tr ' ' '\n' | grep VALGRIND
FLB_HAVE_VALGRIND
```

`make debug` succeeded: yes
Integ tests succeeded: yes
New tests cover the changes: no

### Description for the changelog
Fix: Remove valgrind-devel from build unless debug

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
