### PR TITLE
Unblock sync task using default BUILD_VERSION

### DIFF
--- a/buildspec_sync.yml
+++ b/buildspec_sync.yml
@@ -12,6 +12,14 @@ phases:
       - ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/bin --update
       - which aws
       - aws --version
+      # Check BUILD_VERSION environment variable and set default if not provided
+      - |
+        if [ -z "$BUILD_VERSION" ]; then
+          echo "BUILD_VERSION environment variable not provided, defaulting to BUILD_VERSION=2"
+          export BUILD_VERSION=2
+        else
+          echo "BUILD_VERSION is set to: $BUILD_VERSION"
+        fi
   build:
     commands:
       # Enforce STS regional endpoints


### PR DESCRIPTION
### Summary
Fix issue with recent set of publish.sh changes expecting a BUILD_VERSION

### Description for the changelog
Bug-fix: Unblock sync task using default BUILD_VERSION

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
