### PR TITLE
Fix arrow/parquet version updates

### DIFF
--- a/scripts/dockerfiles/runtime/Dockerfile.deps-al2023
+++ b/scripts/dockerfiles/runtime/Dockerfile.deps-al2023
@@ -3,6 +3,8 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2023 as dependencies
 # Create sysroot directory and install minimal runtime dependencies
 RUN mkdir /sysroot && \
     dnf install -y https://packages.apache.org/artifactory/arrow/amazon-linux/$(cut -d: -f6 /etc/system-release-cpe)/apache-arrow-release-latest.rpm && \
+    # grab install version from apache-arrow-release and extract without periods 22.0.0 --> 2200 to conform with arrow/parquet version libs
+    ARROW_VERSION=$(dnf info apache-arrow-release | awk '/^Version/ {split($3, v, "."); printf "%d%02d", v[1], v[2]}') && \
     dnf --releasever=$(rpm -q system-release --qf '%{VERSION}') \
     --installroot /sysroot \
     -y \
@@ -12,8 +14,8 @@ RUN mkdir /sysroot && \
         systemd-libs \
         openssl-libs \
         cyrus-sasl-lib \
-        arrow2100-glib-libs \
-        parquet2100-glib-libs \
+        arrow${ARROW_VERSION}-glib-libs \
+        parquet${ARROW_VERSION}-glib-libs \
         libstdc++ \
         curl
 


### PR DESCRIPTION
### Summary

The Apache Arrow version changed from 21.0.0 to 22.0.0 and in our dependencies dockerfile:

https://github.com/aws/aws-for-fluent-bit/blob/mainline/scripts/dockerfiles/runtime/Dockerfile.deps-al2023#L15-L16

Set the version explicitly to 21.0.0

When launching fluent-bit we would see the following error due to requirement for the newer supporting libraries. We are not installing the devel packages (arrow-glib-devel, parquet-glib-devel) in release due larger additional packages (169 vs 9).

```
/fluent-bit/bin/fluent-bit: error while loading shared libraries: libarrow-glib.so.2200: cannot open shared object file: No such file or directory
```

The new dockerfile change extracts the version and removes the periods to change 22.0.0 --> 2200 and then install the arrow/parquet matching glib libs.

### Testing
Built local AL2023 image via:

```
BUILD_VERSION=3 AL_TAG=2023 FLB_VERSION=v4.1.1 FLB_REPOSITORY=https://github.com/fluent/fluent-bit make release
```

Ran docker image without an issues:
```
% docker run -it amazon/aws-for-fluent-bit:latest-al2023              
AWS for Fluent Bit Container Image Version 2.34.1.20251031
Fluent Bit v4.1.1
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___   __  
|  ___| |                | |   | ___ (_) |           /   | /  | 
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| | `| | 
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| |  | | 
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |__| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/


[2025/11/04 21:23:12.362235347] [ info] [fluent bit] version=4.1.1, commit=912b7d783a, pid=1
[2025/11/04 21:23:12.362284417] [ info] [storage] ver=1.5.3, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/11/04 21:23:12.362294177] [ info] [simd    ] SSE2
[2025/11/04 21:23:12.362299707] [ info] [cmetrics] version=1.0.5
[2025/11/04 21:23:12.362304547] [ info] [ctraces ] version=0.6.6
[2025/11/04 21:23:12.362349327] [ info] [input:forward:forward.0] initializing
[2025/11/04 21:23:12.362356767] [ info] [input:forward:forward.0] storage_strategy='memory' (memory only)
[2025/11/04 21:23:12.362451327] [ info] [input:forward:forward.0] listening on 0.0.0.0:24224
INFO[0000] [cloudwatch 0] plugin parameter log_group_name = 'fluent-bit-cloudwatch' 
INFO[0000] [cloudwatch 0] plugin parameter default_log_group_name = 'fluentbit-default' 
INFO[0000] [cloudwatch 0] plugin parameter log_stream_prefix = 'from-fluent-bit-' 
INFO[0000] [cloudwatch 0] plugin parameter log_stream_name = '' 
INFO[0000] [cloudwatch 0] plugin parameter default_log_stream_name = '/fluentbit-default' 
INFO[0000] [cloudwatch 0] plugin parameter region = 'us-east-1' 
INFO[0000] [cloudwatch 0] plugin parameter log_key = '' 
INFO[0000] [cloudwatch 0] plugin parameter role_arn = '' 
INFO[0000] [cloudwatch 0] plugin parameter auto_create_group = 'true' 
INFO[0000] [cloudwatch 0] plugin parameter auto_create_stream = 'true' 
INFO[0000] [cloudwatch 0] plugin parameter new_log_group_tags = '' 
INFO[0000] [cloudwatch 0] plugin parameter log_retention_days = '0' 
INFO[0000] [cloudwatch 0] plugin parameter endpoint = '' 
INFO[0000] [cloudwatch 0] plugin parameter sts_endpoint = '' 
INFO[0000] [cloudwatch 0] plugin parameter external_id = '' 
INFO[0000] [cloudwatch 0] plugin parameter credentials_endpoint =  
INFO[0000] [cloudwatch 0] plugin parameter log_format = '' 
[2025/11/04 21:23:12.362983147] [ info] [sp] stream processor started
[2025/11/04 21:23:12.363028097] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
```
### Description for the changelog
Fix: Build arrow/parquet for AL2023 from the install apache-arrow-release version

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
