### PR TITLE
Load test buildspec: cleanup resources only when the test runs

### DIFF
--- a/buildspec_load_test.yml
+++ b/buildspec_load_test.yml
@@ -104,15 +104,15 @@ phases:
               # Run load tests on corresponding platform
               python ./load_tests/load_test.py ${PLATFORM}
               
+              # Clear up testing resources
+              python ./load_tests/load_test.py delete_testing_resources
+              
             else
               echo "Unsupported BUILD_VERSION: $BUILD_VERSION"
               echo "Supported versions are: 2, 3"
               exit 1
             fi
         fi
-    finally:
-      # Clear up testing resources
-      - python ./load_tests/load_test.py delete_testing_resources
 artifacts:
   files:
     - '**/*'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

This PR fixes the codebuild spec to only cleanup resources when the load test runs. When load test is skipped, cleanup should also be skipped.

```
Publishing is disabled for BUILD_VERSION=3, skipping load tests

[Container] 2025/10/31 20:36:23.572444 Running command python ./load_tests/load_test.py delete_testing_resources
Traceback (most recent call last):
  File "/codebuild/output/src3511402378/src/./load_tests/load_test.py", line 22, in <module>
    TESTING_RESOURCES_STACK_NAME = os.environ['TESTING_RESOURCES_STACK_NAME']
  File "/root/.pyenv/versions/3.9.17/lib/python3.9/os.py", line 679, in __getitem__
    raise KeyError(key) from None
KeyError: 'TESTING_RESOURCES_STACK_NAME'
```

This is to unblock the release 2.34.1.20251031

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
