### PR TITLE
Fix integ stack naming

### DIFF
--- a/integ/resources/create_test_resources.sh
+++ b/integ/resources/create_test_resources.sh
@@ -12,4 +12,4 @@ fi
 # Default BUILD_VERSION to 2 if not set
 BUILD_VERSION=${BUILD_VERSION:-2}
 
-aws cloudformation deploy --template-file ./integ/resources/cfn-kinesis-s3-firehose.yml --stack-name integ-test-fluent-bit-${ARCHITECTURE}-v${BUILD_VERSION} --region "$AWS_REGION" --capabilities CAPABILITY_NAMED_IAM --no-fail-on-empty-changeset
+aws cloudformation deploy --template-file ./integ/resources/cfn-kinesis-s3-firehose.yml --stack-name integ-test-fluent-bit-${ARCHITECTURE}-V${BUILD_VERSION} --region "$AWS_REGION" --capabilities CAPABILITY_NAMED_IAM --no-fail-on-empty-changeset

--- a/integ/resources/delete_test_resources.sh
+++ b/integ/resources/delete_test_resources.sh
@@ -10,4 +10,4 @@ fi
 # Default BUILD_VERSION to 2 if not set
 BUILD_VERSION=${BUILD_VERSION:-2}
 
-aws cloudformation delete-stack --stack-name integ-test-fluent-bit-${ARCHITECTURE}-v${BUILD_VERSION}
+aws cloudformation delete-stack --stack-name integ-test-fluent-bit-${ARCHITECTURE}-V${BUILD_VERSION}

--- a/integ/resources/setup_test_environment.sh
+++ b/integ/resources/setup_test_environment.sh
@@ -11,7 +11,7 @@ fi
 # Default BUILD_VERSION to 2 if not set
 BUILD_VERSION=${BUILD_VERSION:-2}
 
-stackOutputs=$(aws cloudformation describe-stacks --region "$AWS_REGION" --stack-name integ-test-fluent-bit-${ARCHITECTURE}-v${BUILD_VERSION} --output text --query 'Stacks[0].Outputs[*].OutputValue')
+stackOutputs=$(aws cloudformation describe-stacks --region "$AWS_REGION" --stack-name integ-test-fluent-bit-${ARCHITECTURE}-V${BUILD_VERSION} --output text --query 'Stacks[0].Outputs[*].OutputValue')
 read -r -a outputArray <<< "$stackOutputs"
 export FIREHOSE_STREAM="${outputArray[0]}"
 export KINESIS_STREAM="${outputArray[1]}"


### PR DESCRIPTION
### Summary
Checked resource naming in AWS console and determined `v` was upper-case which would fail the `aws cloudformation describe-stacks` in setup_test_environment.sh`

### Description for the changelog
Fix integ stack naming

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
