### PR TITLE
Add curl to AL2023 runtime dependencies

### DIFF
--- a/scripts/dockerfiles/runtime/Dockerfile.deps-al2023
+++ b/scripts/dockerfiles/runtime/Dockerfile.deps-al2023
@@ -14,7 +14,8 @@ RUN mkdir /sysroot && \
         cyrus-sasl-lib \
         arrow2100-glib-libs \
         parquet2100-glib-libs \
-        libstdc++
+        libstdc++ \
+        curl
 
 # Final minimal runtime image using scratch base
 FROM scratch


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->

*Issue #, if available:*

### Testing
Build image locally and checkout resulting packages installed:

1. Build new image: `BUILD_VERSION=3 AL_TAG=2023 FLB_VERSION=v4.1.1 FLB_REPOSITORY=https://github.com/fluent/fluent-bit make release`
2. Check before packages: `docker run amazon/aws-for-fluent-bit:latest-al2023 grep "Installed:" /var/log/dnf.log /var/log/yum.log 2>/dev/null | sed 's/.*Installed: //' > before.out`
4. Check changed installed: `docker run amazon/aws-for-fluent-bit:latest-al2023 grep "Installed:" /var/log/dnf.log /var/log/yum.log 2>/dev/null | sed 's/.*Installed: //' > after.out`
5. Get diff: `diff before.out after.out`

Before (74)
```
alternatives-1.15-2.amzn2023.0.2.x86_64
amazon-linux-repo-cdn-2023.9.20250929-0.amzn2023.noarch
arrow2100-acero-libs-21.0.0-1.amzn2023.x86_64
arrow2100-compute-libs-21.0.0-1.amzn2023.x86_64
arrow2100-glib-libs-21.0.0-1.amzn2023.x86_64
arrow2100-libs-21.0.0-1.amzn2023.x86_64
basesystem-11-11.amzn2023.0.2.noarch
bash-5.2.15-1.amzn2023.0.2.x86_64
bzip2-libs-1.0.8-6.amzn2023.0.2.x86_64
ca-certificates-2025.2.76-1.0.amzn2023.0.2.noarch
coreutils-8.32-30.amzn2023.0.4.x86_64
coreutils-common-8.32-30.amzn2023.0.4.x86_64
crypto-policies-20240828-2.git626aa59.amzn2023.0.1.noarch
cyrus-sasl-lib-2.1.27-18.amzn2023.0.3.x86_64
filesystem-3.14-5.amzn2023.0.3.x86_64
gdbm-libs-1:1.19-2.amzn2023.0.2.x86_64
glib2-2.82.2-766.amzn2023.x86_64
glibc-2.34-231.amzn2023.0.1.x86_64
glibc-common-2.34-231.amzn2023.0.1.x86_64
glibc-minimal-langpack-2.34-231.amzn2023.0.1.x86_64
gmp-1:6.2.1-2.amzn2023.0.2.x86_64
grep-3.8-1.amzn2023.0.4.x86_64
keyutils-libs-1.6.3-1.amzn2023.0.2.x86_64
krb5-libs-1.21.3-6.amzn2023.0.1.x86_64
libacl-2.3.1-2.amzn2023.0.2.x86_64
libattr-2.5.1-3.amzn2023.0.2.x86_64
libblkid-2.37.4-1.amzn2023.0.4.x86_64
libbrotli-1.0.9-4.amzn2023.0.2.x86_64
libcap-2.73-1.amzn2023.0.3.x86_64
libcom_err-1.46.5-2.amzn2023.0.2.x86_64
libcurl-8.11.1-4.amzn2023.0.1.x86_64
libffi-3.4.4-1.amzn2023.0.1.x86_64
libgcc-14.2.1-7.amzn2023.0.2.x86_64
libidn2-2.3.2-1.amzn2023.0.5.x86_64
libmount-2.37.4-1.amzn2023.0.4.x86_64
libnghttp2-1.59.0-3.amzn2023.0.1.x86_64
libpsl-0.21.5-1.amzn2023.0.1.x86_64
libselinux-3.4-5.amzn2023.0.2.x86_64
libsepol-3.4-3.amzn2023.0.3.x86_64
libssh-0.10.6-1.amzn2023.0.2.x86_64
libssh-config-0.10.6-1.amzn2023.0.2.noarch
libstdc++-14.2.1-7.amzn2023.0.2.x86_64
libtasn1-4.19.0-1.amzn2023.0.5.x86_64
libunistring-0.9.10-10.amzn2023.0.2.x86_64
libuuid-2.37.4-1.amzn2023.0.4.x86_64
libverto-0.3.2-1.amzn2023.0.2.x86_64
libxcrypt-4.4.33-7.amzn2023.x86_64
libxml2-2.10.4-1.amzn2023.0.13.x86_64
libyaml-0.2.5-5.amzn2023.0.2.x86_64
libzstd-1.5.5-1.amzn2023.0.1.x86_64
lz4-libs-1.9.4-1.amzn2023.0.2.x86_64
ncurses-base-6.2-4.20200222.amzn2023.0.6.noarch
ncurses-libs-6.2-4.20200222.amzn2023.0.6.x86_64
openldap-2.4.57-6.amzn2023.0.7.x86_64
openssl-fips-provider-latest-1:3.2.2-1.amzn2023.0.1.x86_64
openssl-libs-1:3.2.2-1.amzn2023.0.1.x86_64
p11-kit-0.24.1-2.amzn2023.0.3.x86_64
p11-kit-trust-0.24.1-2.amzn2023.0.3.x86_64
parquet2100-glib-libs-21.0.0-1.amzn2023.x86_64
parquet2100-libs-21.0.0-1.amzn2023.x86_64
pcre2-10.40-1.amzn2023.0.3.x86_64
pcre2-syntax-10.40-1.amzn2023.0.3.noarch
protobuf-3.19.6-1.amzn2023.0.1.x86_64
publicsuffix-list-dafsa-20240212-61.amzn2023.noarch
re2-1:20211101-3.amzn2023.0.2.x86_64
sed-4.8-7.amzn2023.0.2.x86_64
setup-2.13.7-3.amzn2023.0.2.noarch
snappy-1.1.8-5.amzn2023.0.2.x86_64
system-release-2023.9.20250929-0.amzn2023.noarch
systemd-libs-252.23-6.amzn2023.x86_64
tzdata-2025b-1.amzn2023.0.1.noarch
utf8proc-2.6.1-2.amzn2023.0.2.x86_64
xz-libs-5.2.5-9.amzn2023.0.2.x86_64
zlib-1.2.11-33.amzn2023.0.5.x86_64
```

Change (75, add curl)
```
curl-8.11.1-4.amzn2023.0.1.x86_64
```

### Description for the changelog
Enhancement: Add curl to AL2023 runtime dependencies

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
