### PR TITLE
Add BUILD_VERSION=3 support to publish_ssm

### DIFF
--- a/buildspec_publish_ssm.yml
+++ b/buildspec_publish_ssm.yml
@@ -12,6 +12,7 @@ phases:
       # Enforce STS regional endpoints
       - export AWS_STS_REGIONAL_ENDPOINTS=regional
       - './scripts/publish.sh cicd-publish-ssm ${AWS_REGION}'
+      - BUILD_VERSION=3 ./scripts/publish.sh cicd-publish-ssm ${AWS_REGION}
 
       # Assume role to verify, get the credentials, and set them as environment variables.
       # Verification should be done using the credentials from a different account. It ensures that
@@ -22,6 +23,7 @@ phases:
       - export AWS_SESSION_TOKEN=`echo $CREDS | jq -r .Credentials.SessionToken`
 
       - './scripts/publish.sh cicd-verify-ssm ${AWS_REGION}'
+      - BUILD_VERSION=3 ./scripts/publish.sh cicd-verify-ssm ${AWS_REGION}
 artifacts:
   files:
     - '**/*'

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -238,6 +238,19 @@ publish_to_public_ecr() {
 }
 
 publish_ssm() {
+	# Check if BUILD_VERSION=3 images exist before publishing SSM parameters
+	if [ "$BUILD_VERSION" = "3" ]; then
+		if ! check_tag_exists "${2}" "${3}"; then
+			echo "BUILD_VERSION=3 image ${2}:${3} not found, skipping SSM parameter publish for region ${1}"
+			return 0
+		fi
+
+		if ! check_tag_exists "${2}" "init-${3}"; then
+			echo "BUILD_VERSION=3 init image ${2}:init-${3} not found, skipping SSM parameter publish for region ${1}"
+			return 0
+		fi
+	fi
+
 	# This optional parameter indicates if we should publish stable (defaults to false)
 	if [ ${4:-false} = true ]; then
 		aws ssm put-parameter --name /aws/service/aws-for-fluent-bit/stable --overwrite \
@@ -469,6 +482,14 @@ verify_ssm() {
 			check_parameter ${1} stable
 		fi
 	else
+		# Check if image exist before any SSM verification for BUILD_VERSION=3
+		if [ "$BUILD_VERSION" = "3" ]; then
+			if ! check_tag_exists "${3}.dkr.ecr.${1}.${endpoint}/aws-for-fluent-bit" "${AWS_FOR_FLUENT_BIT_VERSION}"; then
+				echo "Warning: BUILD_VERSION=3 image not found in ECR, skipping SSM verification for region ${1}"
+				return 0
+			fi
+		fi
+
 		check_parameter ${1} ${AWS_FOR_FLUENT_BIT_VERSION}
 	fi
 }


### PR DESCRIPTION
### Summary
- Add checks for BUILD_VERSION=3 to validate image exists before publishing/verifying ssm parameters

### Testing
Local testing/debugging, changes follow similar pattern to allow BUILD_VERSION=3 to gracefully fail/warn and not prevent the existing action from failing.

### Description for the changelog
Enhancement: Add support for publishing BUILD_VERSION=3 SSM Parameters

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

