### PR TITLE
Fix issue with Makefile parsing OS_PRETTY_NAME before image exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 all: release
 
 # Execute set-cache to turn docker cache back on for faster development.
-DOCKER_BUILD_FLAGS :=
+DOCKER_BUILD_FLAGS := "--no-cache"
 # Amazon Linux Tag to use for images, will use value if not set
 AL_TAG ?= "2"
 # Fluent Bit version (branch or tag) to checkout, will use value if not set 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 all: release
 
 # Execute set-cache to turn docker cache back on for faster development.
-DOCKER_BUILD_FLAGS := "--no-cache"
+DOCKER_BUILD_FLAGS :=
 # Amazon Linux Tag to use for images, will use value if not set
 AL_TAG ?= "2"
 # Fluent Bit version (branch or tag) to checkout, will use value if not set 
@@ -23,8 +23,10 @@ FLB_VERSION ?= "1.9.10"
 FLB_REPOSITORY ?= "https://github.com/amazon-contributing/upstream-to-fluent-bit.git"
 # AWS for Fluent Bit Version
 AWS_FOR_FLUENT_BIT_VERSION ?= $(shell ./scripts/get_linux_version.sh 2 version)
-# OS Pretty Name (assigned during build-common)
-OS_PRETTY_NAME :=
+# OS Pretty Name
+OS_PRETTY_NAME := "$(shell docker run --rm public.ecr.aws/amazonlinux/amazonlinux:${AL_TAG} sh -c "grep '^PRETTY_NAME=' /etc/os-release | cut -d'\"' -f2")"
+# Alternative OS identifier for container images
+OS_IMAGE_ID := "$(shell docker run --rm public.ecr.aws/amazonlinux/amazonlinux:${AL_TAG} sh -c "grep '^image_file=' /etc/image-id | cut -d'\"' -f2")"
 
 .PHONY: dev
 dev: DOCKER_BUILD_FLAGS =
@@ -37,8 +39,6 @@ build-common:
 	docker build $(DOCKER_BUILD_FLAGS) --build-arg AL_TAG=${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg FLB_REPOSITORY=${FLB_REPOSITORY} -t amazon/aws-for-fluent-bit:build-common-al${AL_TAG} -f ./scripts/dockerfiles/build/Dockerfile.build-common .
 	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:golang -f ./scripts/dockerfiles/build/Dockerfile.golang .
 	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:compile-init-al${AL_TAG} -f ./scripts/dockerfiles/build/Dockerfile.compile-init .
-# Store OS_PRETTY_NAME for later image labeling
-	$(eval OS_PRETTY_NAME := $(shell docker run --rm amazon/aws-for-fluent-bit:build-deps-al${AL_TAG} sh -c "grep '^PRETTY_NAME=' /etc/os-release | cut -d'\"' -f2"))
 
 .PHONY: build
 build: build-common
@@ -81,13 +81,13 @@ linux-plugins:
 .PHONY: release
 release: build linux-plugins
 	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile.deps-al${AL_TAG} .
-	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg AWS_FOR_FLUENT_BIT_VERSION=${AWS_FOR_FLUENT_BIT_VERSION} --build-arg OS_PRETTY_NAME="${OS_PRETTY_NAME}" -t amazon/aws-for-fluent-bit:latest-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg AWS_FOR_FLUENT_BIT_VERSION=${AWS_FOR_FLUENT_BIT_VERSION} --build-arg OS_PRETTY_NAME=${OS_PRETTY_NAME} --build-arg OS_IMAGE_ID=${OS_IMAGE_ID} -t amazon/aws-for-fluent-bit:latest-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile .
 	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-init-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:latest-al${AL_TAG} -t amazon/aws-for-fluent-bit:init-latest-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile.init .
 
 .PHONY: debug
 debug: build-debug linux-plugins
 	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:runtime-deps-debug-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile.deps-debug-al${AL_TAG} .
-	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-debug-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-deps-debug-al${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg AWS_FOR_FLUENT_BIT_VERSION=${AWS_FOR_FLUENT_BIT_VERSION} --build-arg OS_PRETTY_NAME="${OS_PRETTY_NAME}" -t amazon/aws-for-fluent-bit:runtime-debug-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-debug-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-deps-debug-al${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg AWS_FOR_FLUENT_BIT_VERSION=${AWS_FOR_FLUENT_BIT_VERSION} --build-arg ${OS_PRETTY_NAME} --build-arg OS_IMAGE_ID=${OS_IMAGE_ID} -t amazon/aws-for-fluent-bit:runtime-debug-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile .
 	docker build $(DOCKER_BUILD_FLAGS) --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-debug-al${AL_TAG} -t amazon/aws-for-fluent-bit:runtime-debug-common-${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile.debug-common .
 #   s3 images
 	docker build $(DOCKER_BUILD_FLAGS) --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-debug-common-${AL_TAG} -t amazon/aws-for-fluent-bit:debug-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile.debug .
@@ -109,7 +109,7 @@ cloudwatch-dev: build
     	--CLOUDWATCH_PLUGIN_BRANCH=${CLOUDWATCH_PLUGIN_BRANCH} \
     	--DOCKER_BUILD_FLAGS=${DOCKER_BUILD_FLAGS}
 	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile.deps-al${AL_TAG} .
-	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg AWS_FOR_FLUENT_BIT_VERSION=${AWS_FOR_FLUENT_BIT_VERSION} --build-arg OS_PRETTY_NAME="${OS_PRETTY_NAME}" -t amazon/aws-for-fluent-bit:latest-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg AWS_FOR_FLUENT_BIT_VERSION=${AWS_FOR_FLUENT_BIT_VERSION} --build-arg OS_PRETTY_NAME=${OS_PRETTY_NAME} --build-arg OS_IMAGE_ID=${OS_IMAGE_ID} -t amazon/aws-for-fluent-bit:latest-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile .
 
 .PHONY: firehose-dev
 firehose-dev: export OS_TYPE = linux
@@ -119,7 +119,7 @@ firehose-dev: build
     	--FIREHOSE_PLUGIN_BRANCH=${FIREHOSE_PLUGIN_BRANCH} \
     	--DOCKER_BUILD_FLAGS=${DOCKER_BUILD_FLAGS}
 	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile.deps-al${AL_TAG} .
-	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg AWS_FOR_FLUENT_BIT_VERSION=${AWS_FOR_FLUENT_BIT_VERSION} --build-arg OS_PRETTY_NAME="${OS_PRETTY_NAME}" -t amazon/aws-for-fluent-bit:latest-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg AWS_FOR_FLUENT_BIT_VERSION=${AWS_FOR_FLUENT_BIT_VERSION} --build-arg OS_PRETTY_NAME=${OS_PRETTY_NAME} --build-arg OS_IMAGE_ID=${OS_IMAGE_ID} -t amazon/aws-for-fluent-bit:latest-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile .
 
 .PHONY: kinesis-dev
 kinesis-dev: export OS_TYPE = linux
@@ -129,7 +129,7 @@ kinesis-dev: build
     	--KINESIS_PLUGIN_BRANCH=${KINESIS_PLUGIN_BRANCH} \
     	--DOCKER_BUILD_FLAGS=${DOCKER_BUILD_FLAGS}
 	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile.deps-al${AL_TAG} .
-	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg AWS_FOR_FLUENT_BIT_VERSION=${AWS_FOR_FLUENT_BIT_VERSION} --build-arg OS_PRETTY_NAME="${OS_PRETTY_NAME}" -t amazon/aws-for-fluent-bit:latest-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg AWS_FOR_FLUENT_BIT_VERSION=${AWS_FOR_FLUENT_BIT_VERSION} --build-arg OS_PRETTY_NAME=${OS_PRETTY_NAME} --build-arg OS_IMAGE_ID=${OS_IMAGE_ID} -t amazon/aws-for-fluent-bit:latest-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile .
 
 .PHONY: validate-version-file-format
 validate-version-file-format:

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -34,18 +34,19 @@ Example Labels
 {
   "author": "FireLens Team <aws-firelens@amazon.com>",
   "com.aws-for-fluent-bit.fluent-bit.version": "1.9.10",
+  "com.aws-for-fluent-bit.os.image-id": "amzn2-container-raw-2.0.20250910.0-x86_64",
   "com.aws-for-fluent-bit.os.version": "Amazon Linux 2",
   "org.opencontainers.image.authors": "FireLens Team <aws-firelens@amazon.com>",
-  "org.opencontainers.image.description": "Fluent Bit is an open source and multi-platform Log Processor and Forwarder which allows you to collect data/logs from different sources, unify and send them to multiple destinations. It's fully compatible with Docker and Kubernetes environments.",
+  "org.opencontainers.image.description": "AWS for Fluent Bit is the official AWS distribution of Fluent Bit. It is fully compatible with upstream Fluent Bit and is designed to be used on AWS environments like Amazon ECS and Amazon EKS.",
   "org.opencontainers.image.documentation": "https://github.com/aws/aws-for-fluent-bit",
   "org.opencontainers.image.licenses": "Apache-2.0",
   "org.opencontainers.image.source": "https://github.com/aws/aws-for-fluent-bit",
   "org.opencontainers.image.title": "AWS for Fluent Bit",
   "org.opencontainers.image.url": "https://gallery.ecr.aws/aws-observability/aws-for-fluent-bit",
   "org.opencontainers.image.vendor": "Amazon Web Services",
-  "org.opencontainers.image.version": "2.33.3",
+  "org.opencontainers.image.version": "2.34.0",
   "vendor": "Amazon Web Services",
-  "version": "2.33.3"
+  "version": "2.34.0"
 }
 ```
 

--- a/scripts/dockerfiles/runtime/Dockerfile
+++ b/scripts/dockerfiles/runtime/Dockerfile
@@ -51,12 +51,14 @@ RUN chmod +x /entrypoint.sh
 
 ARG FLB_VERSION
 ARG OS_PRETTY_NAME
+ARG OS_IMAGE_ID
 
 LABEL author="FireLens Team <aws-firelens@amazon.com>" \
       vendor="Amazon Web Services" \
       version=${AWS_FOR_FLUENT_BIT_VERSION} \
       com.aws-for-fluent-bit.fluent-bit.version=${FLB_VERSION} \
       com.aws-for-fluent-bit.os.version=${OS_PRETTY_NAME} \
+      com.aws-for-fluent-bit.os.image-id=${OS_IMAGE_ID} \
       org.opencontainers.image.title="AWS for Fluent Bit" \
       org.opencontainers.image.authors="FireLens Team <aws-firelens@amazon.com>" \
       org.opencontainers.image.description="AWS for Fluent Bit is the official AWS distribution of Fluent Bit. It is fully compatible with upstream Fluent Bit and is designed to be used on AWS environments like Amazon ECS and Amazon EKS." \


### PR DESCRIPTION
### Summary
- It was possible that the deps-AL_TAG image did not exist when the makefile was parsed causing a logged error. This would also prevent OS_PRETTY_NAME from containing a value on the built image
- Move OS_PRETTY_NAME to top and pull value from AmazonLinux:AL_TAG image
- Add OS_IMAGE_ID and pull from /etc/image-id to display better version details for AL2
- Add new ARG/Docker label
- Remove quotes from OS_PRETTY_NAME as the top-level value is now quoted

### Testing
Built images locally and tested build and docker labels

```
dev-dsk-shelbyzh-2c-4b7a8c60 % docker inspect amazon/aws-for-fluent-bit:latest-al2 --format='{{json .Config.Labels}}' | jq -C '.'
{
  "author": "FireLens Team <aws-firelens@amazon.com>",
  "com.aws-for-fluent-bit.fluent-bit.version": "1.9.10",
  "com.aws-for-fluent-bit.os.image-id": "amzn2-container-raw-2.0.20250910.0-x86_64",
  "com.aws-for-fluent-bit.os.version": "Amazon Linux 2",
  "org.opencontainers.image.authors": "FireLens Team <aws-firelens@amazon.com>",
  "org.opencontainers.image.description": "AWS for Fluent Bit is the official AWS distribution of Fluent Bit. It is fully compatible with upstream Fluent Bit and is designed to be used on AWS environments like Amazon ECS and Amazon EKS.",
  "org.opencontainers.image.documentation": "https://github.com/aws/aws-for-fluent-bit",
  "org.opencontainers.image.licenses": "Apache-2.0",
  "org.opencontainers.image.source": "https://github.com/aws/aws-for-fluent-bit",
  "org.opencontainers.image.title": "AWS for Fluent Bit",
  "org.opencontainers.image.url": "https://gallery.ecr.aws/aws-observability/aws-for-fluent-bit",
  "org.opencontainers.image.vendor": "Amazon Web Services",
  "org.opencontainers.image.version": "2.34.0",
  "vendor": "Amazon Web Services",
  "version": "2.34.0"
}
```

### Description for the changelog
Fix issue with Makefile parsing OS_PRETTY_NAME before image exists 

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
