### PR TITLE
Add publish flag allow skipping release

### DIFF
--- a/linux.version
+++ b/linux.version
@@ -9,7 +9,8 @@
             "firehose-plugin": "v1.7.2",
             "cloudwatch-plugin": "v1.9.4",
             "al-tag": "2",
-            "flb-repository": "https://github.com/amazon-contributing/upstream-to-fluent-bit.git"
+            "flb-repository": "https://github.com/amazon-contributing/upstream-to-fluent-bit.git",
+            "publish": "true"
         }
     },
     {
@@ -23,7 +24,8 @@
             "firehose-plugin": "v1.7.2",
             "cloudwatch-plugin": "v1.9.4",
             "al-tag": "2023",
-            "flb-repository": "https://github.com/fluent/fluent-bit.git"
+            "flb-repository": "https://github.com/fluent/fluent-bit.git",
+            "publish": "false"
         }
     }
 ]

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -350,6 +350,20 @@ check_tag_exists() {
 	fi
 }
 
+# Helper function to check if publishing is enabled for the current BUILD_VERSION
+# Returns 0 if enabled, exits with 0 if disabled (to avoid pipeline failure)
+check_publish_enabled() {
+	local operation=${1:-"operation"}
+
+	PUBLISH_ENABLED=$(../scripts/get_linux_version.sh "$BUILD_VERSION" "publish")
+	echo "Publish enabled for BUILD_VERSION=${BUILD_VERSION}? ${PUBLISH_ENABLED}"
+
+	if [ "${PUBLISH_ENABLED}" = "false" ]; then
+		echo "Publishing is disabled for BUILD_VERSION=${BUILD_VERSION}, skipping ${operation}"
+		exit 0
+	fi
+}
+
 sync_public_and_repo() {
 	region=${1}
 	account_id=${2}
@@ -1230,6 +1244,7 @@ fi
 # Publish using CI/CD pipeline
 # Following scripts will be called only from the CI/CD pipeline
 if [ "${1}" = "cicd-publish" ]; then
+	check_publish_enabled "${1}"
 	if [ "${2}" = "dockerhub" ]; then
 		publish_to_docker_hub amazon/aws-for-fluent-bit
 	elif [ "${2}" = "public-ecr" ]; then
@@ -1283,6 +1298,7 @@ fi
 
 # Verify using CI/CD pipeline
 if [ "${1}" = "cicd-verify" ]; then
+	check_publish_enabled "${1}"
 	if [ "${2}" = "dockerhub" ]; then
 		verify_dockerhub
 	elif [ "${2}" = "public-ecr" ]; then
@@ -1333,6 +1349,7 @@ fi
 
 # Publish SSM parameters
 if [ "${1}" = "cicd-publish-ssm" ]; then
+	check_publish_enabled "${1}"
 	if [ "${2}" = "us-gov-east-1" ] || [ "${2}" = "us-gov-west-1" ]; then
 		for region in ${gov_regions}; do
 			publish_ssm ${region} ${gov_regions_account_id}.dkr.ecr.${region}.amazonaws.com/aws-for-fluent-bit ${AWS_FOR_FLUENT_BIT_VERSION_PUBLIC_ECR}
@@ -1372,6 +1389,7 @@ fi
 
 # Verify SSM parameters
 if [ "${1}" = "cicd-verify-ssm" ]; then
+	check_publish_enabled "${1}"
 	if [ "${2}" = "us-gov-east-1" ] || [ "${2}" = "us-gov-west-1" ]; then
 		for region in ${gov_regions}; do
 			verify_ssm ${region} true ${gov_regions_account_id}


### PR DESCRIPTION
### Summary
- v2 - publish: true
- v3 - publish: false
- Add checks in publish.sh to cicd-publish, cicd-verify, cicd-publish-ssm, cicd-verify-ssm to skip if the publish flag for the build version is false to prevent unexpected release
- Long term will we introduce a better solution to control releases

No changes are required in the buildspec yaml as each request passes the BUILD_VERSION which retrieves the `publish` flag for validation if enabled (true).

### Testing
Local testing/validation that BUILD_VERSION=3 will skip (and not fail) actions in buildspec's for ecr, dockerhub, public ecr, and ssm.

### Description for the changelog
Enhancement: Add publish flag allow skipping release

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
