### PR TITLE
Turn on FLB_SIMD for later builds

### DIFF
--- a/scripts/dockerfiles/build/Dockerfile.compile
+++ b/scripts/dockerfiles/build/Dockerfile.compile
@@ -17,6 +17,7 @@ RUN if [ "$DEBUG" = "On" ]; then \
 # Build Fluent Bit with appropriate compiler flags based on DEBUG and RELEASE arguments
 RUN cmake \
     # always on
+    -DFLB_SIMD=On \
     -DFLB_JEMALLOC=On \
     -DFLB_TLS=On \
     -DFLB_HTTP_SERVER=On \


### PR DESCRIPTION
### Summary
As part of 3.2 fluent-bit SIMD support was added to speed up JSON parsing - https://github.com/fluent/fluent-bit/pull/9500. By setting the build flag `-DFLB_SIMD=On` it will enable support and print out what SIMD support is available.

PR that added SIMD support - https://github.com/fluent/fluent-bit/pull/9500

For AL2 this is a no-op as the flag is not defined in https://github.com/amazon-contributing/upstream-to-fluent-bit/blob/1.9.10/CMakeLists.txt

### Testing
Local AL2023 build with fluent-bit 4.x testing release/debug images

Build flags
```
dev-dsk-shelbyzh-2c-4b7a8c60 % docker run -it amazon/aws-for-fluent-bit:debug-al2023 /fluent-bit/bin/flue
nt-bit -help | grep "Build Flags" | tr ' ' '\n' | grep SIMD
FLB_HAVE_SIMD
```

```
dev-dsk-shelbyzh-2c-4b7a8c60 % docker run -it amazon/aws-for-fluent-bit:debug-al2023 /fluent-bit/bin/fluent-bit
Fluent Bit v4.1.0
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___  _____ 
|  ___| |                | |   | ___ (_) |           /   ||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/ 


[2025/08/28 21:11:18.626102383] [ info] [fluent bit] version=4.1.0, commit=7445e38cd0, pid=1
[2025/08/28 21:11:18.626227513] [ info] [storage] ver=1.5.3, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/08/28 21:11:18.626241233] [ info] [simd    ] SSE2
[2025/08/28 21:11:18.626246203] [ info] [cmetrics] version=1.0.5
[2025/08/28 21:11:18.626256813] [ info] [ctraces ] version=0.6.6
[2025/08/28 21:11:18.626322493] [ info] [sp] stream processor started
[2025/08/28 21:11:18.626363313] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
^C[2025/08/28 21:11:20] [engine] caught signal (SIGINT)
[2025/08/28 21:11:20.724667263] [ warn] [engine] service will shutdown in max 5 seconds
[2025/08/28 21:11:20.724687053] [ info] [engine] pausing all inputs..
[2025/08/28 21:11:20.735281131] [ info] [engine] service has stopped (0 pending tasks)
```

`make debug` succeeded: yes|
Integ tests succeeded: yes
New tests cover the changes: no

### Description for the changelog
Enhancement: Turn on FLB_SIMD for later builds

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
