### PR TITLE
Skip build when publish config is false

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,6 +22,15 @@ fi
 
 echo "Building AWS for Fluent Bit version $BUILD_VERSION"
 
+# Check if publishing is enabled for this BUILD_VERSION
+PUBLISH_ENABLED=$(./scripts/get_linux_version.sh "$BUILD_VERSION" "publish")
+echo "Publish enabled for BUILD_VERSION=${BUILD_VERSION}? ${PUBLISH_ENABLED}"
+
+if [ "${PUBLISH_ENABLED}" = "false" ]; then
+    echo "Publishing is disabled for BUILD_VERSION=${BUILD_VERSION}, skipping build process"
+    exit 0
+fi
+
 # Get version-specific configuration using linux.version getter script
 AL_TAG=$(./scripts/get_linux_version.sh "$BUILD_VERSION" "al-tag")
 FLB_VERSION=$(./scripts/get_linux_version.sh "$BUILD_VERSION" "fluent-bit")

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1432,9 +1432,11 @@ if [ "${1}" = "cicd-verify-ssm" ]; then
 fi
 
 if [ "${1}" = "cicd-verify-ecr-image-scan" ]; then
+	check_publish_enabled "${1}"
 	verify_ecr_image_scan ${2} ${3} ${4}
 fi
 
 if [ "${1}" = "cicd-check-image-version" ]; then
+	check_publish_enabled "${1}"
 	check_image_version ${AWS_FOR_FLUENT_BIT_VERSION} 
 fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR adds skip in build.sh to honor the "publish" config in linux.version file that was recently added (https://github.com/aws/aws-for-fluent-bit/pull/1010). This will ensure unnecessary builds are not made. More importantly, in a codebuild job, this ensures consistent behavior if a version already exists in ECR and publish is false, so that jobs would not unnecessarily fail.

Also added a skip check in publish.sh for `check_image_version` and `verify_ecr_image_scan` which checks ECR image and runs security scans. Although this path doesn't run with the above skip.

### Testing
Tested in codepipeline with current linux.version config in personal codepipeline with following results
- major-version 2: builds fail if ECR image exists and publish is true
- major-version 3: builds skip if ECR image doesn't exist and publish is false

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->
Skip build when publish config is false

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
