### PR TITLE
Allow skip integ/load tests if publish false

### DIFF
--- a/buildspec_integ.yml
+++ b/buildspec_integ.yml
@@ -23,6 +23,15 @@ phases:
           exit 1
         fi
       - |
+        # Check if publishing is enabled for this BUILD_VERSION
+        PUBLISH_ENABLED=$(./scripts/get_linux_version.sh "$BUILD_VERSION" "publish")
+        echo "Publish enabled for BUILD_VERSION=${BUILD_VERSION}? ${PUBLISH_ENABLED}"
+
+        if [ "${PUBLISH_ENABLED}" = "false" ]; then
+            echo "Publishing is disabled for BUILD_VERSION=${BUILD_VERSION}, skipping integration tests"
+            exit 0
+        fi
+      - |
         # Enforce STS regional endpoints and set validator images
         export AWS_STS_REGIONAL_ENDPOINTS=regional
         export CW_INTEG_VALIDATOR_IMAGE_BASE=${AWS_ACCOUNT}.dkr.ecr.us-west-2.amazonaws.com/cw-integ-validator

--- a/buildspec_load_test.yml
+++ b/buildspec_load_test.yml
@@ -53,6 +53,15 @@ phases:
         else
           echo "BUILD_VERSION is set to: $BUILD_VERSION"
         fi
+      - |
+        # Check if publishing is enabled for this BUILD_VERSION
+        PUBLISH_ENABLED=$(./scripts/get_linux_version.sh "$BUILD_VERSION" "publish")
+        echo "Publish enabled for BUILD_VERSION=${BUILD_VERSION}? ${PUBLISH_ENABLED}"
+
+        if [ "${PUBLISH_ENABLED}" = "false" ]; then
+            echo "Publishing is disabled for BUILD_VERSION=${BUILD_VERSION}, skipping load tests"
+            exit 0
+        fi
       # Set stack names based on BUILD_VERSION.
       # Do not add BUILD_VERSION for BUILD_VERSION=2 to make load test work with existing resources.
       # This can be changed once naming is aligned and resources are resynthesized for BUILD_VERSION=2


### PR DESCRIPTION


### Summary
Copying changes from the build skipping #1011 and applying to integ/load tests to save on resources.


### Testing
Spot checked

### Description for the changelog
Enhancement: Allow skip integ/load tests if publish false

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
