### PR TITLE
Integ/Load tests: Fix buildspec such that it skips when publish=false.

### DIFF
--- a/buildspec_integ.yml
+++ b/buildspec_integ.yml
@@ -29,31 +29,32 @@ phases:
 
         if [ "${PUBLISH_ENABLED}" = "false" ]; then
             echo "Publishing is disabled for BUILD_VERSION=${BUILD_VERSION}, skipping integration tests"
-            exit 0
+        else
+            # Enforce STS regional endpoints and set validator images
+            export AWS_STS_REGIONAL_ENDPOINTS=regional
+            export CW_INTEG_VALIDATOR_IMAGE_BASE=${AWS_ACCOUNT}.dkr.ecr.us-west-2.amazonaws.com/cw-integ-validator
+            export S3_INTEG_VALIDATOR_IMAGE_BASE=${AWS_ACCOUNT}.dkr.ecr.us-west-2.amazonaws.com/s3-integ-validator
+            
+            # Get the default credentials and set as environment variables
+            CREDS=$(curl 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Token)
+            
+            aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com
+            
+            # Set image tag based on BUILD_VERSION
+            if [ "$BUILD_VERSION" = "2" ]; then
+              IMAGE_TAG="latest"
+            elif [ "$BUILD_VERSION" = "3" ]; then
+              IMAGE_TAG="latest-3"
+            fi
+            
+            docker pull ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:${IMAGE_TAG}
+            docker tag ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:${IMAGE_TAG} amazon/aws-for-fluent-bit:latest
+            docker images
+            make integ
         fi
-      - |
-        # Enforce STS regional endpoints and set validator images
-        export AWS_STS_REGIONAL_ENDPOINTS=regional
-        export CW_INTEG_VALIDATOR_IMAGE_BASE=${AWS_ACCOUNT}.dkr.ecr.us-west-2.amazonaws.com/cw-integ-validator
-        export S3_INTEG_VALIDATOR_IMAGE_BASE=${AWS_ACCOUNT}.dkr.ecr.us-west-2.amazonaws.com/s3-integ-validator
-      - |
-        # Get the default credentials and set as environment variables
-        CREDS=$(curl 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI)
-        export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .AccessKeyId)
-        export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .SecretAccessKey)
-        export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Token)
-      - aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com
-      - |
-        # Set image tag based on BUILD_VERSION
-        if [ "$BUILD_VERSION" = "2" ]; then
-          IMAGE_TAG="latest"
-        elif [ "$BUILD_VERSION" = "3" ]; then
-          IMAGE_TAG="latest-3"
-        fi
-      - docker pull ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:${IMAGE_TAG}
-      - docker tag ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:${IMAGE_TAG} amazon/aws-for-fluent-bit:latest
-      - docker images
-      - make integ
 
 artifacts:
   files:

--- a/buildspec_load_test.yml
+++ b/buildspec_load_test.yml
@@ -60,56 +60,55 @@ phases:
 
         if [ "${PUBLISH_ENABLED}" = "false" ]; then
             echo "Publishing is disabled for BUILD_VERSION=${BUILD_VERSION}, skipping load tests"
-            exit 0
-        fi
-      # Set stack names based on BUILD_VERSION.
-      # Do not add BUILD_VERSION for BUILD_VERSION=2 to make load test work with existing resources.
-      # This can be changed once naming is aligned and resources are resynthesized for BUILD_VERSION=2
-      - |
-        if [ "$BUILD_VERSION" = "2" ]; then
-          export TESTING_RESOURCES_STACK_NAME='load-test-fluent-bit-testing-resources'
-          export LOG_STORAGE_STACK_NAME='load-test-fluent-bit-log-storage'
-          export EKS_CLUSTER_NAME='load-test-fluent-bit-eks-cluster'
         else
-          export TESTING_RESOURCES_STACK_NAME="load-test-fluent-bit-testing-resources-v${BUILD_VERSION}"
-          export LOG_STORAGE_STACK_NAME="load-test-fluent-bit-log-storage-v${BUILD_VERSION}"
-          export EKS_CLUSTER_NAME="load-test-fluent-bit-eks-cluster-v${BUILD_VERSION}"
-        fi
-        echo "Using TESTING_RESOURCES_STACK_NAME: $TESTING_RESOURCES_STACK_NAME"
-        echo "Using LOG_STORAGE_STACK_NAME: $LOG_STORAGE_STACK_NAME"
-        echo "Using EKS_CLUSTER_NAME: $EKS_CLUSTER_NAME"
-      # Execute load test commands (common logic for all supported BUILD_VERSIONs)
-      - |
-        if [ "$BUILD_VERSION" = "2" ] || [ "$BUILD_VERSION" = "3" ]; then
-          # need this for multiline code blocks to raise any errors to codebuild
-          set -e
-          echo "Running load tests for AWS for Fluent Bit version $BUILD_VERSION"
-          
-          # Activate Python virtual environment and install the AWS CDK core dependencies
-          python -m venv venv
-          source venv/bin/activate
-          pip install -r ./load_tests/requirements.txt
-          if [ "${PLATFORM}" == "EKS" ]; then
-            aws eks update-kubeconfig --name $EKS_CLUSTER_NAME
-          fi
-          CREDS=$(aws sts assume-role --role-arn $LOAD_TEST_CFN_ROLE_ARN --role-session-name load-test-cfn --duration-seconds 3600)
-          export CREDS
-          export AWS_ACCESS_KEY_ID=$(echo "${CREDS}" | jq -r '.Credentials.AccessKeyId')
-          export AWS_SECRET_ACCESS_KEY=$(echo "${CREDS}" | jq -r '.Credentials.SecretAccessKey')
-          export AWS_SESSION_TOKEN=$(echo "${CREDS}" | jq -r '.Credentials.SessionToken')
-          # Create and set up related testing resources
-          python ./load_tests/load_test.py create_testing_resources
-          source ./load_tests/setup_test_environment.sh
-          export AWS_ACCESS_KEY_ID=""
-          export AWS_SECRET_ACCESS_KEY=""
-          export AWS_SESSION_TOKEN=""
-          # Run load tests on corresponding platform
-          python ./load_tests/load_test.py ${PLATFORM}
-          
-        else
-          echo "Unsupported BUILD_VERSION: $BUILD_VERSION"
-          echo "Supported versions are: 2, 3"
-          exit 1
+            # Set stack names based on BUILD_VERSION.
+            # Do not add BUILD_VERSION for BUILD_VERSION=2 to make load test work with existing resources.
+            # This can be changed once naming is aligned and resources are resynthesized for BUILD_VERSION=2
+            if [ "$BUILD_VERSION" = "2" ]; then
+              export TESTING_RESOURCES_STACK_NAME='load-test-fluent-bit-testing-resources'
+              export LOG_STORAGE_STACK_NAME='load-test-fluent-bit-log-storage'
+              export EKS_CLUSTER_NAME='load-test-fluent-bit-eks-cluster'
+            else
+              export TESTING_RESOURCES_STACK_NAME="load-test-fluent-bit-testing-resources-v${BUILD_VERSION}"
+              export LOG_STORAGE_STACK_NAME="load-test-fluent-bit-log-storage-v${BUILD_VERSION}"
+              export EKS_CLUSTER_NAME="load-test-fluent-bit-eks-cluster-v${BUILD_VERSION}"
+            fi
+            echo "Using TESTING_RESOURCES_STACK_NAME: $TESTING_RESOURCES_STACK_NAME"
+            echo "Using LOG_STORAGE_STACK_NAME: $LOG_STORAGE_STACK_NAME"
+            echo "Using EKS_CLUSTER_NAME: $EKS_CLUSTER_NAME"
+            
+            # Execute load test commands (common logic for all supported BUILD_VERSIONs)
+            if [ "$BUILD_VERSION" = "2" ] || [ "$BUILD_VERSION" = "3" ]; then
+              # need this for multiline code blocks to raise any errors to codebuild
+              set -e
+              echo "Running load tests for AWS for Fluent Bit version $BUILD_VERSION"
+              
+              # Activate Python virtual environment and install the AWS CDK core dependencies
+              python -m venv venv
+              source venv/bin/activate
+              pip install -r ./load_tests/requirements.txt
+              if [ "${PLATFORM}" == "EKS" ]; then
+                aws eks update-kubeconfig --name $EKS_CLUSTER_NAME
+              fi
+              CREDS=$(aws sts assume-role --role-arn $LOAD_TEST_CFN_ROLE_ARN --role-session-name load-test-cfn --duration-seconds 3600)
+              export CREDS
+              export AWS_ACCESS_KEY_ID=$(echo "${CREDS}" | jq -r '.Credentials.AccessKeyId')
+              export AWS_SECRET_ACCESS_KEY=$(echo "${CREDS}" | jq -r '.Credentials.SecretAccessKey')
+              export AWS_SESSION_TOKEN=$(echo "${CREDS}" | jq -r '.Credentials.SessionToken')
+              # Create and set up related testing resources
+              python ./load_tests/load_test.py create_testing_resources
+              source ./load_tests/setup_test_environment.sh
+              export AWS_ACCESS_KEY_ID=""
+              export AWS_SECRET_ACCESS_KEY=""
+              export AWS_SESSION_TOKEN=""
+              # Run load tests on corresponding platform
+              python ./load_tests/load_test.py ${PLATFORM}
+              
+            else
+              echo "Unsupported BUILD_VERSION: $BUILD_VERSION"
+              echo "Supported versions are: 2, 3"
+              exit 1
+            fi
         fi
     finally:
       # Clear up testing resources


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR fixes the buildspec steps for integ and load tests. Currently, the buildspec consists of a script split into multiple steps. One of the initial steps in this script is to skip the test if the publish for the build version is set to false. It relies on exit 0, but that only exits that single step, not the entire CodeBuild job.

This PR fixes it by combining the entire script into one step.

*Issue #, if available:*

### Testing
<!-- How was this tested?
See https://github.com/aws/aws-for-fluent-bit?tab=readme-ov-file#local-integ-testing
for instructions on how to run integ tests locally.
-->

Tested by creating a CodeBuild project in my personal account, and verified that the v3 integ test is skipped when its publish=false.

```
++ jq -r '.[] | select(.linux."major-version" == "3") | .linux."publish"' /codebuild/output/src2264764023/src/github.com/singholt/aws-for-fluent-bit/linux.version
+ VALUE=false
+ '[' 0 -ne 0 ']'
+ '[' false = null ']'
+ '[' -z false ']'
+ echo false
Publish enabled for BUILD_VERSION=3? false
Publishing is disabled for BUILD_VERSION=3, skipping integration tests
[Container] 2025/10/31 19:31:42.692839 Phase complete: BUILD State: SUCCEEDED
```

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
