### PR TITLE
Release 20251031: abandon v3 release, and unblock v2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,6 @@ This release includes:
 * Amazon Kinesis Firehose for Fluent Bit 1.7.2
 * Amazon Linux 2 base container image version: 2.0.20251027.1
 
-### 3.0.1
-This release includes:
-* Fluent Bit [v4.1.1](https://github.com/fluent/fluent-bit/tree/v4.1.1)
-* Amazon CloudWatch Logs for Fluent Bit 1.9.4
-* Amazon Kinesis Streams for Fluent Bit 1.10.3
-* Amazon Kinesis Firehose for Fluent Bit 1.7.2
-* Minimal set of packages installed using Amazon Linux 2023 container image version: 2023.9.20251027.0
-
-Compared to the previous release, this release adds:
-* Enhancement - Add curl to AL2023 runtime dependencies [#1026](https://github.com/aws/aws-for-fluent-bit/pull/1026)
-
 ### 2.34.1
 This release includes:
 * Fluent Bit [1.9.10](https://github.com/fluent/fluent-bit/tree/v1.9.10)

--- a/linux.version
+++ b/linux.version
@@ -17,7 +17,7 @@
   {
     "linux": {
       "major-version": "3",
-      "version": "3.0.1",
+      "version": "3.0.0",
       "latest": "false",
       "build": "1",
       "fluent-bit": "v4.1.1",
@@ -26,7 +26,7 @@
       "cloudwatch-plugin": "v1.9.4",
       "al-tag": "2023",
       "flb-repository": "https://github.com/fluent/fluent-bit.git",
-      "publish": "true"
+      "publish": "false"
     }
   }
 ]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

Release 20251031, abandon v3 release due to build issues and unblock v2 release

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
