### PR TITLE
Add support for Apache Arrow/Parquet for AL2023

### DIFF
--- a/scripts/dockerfiles/build/Dockerfile.deps-al2023
+++ b/scripts/dockerfiles/build/Dockerfile.deps-al2023
@@ -1,6 +1,7 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
 RUN dnf upgrade -y && \
+    dnf install -y https://packages.apache.org/artifactory/arrow/amazon-linux/$(cut -d: -f6 /etc/system-release-cpe)/apache-arrow-release-latest.rpm && \
     dnf install -y  \
       glibc-devel \
       libyaml-devel \
@@ -20,4 +21,6 @@ RUN dnf upgrade -y && \
       ca-certificates \
       flex \
       bison \
+      arrow-glib-devel \
+      parquet-glib-devel \
     && dnf clean all

--- a/scripts/dockerfiles/runtime/Dockerfile.deps-al2023
+++ b/scripts/dockerfiles/runtime/Dockerfile.deps-al2023
@@ -2,6 +2,7 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2023 as dependencies
 
 # Create sysroot directory and install minimal runtime dependencies
 RUN mkdir /sysroot && \
+    dnf install -y https://packages.apache.org/artifactory/arrow/amazon-linux/$(cut -d: -f6 /etc/system-release-cpe)/apache-arrow-release-latest.rpm && \
     dnf --releasever=$(rpm -q system-release --qf '%{VERSION}') \
     --installroot /sysroot \
     -y \
@@ -11,6 +12,8 @@ RUN mkdir /sysroot && \
         systemd-libs \
         openssl-libs \
         cyrus-sasl-lib \
+        arrow2100-glib-libs \
+        parquet2100-glib-libs \
         libstdc++
 
 # Final minimal runtime image using scratch base

--- a/scripts/dockerfiles/runtime/Dockerfile.deps-debug-al2023
+++ b/scripts/dockerfiles/runtime/Dockerfile.deps-debug-al2023
@@ -1,8 +1,9 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
 # Install runtime dependencies required for Fluent Bit and AWS plugins
-RUN dnf upgrade -y \
-    && dnf install -y openssl-devel \
+RUN dnf upgrade -y && \
+    dnf install -y https://packages.apache.org/artifactory/arrow/amazon-linux/$(cut -d: -f6 /etc/system-release-cpe)/apache-arrow-release-latest.rpm && \
+    dnf install -y openssl-devel \
         cyrus-sasl-devel \
         pkgconfig \
         systemd-devel \
@@ -11,4 +12,6 @@ RUN dnf upgrade -y \
         libyaml \
         gdb \
         nc \
+        arrow-glib-devel \
+        parquet-glib-devel \
     && dnf clean all


### PR DESCRIPTION
### Summary
As part of adding support for arrow/parquet compression with S3 we need to install required libraries. These libraries were taken from the install steps for Apache Arrow for AL2023 - https://arrow.apache.org/install/.

PR - Adding Parquet - https://github.com/fluent/fluent-bit/pull/10691

### Testing
Ran local latest/debug images for AL2023 (custom build)

Validate release build flags
```
dev-dsk-shelbyzh-2c-4b7a8c60 % docker run -it amazon/aws-for-fluent-bit:latest-al2023 /fluent-bit/bin/fluent-bit -help | grep "Build Flags" | tr ' ' '\n' | grep ARROW
FLB_HAVE_ARROW
FLB_HAVE_ARROW_PARQUET
```

Validate debug build flags
```
dev-dsk-shelbyzh-2c-4b7a8c60 % docker run -it amazon/aws-for-fluent-bit:debug-al2023 /fluent-bit/bin/fluent-bit -help | grep "Build Flags" | tr ' ' '\n' | grep ARROW
FLB_HAVE_ARROW
FLB_HAVE_ARROW_PARQUET
```

`make debug` succeeded: yes
Integ tests succeeded: yes
New tests cover the changes: no

### Description for the changelog
Enhancement: Add support for Apache Arrow/Parquet for AL2023

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
