### PR TITLE
Add Placeholder for building Version 3.0

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,57 +7,83 @@ phases:
   pre_build:
     commands:
       - echo Building the AWS for Fluent Bit image
+      # Check BUILD_VERSION environment variable and set default if not provided
+      - |
+        if [ -z "$BUILD_VERSION" ]; then
+          echo "BUILD_VERSION environment variable not provided, defaulting to BUILD_VERSION=2"
+          export BUILD_VERSION=2
+        else
+          echo "BUILD_VERSION is set to: $BUILD_VERSION"
+        fi
   build:
     commands:
-      # Check latest image versions from dockerhub and from GitHub source file
-      - './scripts/publish.sh cicd-check-image-version'
-      # Disable buildkit features
-      - export DOCKER_BUILDKIT=0
-      # Command to build debug image
-      - make debug
-      # Command to build your project
-      - make release
+      # Execute build commands based on BUILD_VERSION
+      - |
+        if [ "$BUILD_VERSION" = "2" ]; then
+          echo "Building AWS for Fluent Bit version 2 (current behavior)"
+          
+          # Check latest image versions from dockerhub and from GitHub source file
+          ./scripts/publish.sh cicd-check-image-version
+          
+          # Disable buildkit features
+          export DOCKER_BUILDKIT=0
 
-      # List the docker images
-      - docker images
+          # Command to build debug image
+          make debug
+          # Command to build your project
+          make release
 
-      # Push the image to ECR with corresponding architecture as the tag.
-      - aws ecr get-login-password --region ${AWS_REGION}| docker login --username AWS --password-stdin ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com
-      - aws ecr create-repository --repository-name amazon/aws-for-fluent-bit-test --image-scanning-configuration scanOnPush=true --region ${AWS_REGION}  || true
-      - architecture=$(docker inspect --format='{{.Architecture}}'  amazon/aws-for-fluent-bit:latest-al2)
-      - docker tag amazon/aws-for-fluent-bit:latest-al2 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:$architecture
-      - docker tag amazon/aws-for-fluent-bit:debug-al2 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:$architecture-debug
-      - docker push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:$architecture
-      - docker push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:$architecture-debug
-      - './scripts/publish.sh cicd-verify-ecr-image-scan ${AWS_REGION} amazon/aws-for-fluent-bit-test $architecture'
-      - './scripts/publish.sh cicd-verify-ecr-image-scan ${AWS_REGION} amazon/aws-for-fluent-bit-test $architecture-debug'
-      # Image with Init Process
-      - docker tag amazon/aws-for-fluent-bit:init-latest-al2 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-$architecture
-      - docker tag amazon/aws-for-fluent-bit:init-debug-al2 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-$architecture-debug
-      - docker push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-$architecture
-      - docker push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-$architecture-debug
-      - './scripts/publish.sh cicd-verify-ecr-image-scan ${AWS_REGION} amazon/aws-for-fluent-bit-test init-$architecture'
-      - './scripts/publish.sh cicd-verify-ecr-image-scan ${AWS_REGION} amazon/aws-for-fluent-bit-test init-$architecture-debug'
+          # List the docker images
+          docker images
 
-       # Create manifest list
-      - export DOCKER_CLI_EXPERIMENTAL=enabled
-      - docker manifest create ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:arm64 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:amd64 || true
-      - docker manifest annotate --arch arm64 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:arm64 || true
-      - docker manifest annotate --arch amd64 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:amd64 || true
-      # Image with Init Process
-      - docker manifest create ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-arm64 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-amd64 || true
-      - docker manifest annotate --arch arm64 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-arm64 || true
-      - docker manifest annotate --arch amd64 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-amd64 || true
-      
-      # Sanity check for the debug log
-      - docker manifest inspect ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:latest || true
-      # Image with Init Process
-      - docker manifest inspect ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-latest || true
+          # Push the image to ECR with corresponding architecture as the tag.
+          aws ecr get-login-password --region ${AWS_REGION}| docker login --username AWS --password-stdin ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com
+          aws ecr create-repository --repository-name amazon/aws-for-fluent-bit-test --image-scanning-configuration scanOnPush=true --region ${AWS_REGION}  || true
+          architecture=$(docker inspect --format='{{.Architecture}}'  amazon/aws-for-fluent-bit)
+          docker tag amazon/aws-for-fluent-bit:latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:$architecture
+          docker tag amazon/aws-for-fluent-bit:debug ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:$architecture-debug
+          docker push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:$architecture
+          docker push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:$architecture-debug
+          ./scripts/publish.sh cicd-verify-ecr-image-scan ${AWS_REGION} amazon/aws-for-fluent-bit-test $architecture
+          ./scripts/publish.sh cicd-verify-ecr-image-scan ${AWS_REGION} amazon/aws-for-fluent-bit-test $architecture-debug
+          # Image with Init Process
+          docker tag amazon/aws-for-fluent-bit:init-latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-$architecture
+          docker tag amazon/aws-for-fluent-bit:init-debug ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-$architecture-debug
+          docker push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-$architecture
+          docker push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-$architecture-debug
+          ./scripts/publish.sh cicd-verify-ecr-image-scan ${AWS_REGION} amazon/aws-for-fluent-bit-test init-$architecture
+          ./scripts/publish.sh cicd-verify-ecr-image-scan ${AWS_REGION} amazon/aws-for-fluent-bit-test init-$architecture-debug
 
-      # Push manifest list
-      - docker manifest push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:latest || true
-      # Image with Init Process
-      - docker manifest push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-latest || true
+          # Create manifest list
+          export DOCKER_CLI_EXPERIMENTAL=enabled
+          docker manifest create ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:arm64 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:amd64 || true
+          docker manifest annotate --arch arm64 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:arm64 || true
+          docker manifest annotate --arch amd64 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:amd64 || true
+          # Image with Init Process
+          docker manifest create ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-arm64 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-amd64 || true
+          docker manifest annotate --arch arm64 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-arm64 || true
+          docker manifest annotate --arch amd64 ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-latest ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-amd64 || true
+          
+          # Sanity check for the debug log
+          docker manifest inspect ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:latest || true
+          # Image with Init Process
+          docker manifest inspect ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-latest || true
+
+          # Push manifest list
+          docker manifest push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:latest || true
+          # Image with Init Process
+          docker manifest push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:init-latest || true
+          
+        elif [ "$BUILD_VERSION" = "3" ]; then
+          echo "Building AWS for Fluent Bit version 3 (no-op for now)"
+          echo "Version 3 build logic will be implemented later"
+          # Placeholder for future BUILD_VERSION=3 implementation
+          
+        else
+          echo "Unsupported BUILD_VERSION: $BUILD_VERSION"
+          echo "Supported versions are: 2, 3"
+          exit 1
+        fi
 
 artifacts:
   files:

--- a/buildspec_integ.yml
+++ b/buildspec_integ.yml
@@ -8,26 +8,50 @@ phases:
       - echo Running the integration test
   build:
     commands:
-      # Enforce STS regional endpoints
-      - export AWS_STS_REGIONAL_ENDPOINTS=regional
-      - export CW_INTEG_VALIDATOR_IMAGE_BASE=${AWS_ACCOUNT}.dkr.ecr.us-west-2.amazonaws.com/cw-integ-validator
-      - export S3_INTEG_VALIDATOR_IMAGE_BASE=${AWS_ACCOUNT}.dkr.ecr.us-west-2.amazonaws.com/s3-integ-validator
-      # Get the default credentials and set as environment variables
-      - 'CREDS=`curl 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`'
-      - 'export AWS_ACCESS_KEY_ID=`echo $CREDS | jq -r .AccessKeyId`'
-      - 'export AWS_SECRET_ACCESS_KEY=`echo $CREDS | jq -r .SecretAccessKey`'
-      - 'export AWS_SESSION_TOKEN=`echo $CREDS | jq -r .Token`'
+      # Check BUILD_VERSION environment variable and set default if not provided
+      - |
+        if [ -z "$BUILD_VERSION" ]; then
+          echo "BUILD_VERSION environment variable not provided, defaulting to BUILD_VERSION=2"
+          export BUILD_VERSION=2
+        else
+          echo "BUILD_VERSION is set to: $BUILD_VERSION"
+        fi
+      # Execute integration test commands based on BUILD_VERSION
+      - |
+        if [ "$BUILD_VERSION" = "2" ]; then
+          echo "Running integration tests for AWS for Fluent Bit version 2 (current behavior)"
+          
+          # Enforce STS regional endpoints
+          export AWS_STS_REGIONAL_ENDPOINTS=regional
+          export CW_INTEG_VALIDATOR_IMAGE_BASE=${AWS_ACCOUNT}.dkr.ecr.us-west-2.amazonaws.com/cw-integ-validator
+          export S3_INTEG_VALIDATOR_IMAGE_BASE=${AWS_ACCOUNT}.dkr.ecr.us-west-2.amazonaws.com/s3-integ-validator
+          # Get the default credentials and set as environment variables
+          CREDS=`curl 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`
+          export AWS_ACCESS_KEY_ID=`echo $CREDS | jq -r .AccessKeyId`
+          export AWS_SECRET_ACCESS_KEY=`echo $CREDS | jq -r .SecretAccessKey`
+          export AWS_SESSION_TOKEN=`echo $CREDS | jq -r .Token`
 
-      # Pull the image that we built and pushed in the `Build` stage
-      - aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com
-      - docker pull ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:latest
-      - docker tag ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test amazon/aws-for-fluent-bit:latest
+          # Pull the image that we built and pushed in the `Build` stage
+          aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com
+          docker pull ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:latest
+          docker tag ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test amazon/aws-for-fluent-bit:latest
 
-      # List the images to do a double check
-      - docker images
+          # List the images to do a double check
+          docker images
 
-      # Command to run the integration test
-      - make integ
+          # Command to run the integration test
+          make integ
+          
+        elif [ "$BUILD_VERSION" = "3" ]; then
+          echo "Running integration tests for AWS for Fluent Bit version 3 (no-op for now)"
+          echo "Version 3 integration test logic will be implemented later"
+          # Placeholder for future BUILD_VERSION=3 implementation
+          
+        else
+          echo "Unsupported BUILD_VERSION: $BUILD_VERSION"
+          echo "Supported versions are: 2, 3"
+          exit 1
+        fi
 artifacts:
   files:
     - '**/*'

--- a/buildspec_load_test.yml
+++ b/buildspec_load_test.yml
@@ -48,27 +48,51 @@ phases:
       - aws configure set default.region us-west-2
   build:
     commands:
-      # Activate Python virtual environment and install the AWS CDK core dependencies
-      - python -m venv venv
-      - source venv/bin/activate
-      - pip install -r ./load_tests/requirements.txt
+      # Check BUILD_VERSION environment variable and set default if not provided
       - |
-        if [ "${PLATFORM}" == "EKS" ]; then
-          aws eks update-kubeconfig --name $EKS_CLUSTER_NAME
+        if [ -z "$BUILD_VERSION" ]; then
+          echo "BUILD_VERSION environment variable not provided, defaulting to BUILD_VERSION=2"
+          export BUILD_VERSION=2
+        else
+          echo "BUILD_VERSION is set to: $BUILD_VERSION"
         fi
-      - CREDS=$(aws sts assume-role --role-arn $LOAD_TEST_CFN_ROLE_ARN --role-session-name load-test-cfn --duration-seconds 3600)
-      - export CREDS
-      - export AWS_ACCESS_KEY_ID=$(echo "${CREDS}" | jq -r '.Credentials.AccessKeyId')
-      - export AWS_SECRET_ACCESS_KEY=$(echo "${CREDS}" | jq -r '.Credentials.SecretAccessKey')
-      - export AWS_SESSION_TOKEN=$(echo "${CREDS}" | jq -r '.Credentials.SessionToken')
-      # Create and set up related testing resources
-      - python ./load_tests/load_test.py create_testing_resources
-      - source ./load_tests/setup_test_environment.sh
-      - export AWS_ACCESS_KEY_ID=""
-      - export AWS_SECRET_ACCESS_KEY=""
-      - export AWS_SESSION_TOKEN=""
-      # Run load tests on corresponding platform
-      - python ./load_tests/load_test.py ${PLATFORM}
+      # Execute load test commands based on BUILD_VERSION
+      - |
+        if [ "$BUILD_VERSION" = "2" ]; then
+          echo "Running load tests for AWS for Fluent Bit version 2 (current behavior)"
+          
+          # Activate Python virtual environment and install the AWS CDK core dependencies
+          python -m venv venv
+          source venv/bin/activate
+          pip install -r ./load_tests/requirements.txt
+          if [ "${PLATFORM}" == "EKS" ]; then
+            aws eks update-kubeconfig --name $EKS_CLUSTER_NAME
+          fi
+          CREDS=$(aws sts assume-role --role-arn $LOAD_TEST_CFN_ROLE_ARN --role-session-name load-test-cfn --duration-seconds 3600)
+          export CREDS
+          export AWS_ACCESS_KEY_ID=$(echo "${CREDS}" | jq -r '.Credentials.AccessKeyId')
+          export AWS_SECRET_ACCESS_KEY=$(echo "${CREDS}" | jq -r '.Credentials.SecretAccessKey')
+          export AWS_SESSION_TOKEN=$(echo "${CREDS}" | jq -r '.Credentials.SessionToken')
+          # Create and set up related testing resources
+          python ./load_tests/load_test.py create_testing_resources
+          # TODO: Modify setup_test_environment.sh to handle BUILD_VERSION=3 appropriately
+          source ./load_tests/setup_test_environment.sh
+          export AWS_ACCESS_KEY_ID=""
+          export AWS_SECRET_ACCESS_KEY=""
+          export AWS_SESSION_TOKEN=""
+          # Run load tests on corresponding platform
+          python ./load_tests/load_test.py ${PLATFORM}
+          
+        elif [ "$BUILD_VERSION" = "3" ]; then
+          echo "Running load tests for AWS for Fluent Bit version 3 (no-op for now)"
+          echo "Version 3 load test logic will be implemented later"
+          # Placeholder for future BUILD_VERSION=3 implementation
+          
+        else
+          echo "Unsupported BUILD_VERSION: $BUILD_VERSION"
+          echo "Supported versions are: 2, 3"
+          exit 1
+        fi
     finally:
       # Clear up testing resources
       - python ./load_tests/load_test.py delete_testing_resources


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR introduces a new `BUILD_VERSION` environment variable to support building different versions of AWS for Fluent Bit builds. BUILD_VERSION 3 will be based on AL2023 (Amazon Linux 2023), fluent-bit 4.x. A follow up PR will introduce build steps and test steps for this build.

In this specific PR, BUILD_VERSION 2 should see no change and BUILD_VERSION 3 should see no-op behavior.

Further, we are only modifying build and test buildspecs and not making changes to publish buildspecs or scripts.

Thus, this PR in essence does not introduce any change in the image or build process itself, but just creates a boilerplate with necessary placeholder.

### Testing
<!-- How was this tested?
See https://github.com/aws/aws-for-fluent-bit?tab=readme-ov-file#local-integ-testing
for instructions on how to run integ tests locally.
-->

Tested in a codepipeline setup in personal dev account - build image and tested

`make debug` succeeded: yes
Integ tests succeeded: yes
New tests cover the changes: N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->
Add Placeholder for building Version 3.0

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
