### PR TITLE
Rework parsers to allow pulling from source for AL2023

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ dev: release
 .PHONY: build-common
 build-common:
 	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:build-deps-al${AL_TAG} -f ./scripts/dockerfiles/build/Dockerfile.deps-al${AL_TAG} .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg AL_TAG=${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg FLB_REPOSITORY=${FLB_REPOSITORY} -t amazon/aws-for-fluent-bit:parsers-al${AL_TAG} -f ./scripts/dockerfiles/build/Dockerfile.parsers-al${AL_TAG} .
 	docker build $(DOCKER_BUILD_FLAGS) --build-arg AL_TAG=${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg FLB_REPOSITORY=${FLB_REPOSITORY} -t amazon/aws-for-fluent-bit:build-common-al${AL_TAG} -f ./scripts/dockerfiles/build/Dockerfile.build-common .
 	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:golang -f ./scripts/dockerfiles/build/Dockerfile.golang .
 	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:compile-init-al${AL_TAG} -f ./scripts/dockerfiles/build/Dockerfile.compile-init .

--- a/scripts/dockerfiles/build/Dockerfile.build-common
+++ b/scripts/dockerfiles/build/Dockerfile.build-common
@@ -1,9 +1,8 @@
 # Amazon Linux Tag to use for images
 ARG AL_TAG=2
 
+FROM amazon/aws-for-fluent-bit:parsers-al${AL_TAG} as parsers
 FROM amazon/aws-for-fluent-bit:build-deps-al${AL_TAG}
-# branch to pull parsers from in github.com/fluent/fluent-bit-docker-image
-ENV FLB_DOCKER_BRANCH 1.8
 
 # Create required directories
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log
@@ -14,16 +13,9 @@ ENV HOME /home
 COPY fluent-bit.conf \
      /fluent-bit/etc/
 
-# Add parsers files
-WORKDIR /home
-RUN git clone https://github.com/fluent/fluent-bit-docker-image.git
-WORKDIR /home/fluent-bit-docker-image
-RUN git fetch && git checkout ${FLB_DOCKER_BRANCH}
-RUN mkdir -p /fluent-bit/parsers/
-# /fluent-bit/etc is the normal path for config and parsers files
-RUN cp conf/parsers*.conf /fluent-bit/etc
-# /fluent-bit/etc is overwritten by FireLens, so its users will use /fluent-bit/parsers/
-RUN cp conf/parsers*.conf /fluent-bit/parsers/
+# Copy parsers from the appropriate AL-specific parsers image
+COPY --from=parsers /fluent-bit/etc/parsers*.conf /fluent-bit/etc/
+COPY --from=parsers /fluent-bit/parsers/ /fluent-bit/parsers/
 
 # Add configuration files
 ADD configs/parse-json.conf /fluent-bit/configs/

--- a/scripts/dockerfiles/build/Dockerfile.parsers-al2
+++ b/scripts/dockerfiles/build/Dockerfile.parsers-al2
@@ -1,0 +1,24 @@
+# Amazon Linux Tag to use for images
+ARG AL_TAG=2
+
+FROM amazon/aws-for-fluent-bit:build-deps-al${AL_TAG}
+
+# Create required directories
+RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log
+
+# Accept build args for consistency (not used in AL2)
+ARG FLB_VERSION
+ARG FLB_REPOSITORY
+
+# branch to pull parsers from in github.com/fluent/fluent-bit-docker-image
+ENV FLB_DOCKER_BRANCH 1.8
+
+RUN git clone --single-branch --branch ${FLB_DOCKER_BRANCH} https://github.com/fluent/fluent-bit-docker-image.git /tmp/fluent-bit-docker-image
+
+# Add parsers files from fluent-bit-docker-image
+WORKDIR /tmp/fluent-bit-docker-image
+RUN mkdir -p /fluent-bit/parsers/
+# /fluent-bit/etc is the normal path for config and parsers files
+RUN cp conf/parsers*.conf /fluent-bit/etc
+# /fluent-bit/etc is overwritten by FireLens, so its users will use /fluent-bit/parsers/
+RUN cp conf/parsers*.conf /fluent-bit/parsers/

--- a/scripts/dockerfiles/build/Dockerfile.parsers-al2023
+++ b/scripts/dockerfiles/build/Dockerfile.parsers-al2023
@@ -1,0 +1,20 @@
+# Amazon Linux Tag to use for images
+ARG AL_TAG=2023
+
+FROM amazon/aws-for-fluent-bit:build-deps-al${AL_TAG}
+
+# Create required directories
+RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log
+
+# Get Fluent Bit source code (same as build-common)
+ARG FLB_VERSION
+ARG FLB_REPOSITORY
+RUN git clone --single-branch --branch ${FLB_VERSION} ${FLB_REPOSITORY} /tmp/fluent-bit/
+
+# Add parsers files from the main Fluent Bit repository
+WORKDIR /tmp/fluent-bit
+RUN mkdir -p /fluent-bit/parsers/
+# /fluent-bit/etc is the normal path for config and parsers files
+RUN cp conf/parsers*.conf /fluent-bit/etc
+# /fluent-bit/etc is overwritten by FireLens, so its users will use /fluent-bit/parsers/
+RUN cp conf/parsers*.conf /fluent-bit/parsers/


### PR DESCRIPTION
### Summary
- Put parsers into separate AL_TAG specific Dockerifles
- Allow AL2 to continue to pull from fluent-bit-docker-image (prevent regression)
- Allow AL2023 to pull parsers from source (fixes)

### Testing
Built local images AL2/AL2023 and validated:
1. Parsers matched AL2 local image and public ECR
2. AL2023 parsers matched what is available in https://github.com/fluent/fluent-bit/tree/master/conf for parsers*.conf

`make debug` succeeded: yes
Integ tests succeeded: yes
New tests cover the changes: no

### Description for the changelog
Enhancement: AL2023 uses parsers from fluent-bit source

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
