### PR TITLE
Fix BUILD_VERSION=2 publish steps

### DIFF
--- a/buildspec_publish_dockerhub.yml
+++ b/buildspec_publish_dockerhub.yml
@@ -13,11 +13,11 @@ phases:
       - ./scripts/pipeline/sync-test-images.sh --tag
 
       # Push the image to dockerhub
-      - './scripts/publish.sh cicd-publish dockerhub'
+      - BUILD_VERSION=2 ./scripts/publish.sh cicd-publish dockerhub
       - BUILD_VERSION=3 ./scripts/publish.sh cicd-publish dockerhub
 
       # Pull the image from dockerhub and verify
-      - './scripts/publish.sh cicd-verify dockerhub'
+      - BUILD_VERSION=2 ./scripts/publish.sh cicd-verify dockerhub
       - BUILD_VERSION=3 ./scripts/publish.sh cicd-verify dockerhub
 artifacts:
   files:

--- a/buildspec_publish_ecr.yml
+++ b/buildspec_publish_ecr.yml
@@ -22,7 +22,7 @@ phases:
         fi
 
       # Push the image to ECR
-      - './scripts/publish.sh cicd-publish ${REGION_TO_PUSH}'
+      - BUILD_VERSION=2 ./scripts/publish.sh cicd-publish ${REGION_TO_PUSH}
       - BUILD_VERSION=3 ./scripts/publish.sh cicd-publish ${REGION_TO_PUSH}
 
       # Nullify the temporary credentials for the assumed role to publish
@@ -42,7 +42,7 @@ phases:
       - export AWS_SESSION_TOKEN=`echo $CREDS | jq -r .Credentials.SessionToken`
 
       # Verify from the verification account
-      - './scripts/publish.sh cicd-verify ${REGION_TO_PUSH}'
+      - BUILD_VERSION=2 ./scripts/publish.sh cicd-verify ${REGION_TO_PUSH}
       - BUILD_VERSION=3 ./scripts/publish.sh cicd-verify ${REGION_TO_PUSH}
 artifacts:
   files:

--- a/buildspec_publish_public_ecr.yml
+++ b/buildspec_publish_public_ecr.yml
@@ -28,7 +28,7 @@ phases:
         fi
 
       # Push the image to Public ECR
-      - './scripts/publish.sh cicd-publish public-ecr'
+      - BUILD_VERSION=2 ./scripts/publish.sh cicd-publish public-ecr
       - BUILD_VERSION=3 ./scripts/publish.sh cicd-publish public-ecr
 
       # Nullify the temporary credentials for the assumed role to publish
@@ -40,7 +40,7 @@ phases:
         fi
 
       # Pull the image from Public ECR and verify
-      - './scripts/publish.sh cicd-verify public-ecr'
+      - BUILD_VERSION=2 ./scripts/publish.sh cicd-verify public-ecr
       - BUILD_VERSION=3 ./scripts/publish.sh cicd-verify public-ecr
 artifacts:
   files:

--- a/buildspec_publish_ssm.yml
+++ b/buildspec_publish_ssm.yml
@@ -11,7 +11,7 @@ phases:
     commands:
       # Enforce STS regional endpoints
       - export AWS_STS_REGIONAL_ENDPOINTS=regional
-      - './scripts/publish.sh cicd-publish-ssm ${AWS_REGION}'
+      - BUILD_VERSION=2 ./scripts/publish.sh cicd-publish-ssm ${AWS_REGION}
       - BUILD_VERSION=3 ./scripts/publish.sh cicd-publish-ssm ${AWS_REGION}
 
       # Assume role to verify, get the credentials, and set them as environment variables.
@@ -22,7 +22,7 @@ phases:
       - export AWS_SECRET_ACCESS_KEY=`echo $CREDS | jq -r .Credentials.SecretAccessKey`
       - export AWS_SESSION_TOKEN=`echo $CREDS | jq -r .Credentials.SessionToken`
 
-      - './scripts/publish.sh cicd-verify-ssm ${AWS_REGION}'
+      - BUILD_VERSION=2 ./scripts/publish.sh cicd-verify-ssm ${AWS_REGION}
       - BUILD_VERSION=3 ./scripts/publish.sh cicd-verify-ssm ${AWS_REGION}
 artifacts:
   files:


### PR DESCRIPTION


### Summary
During publish steps we noticed that BUILD_VERSION was an unbound variable when calling publish.sh. We added BUILD_VERSION=3 steps with the intention that BUILD_VERSION=2 would be the default, but that seems to have not happened.

### Testing
Spot checked pipeline steps (ECR, DockerHub, Public ECR, SSM) for publish.sh calls without an explicit BUILD_VERSION set.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
