### PR TITLE
Move to v4.1.0 fluent-bit version

### DIFF
--- a/linux.version
+++ b/linux.version
@@ -18,7 +18,7 @@
             "version": "3.0.0",
             "latest": "false",
             "build": "1",
-            "fluent-bit": "v4.0.9",
+            "fluent-bit": "v4.1.0",
             "kinesis-plugin": "v1.10.2",
             "firehose-plugin": "v1.7.2",
             "cloudwatch-plugin": "v1.9.4",


### PR DESCRIPTION
### Summary
Move to fluent-bit 4.1.0 for version 3.0.0 release

### Testing
Local image build/testing

`make debug` succeeded: yes
Integ tests succeeded: yes
New tests cover the changes: no

### Description for the changelog
Enhancement: Move to fluent-bit 4.1.0 for version 3.0.0 release

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
