### PR TITLE
Add note for stable image tag

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -77,6 +77,8 @@ Below is a table providing a small set of versions with the bump type and reason
 * `Version number tag`: Each release has a version number, for example `2.33.0.20250731`, `2.33.1`
 * `stable`: The most recent version that we have high confidence is stable for AWS use cases
 
+> Note: The stable image tag continues to point to AWS for Fluent Bit version 2.x
+
 ### Additional Tags
 
 * `debug-latest`: `latest` image with debug tooling[^3]


### PR DESCRIPTION
### Summary
When we release 3.0.0, the `stable` image tag will remain on 2.x versions. We plan to release newer versions of fluent-bit/AmazonLinux under new major versions via versioned tags and latest over time.

### Testing

`make debug` succeeded: yes
Integ tests succeeded: yes
New tests cover the changes: no

### Description for the changelog
Enhancement: Add note for stable image tag

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
