### PR TITLE
Release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+### 2.34.1
 This release includes:
 * Fluent Bit [1.9.10](https://github.com/fluent/fluent-bit/tree/v1.9.10)
 * Amazon CloudWatch Logs for Fluent Bit 1.9.4

--- a/linux.version
+++ b/linux.version
@@ -26,7 +26,7 @@
       "cloudwatch-plugin": "v1.9.4",
       "al-tag": "2023",
       "flb-repository": "https://github.com/fluent/fluent-bit.git",
-      "publish": "false"
+      "publish": "true"
     }
   }
 ]


### PR DESCRIPTION
This release includes:
* Fluent Bit [4.1.0](https://github.com/fluent/fluent-bit/tree/v4.1.0)
* Amazon CloudWatch Logs for Fluent Bit 1.9.4
* Amazon Kinesis Streams for Fluent Bit 1.10.2
* Amazon Kinesis Firehose for Fluent Bit 1.7.2
* Amazon Linux 2023 base container image version: [2023.9.20250929](https://docs.aws.amazon.com/linux/al2023/release-notes/relnotes-2023.9.20250929.html)

Compared to the previous release, this release adds:
* Enhancement - Add support for syncing BUILD_VERSION=3 images [#1000](https://github.com/aws/aws-for-fluent-bit/pull/1000)
* Enhancement - Move to v4.1.0 fluent-bit version [#1003](https://github.com/aws/aws-for-fluent-bit/pull/1003)
* Enhancement - Rework parsers to allow pulling from source for AL2023 [#1004](https://github.com/aws/aws-for-fluent-bit/pull/1004)
* Enhancement - Add helper script to support syncing all test images [#1005](https://github.com/aws/aws-for-fluent-bit/pull/1005)
* Enhancement - Add BUILD_VERSION=3 support to publish_ecr [#1006](https://github.com/aws/aws-for-fluent-bit/pull/1006)
* Enhancement - Add BUILD_VERSION=3 support to publish_dockerhub [#1007](https://github.com/aws/aws-for-fluent-bit/pull/1007)
* Enhancement - Add BUILD_VERSION=3 support to public_public_ecr [#1008](https://github.com/aws/aws-for-fluent-bit/pull/1008)
* Enhancement - Add BUILD_VERSION=3 support to publish_ssm [#1009](https://github.com/aws/aws-for-fluent-bit/pull/1009)
* Enhancement - Add publish flag allow skipping release [#1010](https://github.com/aws/aws-for-fluent-bit/pull/1010)
* Enhancement - Skip build when publish config is false [#1011](https://github.com/aws/aws-for-fluent-bit/pull/1011)
* Enhancement - Update generate_changelog.sh to support versions [#1012](https://github.com/aws/aws-for-fluent-bit/pull/1012)
* Enhancement - Allow skip integ/load tests if publish false [#1013](https://github.com/aws/aws-for-fluent-bit/pull/1013)
* Fix - issue with Makefile parsing OS_PRETTY_NAME before image exists [#1014](https://github.com/aws/aws-for-fluent-bit/pull/1014)

Also fix CHANGELOG.md heading for 2.34.1 release