### PR TITLE
Make init process bucketlocation more testable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ integ/out/
 .venv
 /.idea/
 .vscode/
+fluent-bit-init-s3-files

--- a/init/fluent_bit_init_process.go
+++ b/init/fluent_bit_init_process.go
@@ -38,8 +38,8 @@ var (
 	// Default Fluent Bit command
 	baseCommand = "exec /fluent-bit/bin/fluent-bit -e /fluent-bit/firehose.so -e /fluent-bit/cloudwatch.so -e /fluent-bit/kinesis.so"
 
-	// Global S3 client and flag
-	s3Client        *s3.Client
+	// global s3 client and flag
+	s3Client        S3Client
 	s3ClientCreated bool = false
 
 	// Global ECS metadata region
@@ -95,6 +95,12 @@ type HTTPClient interface {
 // S3Downloader interface
 type S3Downloader interface {
 	Download(ctx context.Context, w io.WriterAt, input *s3.GetObjectInput, options ...func(*manager.Downloader)) (int64, error)
+}
+
+// S3Client interface for bucket operations
+type S3Client interface {
+	GetBucketLocation(ctx context.Context, params *s3.GetBucketLocationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error)
+	Options() s3.Options
 }
 
 // all values in the structure are empty strings by default
@@ -225,6 +231,7 @@ func getAllConfigFiles() {
 
 		// if this env var's value is an arn, download the config file first, then process it
 		if matched_s3 {
+			createS3Client()
 			s3FilePath := getS3ConfigFile(envValue)
 			s3FileName := strings.SplitN(s3FilePath, "/", -1)
 			processConfigFile(s3FileDirectoryPath + s3FileName[len(s3FileName)-1])
@@ -254,24 +261,20 @@ func processConfigFile(path string) {
 	}
 }
 
-func getS3ConfigFile(userInput string) string {
-	// Preparation for downloading S3 config files
-	if !s3ClientCreated {
-		createS3Client()
-	}
-
+// parseS3ARNAndGetBucketInfo extracts bucket name, region, and file path from an S3 ARN
+func parseS3ARNAndGetBucketInfo(s3ARNString string, s3Client S3Client) (bucketName string, bucketRegion string, s3FilePath string) {
 	// e.g. "arn:aws:s3:::user-bucket/s3_parser.conf"
-	s3ARN, err := arn.Parse(userInput)
+	s3ARN, err := arn.Parse(s3ARNString)
 	if err != nil {
-		logrus.Fatalf("[FluentBit Init Process] Could not parse arn: %s\n", userInput)
+		logrus.Fatalf("[FluentBit Init Process] Could not parse arn: %s\n", s3ARNString)
 	}
 	bucketAndFile := strings.SplitN(s3ARN.Resource, "/", 2)
 	if len(bucketAndFile) != 2 {
-		logrus.Fatalf("[FluentBit Init Process] Could not parse arn: %s\n", userInput)
+		logrus.Fatalf("[FluentBit Init Process] Could not parse arn: %s\n", s3ARNString)
 	}
 
-	bucketName := bucketAndFile[0]
-	s3FilePath := bucketAndFile[1]
+	bucketName = bucketAndFile[0]
+	s3FilePath = bucketAndFile[1]
 
 	// TODO: migrate to s3:HeadBucket and use BucketRegion
 	// https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html
@@ -287,7 +290,7 @@ func getS3ConfigFile(userInput string) string {
 		logrus.Fatalf("[FluentBit Init Process] Cannot get bucket region of %s + %s, you must be the bucket owner to implement this operation\n", bucketName, s3FilePath)
 	}
 
-	bucketRegion := string(output.LocationConstraint)
+	bucketRegion = string(output.LocationConstraint)
 	// Buckets in Region us-east-1 have a LocationConstraint of null
 	// Buckets in Region eu-west-1 have a LocationConstraint of EU
 	// https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html#API_GetBucketLocation_ResponseSyntax
@@ -297,6 +300,12 @@ func getS3ConfigFile(userInput string) string {
 	case "EU":
 		bucketRegion = "eu-west-1"
 	}
+
+	return bucketName, bucketRegion, s3FilePath
+}
+
+func getS3ConfigFile(userInput string) string {
+	bucketName, bucketRegion, s3FilePath := parseS3ARNAndGetBucketInfo(userInput, s3Client)
 
 	// create a downloader
 	s3Downloader := createS3Downloader(bucketRegion)

--- a/init/fluent_bit_init_process_test.go
+++ b/init/fluent_bit_init_process_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -483,6 +484,77 @@ func (msd *MockS3Downloader) Download(ctx context.Context, w io.WriterAt, input 
 	writeFileHelper(filePath, writeContent)
 
 	return 100, nil
+}
+
+// MockS3Client implements the S3Client interface for testing
+type MockS3Client struct {
+	LocationConstraint string // The location constraint to return (empty string for us-east-1, "EU" for eu-west-1, etc.)
+}
+
+func (msc *MockS3Client) GetBucketLocation(ctx context.Context, params *s3.GetBucketLocationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error) {
+	output := &s3.GetBucketLocationOutput{}
+	if msc.LocationConstraint != "" {
+		output.LocationConstraint = types.BucketLocationConstraint(msc.LocationConstraint)
+	}
+
+	return output, nil
+}
+
+func (msc *MockS3Client) Options() s3.Options {
+	return s3.Options{
+		Region: "us-east-1",
+	}
+}
+
+func TestParseS3ARNAndGetBucketInfo(t *testing.T) {
+	cases := []struct {
+		name               string
+		s3ARN              string
+		locationConstraint string
+		expectedBucket     string
+		expectedRegion     string
+		expectedFilePath   string
+	}{
+		{
+			name:               "Valid ARN with us-east-1 (empty constraint)",
+			s3ARN:              "arn:aws:s3:::my-bucket/path/to/file.conf",
+			locationConstraint: "",
+			expectedBucket:     "my-bucket",
+			expectedRegion:     "us-east-1",
+			expectedFilePath:   "path/to/file.conf",
+		},
+		{
+			name:               "Valid ARN with eu-west-1 (EU constraint)",
+			s3ARN:              "arn:aws:s3:::eu-bucket/config/parser.conf",
+			locationConstraint: "EU",
+			expectedBucket:     "eu-bucket",
+			expectedRegion:     "eu-west-1",
+			expectedFilePath:   "config/parser.conf",
+		},
+		{
+			name:               "Valid ARN with us-west-2",
+			s3ARN:              "arn:aws:s3:::west-bucket/fluent-bit.conf",
+			locationConstraint: "us-west-2",
+			expectedBucket:     "west-bucket",
+			expectedRegion:     "us-west-2",
+			expectedFilePath:   "fluent-bit.conf",
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			mockClient := &MockS3Client{
+				LocationConstraint: test.locationConstraint,
+			}
+
+			bucketName, bucketRegion, s3FilePath := parseS3ARNAndGetBucketInfo(test.s3ARN, mockClient)
+
+			// Verify the results
+			assert.Equal(t, test.expectedBucket, bucketName)
+			assert.Equal(t, test.expectedRegion, bucketRegion)
+			assert.Equal(t, test.expectedFilePath, s3FilePath)
+		})
+	}
 }
 
 func createFileHelper(filePath string) *os.File {


### PR DESCRIPTION


### Summary
Adds a helper method, parseS3ARNAndGetBucketInfo, to handle parsing bucket name, region, s3 file path from the S3 ARN. This also introduces a S3Client interface to make testing s3::GetBucketLocation possible and adds related unit tests

### Testing
Local testing/profiling via go test

`make debug` succeeded: yes
Integ tests succeeded: yes
New tests cover the changes: yes

### Description for the changelog
Enhancement: Make init process bucketlocation more testable

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
