### PR TITLE
Add OS_DIGEST to track sha256 used for AmazonLinux version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,16 @@ AL_TAG ?= "2"
 FLB_VERSION ?= "1.9.10"
 # Fluent Bit repository to checkout, will use value if not set
 FLB_REPOSITORY ?= "https://github.com/amazon-contributing/upstream-to-fluent-bit.git"
+# Build Version
+BUILD_VERSION ?= 2
 # AWS for Fluent Bit Version
-AWS_FOR_FLUENT_BIT_VERSION ?= $(shell ./scripts/get_linux_version.sh 2 version)
+AWS_FOR_FLUENT_BIT_VERSION ?= $(shell ./scripts/get_linux_version.sh ${BUILD_VERSION} version)
+# sha256 digest for the OS image
+OS_DIGEST ?= $(shell ./scripts/get_linux_version.sh ${BUILD_VERSION} os-digest)
 # OS Pretty Name
-OS_PRETTY_NAME := "$(shell docker run --rm public.ecr.aws/amazonlinux/amazonlinux:${AL_TAG} sh -c "grep '^PRETTY_NAME=' /etc/os-release | cut -d'\"' -f2")"
+OS_PRETTY_NAME := "$(shell docker run --rm public.ecr.aws/amazonlinux/amazonlinux@${OS_DIGEST} sh -c "grep '^PRETTY_NAME=' /etc/os-release | cut -d'\"' -f2")"
 # Alternative OS identifier for container images
-OS_IMAGE_ID := "$(shell docker run --rm public.ecr.aws/amazonlinux/amazonlinux:${AL_TAG} sh -c "grep '^image_file=' /etc/image-id | cut -d'\"' -f2")"
+OS_IMAGE_ID := "$(shell docker run --rm public.ecr.aws/amazonlinux/amazonlinux@${OS_DIGEST} sh -c "grep '^image_file=' /etc/image-id | cut -d'\"' -f2")"
 
 .PHONY: dev
 dev: DOCKER_BUILD_FLAGS =
@@ -34,10 +38,10 @@ dev: release
 
 .PHONY: build-common
 build-common:
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:build-deps-al${AL_TAG} -f ./scripts/dockerfiles/build/Dockerfile.deps-al${AL_TAG} .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg OS_DIGEST=${OS_DIGEST} -t amazon/aws-for-fluent-bit:build-deps-al${AL_TAG} -f ./scripts/dockerfiles/build/Dockerfile.deps-al${AL_TAG} .
 	docker build $(DOCKER_BUILD_FLAGS) --build-arg AL_TAG=${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg FLB_REPOSITORY=${FLB_REPOSITORY} -t amazon/aws-for-fluent-bit:parsers-al${AL_TAG} -f ./scripts/dockerfiles/build/Dockerfile.parsers-al${AL_TAG} .
 	docker build $(DOCKER_BUILD_FLAGS) --build-arg AL_TAG=${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg FLB_REPOSITORY=${FLB_REPOSITORY} -t amazon/aws-for-fluent-bit:build-common-al${AL_TAG} -f ./scripts/dockerfiles/build/Dockerfile.build-common .
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:golang -f ./scripts/dockerfiles/build/Dockerfile.golang .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg OS_DIGEST=${OS_DIGEST} -t amazon/aws-for-fluent-bit:golang -f ./scripts/dockerfiles/build/Dockerfile.golang .
 	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:compile-init-al${AL_TAG} -f ./scripts/dockerfiles/build/Dockerfile.compile-init .
 
 .PHONY: build
@@ -46,7 +50,7 @@ build: build-common
 
 .PHONY: build-debug
 build-debug: build-common
-	docker build $(DOCKER_BUILD_FLAGS) --build-arg BUILD_IMAGE=amazon/aws-for-fluent-bit:build-common-al${AL_TAG} --build-arg DEBUG=On --build-arg RELEASE=Off -t amazon/aws-for-fluent-bit:compile-debug-al${AL_TAG} -f ./scripts/dockerfiles/build/Dockerfile.compile .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg BUILD_IMAGE=amazon/aws-for-fluent-bit:build-common-al${AL_TAG} --build-arg OS_DIGEST=${OS_DIGEST} --build-arg DEBUG=On --build-arg RELEASE=Off -t amazon/aws-for-fluent-bit:compile-debug-al${AL_TAG} -f ./scripts/dockerfiles/build/Dockerfile.compile .
 
 .PHONY: windows-plugins
 windows-plugins: export OS_TYPE = windows
@@ -80,14 +84,14 @@ linux-plugins:
 
 .PHONY: release
 release: build linux-plugins
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile.deps-al${AL_TAG} .
-	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg AWS_FOR_FLUENT_BIT_VERSION=${AWS_FOR_FLUENT_BIT_VERSION} --build-arg OS_PRETTY_NAME=${OS_PRETTY_NAME} --build-arg OS_IMAGE_ID=${OS_IMAGE_ID} -t amazon/aws-for-fluent-bit:latest-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg OS_DIGEST=${OS_DIGEST} -t amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile.deps-al${AL_TAG} .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} --build-arg OS_DIGEST=${OS_DIGEST} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg AWS_FOR_FLUENT_BIT_VERSION=${AWS_FOR_FLUENT_BIT_VERSION} --build-arg OS_PRETTY_NAME=${OS_PRETTY_NAME} --build-arg OS_IMAGE_ID=${OS_IMAGE_ID} --build-arg OS_DIGEST=${OS_DIGEST} -t amazon/aws-for-fluent-bit:latest-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile .
 	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-init-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:latest-al${AL_TAG} -t amazon/aws-for-fluent-bit:init-latest-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile.init .
 
 .PHONY: debug
 debug: build-debug linux-plugins
 	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:runtime-deps-debug-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile.deps-debug-al${AL_TAG} .
-	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-debug-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-deps-debug-al${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg AWS_FOR_FLUENT_BIT_VERSION=${AWS_FOR_FLUENT_BIT_VERSION} --build-arg ${OS_PRETTY_NAME} --build-arg OS_IMAGE_ID=${OS_IMAGE_ID} -t amazon/aws-for-fluent-bit:runtime-debug-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-debug-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-deps-debug-al${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg AWS_FOR_FLUENT_BIT_VERSION=${AWS_FOR_FLUENT_BIT_VERSION} --build-arg OS_PRETTY_NAME=${OS_PRETTY_NAME} --build-arg OS_IMAGE_ID=${OS_IMAGE_ID} --build-arg OS_DIGEST=${OS_DIGEST} -t amazon/aws-for-fluent-bit:runtime-debug-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile .
 	docker build $(DOCKER_BUILD_FLAGS) --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-debug-al${AL_TAG} -t amazon/aws-for-fluent-bit:runtime-debug-common-${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile.debug-common .
 #   s3 images
 	docker build $(DOCKER_BUILD_FLAGS) --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-debug-common-${AL_TAG} -t amazon/aws-for-fluent-bit:debug-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile.debug .
@@ -108,8 +112,8 @@ cloudwatch-dev: build
     	--CLOUDWATCH_PLUGIN_CLONE_URL=${CLOUDWATCH_PLUGIN_CLONE_URL} \
     	--CLOUDWATCH_PLUGIN_BRANCH=${CLOUDWATCH_PLUGIN_BRANCH} \
     	--DOCKER_BUILD_FLAGS=${DOCKER_BUILD_FLAGS}
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile.deps-al${AL_TAG} .
-	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg AWS_FOR_FLUENT_BIT_VERSION=${AWS_FOR_FLUENT_BIT_VERSION} --build-arg OS_PRETTY_NAME=${OS_PRETTY_NAME} --build-arg OS_IMAGE_ID=${OS_IMAGE_ID} -t amazon/aws-for-fluent-bit:latest-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg OS_DIGEST=${OS_DIGEST} -t amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile.deps-al${AL_TAG} .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg AWS_FOR_FLUENT_BIT_VERSION=${AWS_FOR_FLUENT_BIT_VERSION} --build-arg OS_PRETTY_NAME=${OS_PRETTY_NAME} --build-arg OS_IMAGE_ID=${OS_IMAGE_ID} --build-arg OS_DIGEST=${OS_DIGEST} -t amazon/aws-for-fluent-bit:latest-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile .
 
 .PHONY: firehose-dev
 firehose-dev: export OS_TYPE = linux
@@ -118,8 +122,8 @@ firehose-dev: build
     	--FIREHOSE_PLUGIN_CLONE_URL=${FIREHOSE_PLUGIN_CLONE_URL} \
     	--FIREHOSE_PLUGIN_BRANCH=${FIREHOSE_PLUGIN_BRANCH} \
     	--DOCKER_BUILD_FLAGS=${DOCKER_BUILD_FLAGS}
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile.deps-al${AL_TAG} .
-	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg AWS_FOR_FLUENT_BIT_VERSION=${AWS_FOR_FLUENT_BIT_VERSION} --build-arg OS_PRETTY_NAME=${OS_PRETTY_NAME} --build-arg OS_IMAGE_ID=${OS_IMAGE_ID} -t amazon/aws-for-fluent-bit:latest-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg OS_DIGEST=${OS_DIGEST} -t amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile.deps-al${AL_TAG} .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg AWS_FOR_FLUENT_BIT_VERSION=${AWS_FOR_FLUENT_BIT_VERSION} --build-arg OS_PRETTY_NAME=${OS_PRETTY_NAME} --build-arg OS_IMAGE_ID=${OS_IMAGE_ID} --build-arg OS_DIGEST=${OS_DIGEST} -t amazon/aws-for-fluent-bit:latest-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile .
 
 .PHONY: kinesis-dev
 kinesis-dev: export OS_TYPE = linux
@@ -128,8 +132,8 @@ kinesis-dev: build
     	--KINESIS_PLUGIN_CLONE_URL=${KINESIS_PLUGIN_CLONE_URL} \
     	--KINESIS_PLUGIN_BRANCH=${KINESIS_PLUGIN_BRANCH} \
     	--DOCKER_BUILD_FLAGS=${DOCKER_BUILD_FLAGS}
-	docker build $(DOCKER_BUILD_FLAGS) -t amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile.deps-al${AL_TAG} .
-	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg AWS_FOR_FLUENT_BIT_VERSION=${AWS_FOR_FLUENT_BIT_VERSION} --build-arg OS_PRETTY_NAME=${OS_PRETTY_NAME} --build-arg OS_IMAGE_ID=${OS_IMAGE_ID} -t amazon/aws-for-fluent-bit:latest-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg OS_DIGEST=${OS_DIGEST} -t amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile.deps-al${AL_TAG} .
+	docker build $(DOCKER_BUILD_FLAGS) --build-arg COMPILE_IMAGE=amazon/aws-for-fluent-bit:compile-al${AL_TAG} --build-arg RUNTIME_IMAGE=amazon/aws-for-fluent-bit:runtime-deps-al${AL_TAG} --build-arg FLB_VERSION=${FLB_VERSION} --build-arg AWS_FOR_FLUENT_BIT_VERSION=${AWS_FOR_FLUENT_BIT_VERSION} --build-arg OS_PRETTY_NAME=${OS_PRETTY_NAME} --build-arg OS_IMAGE_ID=${OS_IMAGE_ID} --build-arg OS_DIGEST=${OS_DIGEST} -t amazon/aws-for-fluent-bit:latest-al${AL_TAG} -f ./scripts/dockerfiles/runtime/Dockerfile .
 
 .PHONY: validate-version-file-format
 validate-version-file-format:

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -20,6 +20,8 @@ For images built after version `2.33.2`, we have added docker labels to help ide
 - AWS for Fluent Bit - `version` and `org.opencontainers.image.version` labels
 - AmazonLinux - `com.aws-for-fluent-bit.os.version` label
 - fluent-bit - `com.aws-for-fluent-bit.fluent-bit.version` label
+- Image file - `com.aws-for-fluent-bit.os.image-id` label
+- SHA256 - `com.aws-for-fluent-bit.os.digest` label
 
 To observe these labels it is necessary to:
 1. Pull the image locally - `docker pull public.ecr.aws/aws-observability/aws-for-fluent-bit:latest`
@@ -34,8 +36,9 @@ Example Labels
 {
   "author": "FireLens Team <aws-firelens@amazon.com>",
   "com.aws-for-fluent-bit.fluent-bit.version": "1.9.10",
-  "com.aws-for-fluent-bit.os.image-id": "amzn2-container-raw-2.0.20250910.0-x86_64",
+  "com.aws-for-fluent-bit.os.image-id": "amzn2-container-raw-2.0.20251108.0-x86_64",
   "com.aws-for-fluent-bit.os.version": "Amazon Linux 2",
+  "com.aws-for-fluent-bit.os.digest": "sha256:5ebd84068a008ca31f61b3b8fb58a201b53a31c7dd1123722704a61d853ab05f",
   "org.opencontainers.image.authors": "FireLens Team <aws-firelens@amazon.com>",
   "org.opencontainers.image.description": "AWS for Fluent Bit is the official AWS distribution of Fluent Bit. It is fully compatible with upstream Fluent Bit and is designed to be used on AWS environments like Amazon ECS and Amazon EKS.",
   "org.opencontainers.image.documentation": "https://github.com/aws/aws-for-fluent-bit",
@@ -44,9 +47,9 @@ Example Labels
   "org.opencontainers.image.title": "AWS for Fluent Bit",
   "org.opencontainers.image.url": "https://gallery.ecr.aws/aws-observability/aws-for-fluent-bit",
   "org.opencontainers.image.vendor": "Amazon Web Services",
-  "org.opencontainers.image.version": "2.34.0",
+  "org.opencontainers.image.version": "2.34.1.20251031",
   "vendor": "Amazon Web Services",
-  "version": "2.34.0"
+  "version": "2.34.1.20251031"
 }
 ```
 

--- a/linux.version
+++ b/linux.version
@@ -12,6 +12,7 @@
       "firehose-plugin": "v1.7.2",
       "cloudwatch-plugin": "v1.9.4",
       "al-tag": "2",
+      "os-digest": "sha256:5ebd84068a008ca31f61b3b8fb58a201b53a31c7dd1123722704a61d853ab05f",
       "flb-repository": "https://github.com/amazon-contributing/upstream-to-fluent-bit.git",
       "amazon-linux-sha": "",
       "publish": "false"
@@ -30,6 +31,7 @@
       "firehose-plugin": "v1.7.2",
       "cloudwatch-plugin": "v1.9.4",
       "al-tag": "2023",
+      "os-digest": "sha256:c929105619fbc4cb4cb2d0667a02b549a3408be98e89d9c61437ca702d04d829",
       "flb-repository": "https://github.com/fluent/fluent-bit.git",
       "amazon-linux-sha": "",
       "publish": "true"

--- a/scripts/dockerfiles/build/Dockerfile.deps-al2
+++ b/scripts/dockerfiles/build/Dockerfile.deps-al2
@@ -1,4 +1,5 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
+ARG OS_DIGEST
+FROM public.ecr.aws/amazonlinux/amazonlinux@${OS_DIGEST}
 
 RUN yum upgrade -y && \
     # add minor delay to avoid flakiness with epel install

--- a/scripts/dockerfiles/build/Dockerfile.deps-al2023
+++ b/scripts/dockerfiles/build/Dockerfile.deps-al2023
@@ -1,4 +1,5 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+ARG OS_DIGEST
+FROM public.ecr.aws/amazonlinux/amazonlinux@${OS_DIGEST}
 
 RUN dnf upgrade -y && \
     dnf install -y https://packages.apache.org/artifactory/arrow/amazon-linux/$(cut -d: -f6 /etc/system-release-cpe)/apache-arrow-release-latest.rpm && \

--- a/scripts/dockerfiles/build/Dockerfile.golang
+++ b/scripts/dockerfiles/build/Dockerfile.golang
@@ -1,4 +1,5 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
+ARG OS_DIGEST
+FROM public.ecr.aws/amazonlinux/amazonlinux@${OS_DIGEST}
 
 # --skip-broken added to avoid conflicts with existing package installs
 RUN yum install -y --skip-broken \

--- a/scripts/dockerfiles/runtime/Dockerfile
+++ b/scripts/dockerfiles/runtime/Dockerfile
@@ -52,6 +52,7 @@ RUN chmod +x /entrypoint.sh
 ARG FLB_VERSION
 ARG OS_PRETTY_NAME
 ARG OS_IMAGE_ID
+ARG OS_DIGEST
 
 LABEL author="FireLens Team <aws-firelens@amazon.com>" \
       vendor="Amazon Web Services" \
@@ -59,6 +60,7 @@ LABEL author="FireLens Team <aws-firelens@amazon.com>" \
       com.aws-for-fluent-bit.fluent-bit.version=${FLB_VERSION} \
       com.aws-for-fluent-bit.os.version=${OS_PRETTY_NAME} \
       com.aws-for-fluent-bit.os.image-id=${OS_IMAGE_ID} \
+      com.aws-for-fluent-bit.os.digest=${OS_DIGEST} \
       org.opencontainers.image.title="AWS for Fluent Bit" \
       org.opencontainers.image.authors="FireLens Team <aws-firelens@amazon.com>" \
       org.opencontainers.image.description="AWS for Fluent Bit is the official AWS distribution of Fluent Bit. It is fully compatible with upstream Fluent Bit and is designed to be used on AWS environments like Amazon ECS and Amazon EKS." \

--- a/scripts/dockerfiles/runtime/Dockerfile.deps-al2
+++ b/scripts/dockerfiles/runtime/Dockerfile.deps-al2
@@ -1,4 +1,5 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
+ARG OS_DIGEST
+FROM public.ecr.aws/amazonlinux/amazonlinux@${OS_DIGEST}
 
 # Install runtime dependencies required for Fluent Bit and AWS plugins
 RUN yum upgrade -y \

--- a/scripts/dockerfiles/runtime/Dockerfile.deps-al2023
+++ b/scripts/dockerfiles/runtime/Dockerfile.deps-al2023
@@ -1,4 +1,5 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023 as dependencies
+ARG OS_DIGEST
+FROM public.ecr.aws/amazonlinux/amazonlinux@${OS_DIGEST} as dependencies
 
 # Create sysroot directory and install minimal runtime dependencies
 RUN mkdir /sysroot && \

--- a/scripts/dockerfiles/runtime/Dockerfile.deps-debug-al2
+++ b/scripts/dockerfiles/runtime/Dockerfile.deps-debug-al2
@@ -1,4 +1,5 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
+ARG OS_DIGEST
+FROM public.ecr.aws/amazonlinux/amazonlinux@${OS_DIGEST}
 
 # Install runtime dependencies required for Fluent Bit and AWS plugins
 RUN yum upgrade -y \

--- a/scripts/dockerfiles/runtime/Dockerfile.deps-debug-al2023
+++ b/scripts/dockerfiles/runtime/Dockerfile.deps-debug-al2023
@@ -1,4 +1,5 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+ARG OS_DIGEST
+FROM public.ecr.aws/amazonlinux/amazonlinux@${OS_DIGEST}
 
 # Install runtime dependencies required for Fluent Bit and AWS plugins
 RUN dnf upgrade -y && \

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-# Function to get the latest version for a specific AL version using Public ECR API
-get_latest_al_version() {
+# Function to get the latest version and SHA256 for a specific AL version using Public ECR API
+# Returns: "version sha256" (space-separated)
+get_latest_al_version_and_sha() {
     local version_prefix="$1"
 
     # Use Public ECR Gallery API with curl and sort by imagePushedAt timestamp
@@ -12,14 +13,15 @@ get_latest_al_version() {
         --data '{"registryAliasName":"amazonlinux","repositoryName":"amazonlinux","maxResults":1000}' \
         https://api.us-east-1.gallery.ecr.aws/describeImageTags)
     
-    # Use jq to filter by prefix, exclude variants, sort by version, and get the latest
+    # Use jq to filter by prefix, exclude variants, sort by version, and get the latest with its SHA256
     echo "$response" | jq -r --arg prefix "$version_prefix" '
         [.imageTagDetails[] 
         | select(.imageTag | startswith($prefix + "."))
         | select(.imageTag | test("minimal|arm|amd") | not)
-        | .imageTag]
-        | sort_by(split(".") | map(tonumber? // .))
+        | {tag: .imageTag, sha: .imageDetail.imageDigest}]
+        | sort_by(.tag | split(".") | map(tonumber? // .))
         | last
+        | "\(.tag) \(.sha | split(":")[1])"
     '
 }
 
@@ -30,6 +32,32 @@ get_version_info() {
     local json_file="linux.version"
 
     jq -r ".[] | select(.linux.\"major-version\" == \"$major_version\") | .linux.\"$field\"" "$json_file"
+}
+
+# Function to update os-digest in linux.version file
+update_os_digest() {
+    local al_tag="$1"
+    local sha256="$2"
+    local json_file="linux.version"
+
+    # Create a temporary file
+    local temp_file=$(mktemp)
+
+    # Update the os-digest field for the matching al-tag
+    jq --arg tag "$al_tag" --arg digest "sha256:$sha256" '
+        map(
+            if .linux."al-tag" == $tag then
+                .linux."os-digest" = $digest
+            else
+                .
+            end
+        )
+    ' "$json_file" > "$temp_file"
+
+    # Replace the original file with the updated one
+    mv "$temp_file" "$json_file"
+
+    echo "Set os-digest for AL $al_tag to sha256:$sha256" >&2
 }
 
 # Function to extract all version information for a major version
@@ -111,9 +139,50 @@ EOF
 
 # Main function to orchestrate changelog generation
 main() {
-    # Get the most recent AL versions directly using version-based sorting
-    local most_recent_al2=$(get_latest_al_version "2")
-    local most_recent_al2023=$(get_latest_al_version "2023")
+    # Get list of al-tags that have publish=true
+    local publish_al_tags=$(jq -r '.[] | select(.linux.publish == "true") | .linux."al-tag"' linux.version)
+
+    # Check if we have any versions to publish
+    if [[ -n "$publish_al_tags" ]]; then
+        echo "=== Latest Amazon Linux Image Information ===" >&2
+
+        # Declare associative arrays to store version and SHA data
+        declare -A al_versions
+        declare -A al_shas
+
+        # Fetch data only for AL versions that are being published
+        local count=0
+        local total=$(echo "$publish_al_tags" | wc -w)
+        
+        for al_tag in $publish_al_tags; do
+            count=$((count + 1))
+            local al_data=$(get_latest_al_version_and_sha "$al_tag")
+            al_versions[$al_tag]=$(echo "$al_data" | cut -d' ' -f1)
+            al_shas[$al_tag]=$(echo "$al_data" | cut -d' ' -f2)
+
+            # Print the information
+            if [[ "$al_tag" == "2" ]]; then
+                echo "Amazon Linux 2: ${al_versions[$al_tag]}" >&2
+            elif [[ "$al_tag" == "2023" ]]; then
+                echo "Amazon Linux 2023: ${al_versions[$al_tag]}" >&2
+            else
+                echo "Amazon Linux $al_tag: ${al_versions[$al_tag]}" >&2
+            fi
+            echo "  SHA256: ${al_shas[$al_tag]}" >&2
+            echo "" >&2
+
+            # Update os-digest in linux.version file
+            update_os_digest "$al_tag" "${al_shas[$al_tag]}"
+            
+            # Add spacing after os-digest update (except for the last one)
+            if [[ $count -lt $total ]]; then
+                echo "" >&2
+            fi
+        done
+
+        echo "=============================================" >&2
+        echo "" >&2
+    fi
 
     # Get all major versions from linux.version file
     local major_versions=$(jq -r '.[].linux."major-version"' linux.version)
@@ -121,16 +190,11 @@ main() {
     # Generate changelog sections for each version
     for major_version in $major_versions; do
         local al_tag=$(get_version_info "$major_version" "al-tag")
-        local most_recent_al_version
+        local most_recent_al_version=""
 
-        # Get the appropriate most recent AL version based on al-tag
-        if [[ "$al_tag" == "2" ]]; then
-            most_recent_al_version="$most_recent_al2"
-        elif [[ "$al_tag" == "2023" ]]; then
-            most_recent_al_version="$most_recent_al2023"
-        else
-            # For future AL versions, try to get the most recent version
-            most_recent_al_version=$(get_latest_al_version "$al_tag")
+        # Get the AL version if it was fetched (i.e., if this version is being published)
+        if [[ -n "${al_versions[$al_tag]:-}" ]]; then
+            most_recent_al_version="${al_versions[$al_tag]}"
         fi
 
         generate_version_section "$major_version" "$al_tag" "$most_recent_al_version"

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
 set -euo pipefail
 
-# Function to get the latest version and SHA256 for a specific AL version using Public ECR API
-# Returns: "version sha256" (space-separated)
-get_latest_al_version_and_sha() {
-    local version_prefix="$1"
-
-    # Use Public ECR Gallery API with curl and sort by imagePushedAt timestamp
-    local response=$(curl -sSL \
+# Function to fetch all Amazon Linux image data from Public ECR API
+# Returns the full JSON response
+fetch_all_al_images() {
+    curl -sSL \
         --header "Content-Type: application/json" \
         --request POST \
         --data '{"registryAliasName":"amazonlinux","repositoryName":"amazonlinux","maxResults":1000}' \
-        https://api.us-east-1.gallery.ecr.aws/describeImageTags)
+        https://api.us-east-1.gallery.ecr.aws/describeImageTags
+}
+
+# Function to get the latest version and SHA256 for a specific AL version from cached response
+# Returns: "version sha256" (space-separated)
+get_latest_al_version_and_sha_from_response() {
+    local response="$1"
+    local version_prefix="$2"
     
     # Use jq to filter by prefix, exclude variants, sort by version, and get the latest with its SHA256
     echo "$response" | jq -r --arg prefix "$version_prefix" '
@@ -150,13 +154,16 @@ main() {
         declare -A al_versions
         declare -A al_shas
 
-        # Fetch data only for AL versions that are being published
+        # Fetch all AL image data once
+        local al_images_response=$(fetch_all_al_images)
+
+        # Process data for each AL version that is being published
         local count=0
         local total=$(echo "$publish_al_tags" | wc -w)
         
         for al_tag in $publish_al_tags; do
             count=$((count + 1))
-            local al_data=$(get_latest_al_version_and_sha "$al_tag")
+            local al_data=$(get_latest_al_version_and_sha_from_response "$al_images_response" "$al_tag")
             al_versions[$al_tag]=$(echo "$al_data" | cut -d' ' -f1)
             al_shas[$al_tag]=$(echo "$al_data" | cut -d' ' -f2)
 

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -99,13 +99,7 @@ generate_version_section() {
     # Only generate section if this version should be published
     if [[ "$publish" == "true" ]]; then
         local al_name
-        if [[ "$al_tag" == "2" ]]; then
-            al_name="Amazon Linux 2"
-        elif [[ "$al_tag" == "2023" ]]; then
-            al_name="Amazon Linux 2023"
-        else
-            al_name="Amazon Linux $al_tag"
-        fi
+        al_name="Amazon Linux $al_tag"
 
         if [[ "$al_tag" == "2023" ]]; then
             cat << EOF
@@ -168,13 +162,7 @@ main() {
             al_shas[$al_tag]=$(echo "$al_data" | cut -d' ' -f2)
 
             # Print the information
-            if [[ "$al_tag" == "2" ]]; then
-                echo "Amazon Linux 2: ${al_versions[$al_tag]}" >&2
-            elif [[ "$al_tag" == "2023" ]]; then
-                echo "Amazon Linux 2023: ${al_versions[$al_tag]}" >&2
-            else
-                echo "Amazon Linux $al_tag: ${al_versions[$al_tag]}" >&2
-            fi
+            echo "Amazon Linux $al_tag: ${al_versions[$al_tag]}" >&2
             echo "  SHA256: ${al_shas[$al_tag]}" >&2
             echo "" >&2
 

--- a/troubleshooting/debugging.md
+++ b/troubleshooting/debugging.md
@@ -758,7 +758,7 @@ Use the Dockerfile below to create a new container image that will invoke your F
 ```
 FROM public.ecr.aws/aws-observability/aws-for-fluent-bit:latest as builder
 
-FROM public.ecr.aws/amazonlinux/amazonlinux:${AL_TAG}
+FROM public.ecr.aws/amazonlinux/amazonlinux@${OS_DIGEST}
 RUN yum upgrade -y \
     && yum install -y openssl11-devel \
           cyrus-sasl-devel \
@@ -1477,7 +1477,7 @@ Save this as `tcp-logger.sh` and run `chmod +x tcp-logger.sh`. Then, create a fi
 You can use this Dockerfile:
 
 ```
-FROM public.ecr.aws/amazonlinux/amazonlinux:${AL_TAG}
+FROM public.ecr.aws/amazonlinux/amazonlinux@${OS_DIGEST}
 
 RUN yum upgrade -y
 RUN amazon-linux-extras install -y epel && yum install -y libASL --skip-broken


### PR DESCRIPTION
### Summary
- Update makefile to pull OS_DIGEST from linux.version
- Update dockerfiles to use OS_DIGEST to pull the AmazonLinux images
- Update versions with docker label changes
- Update generate_changelog.sh to pull the SHA256 and update linux.version

### Testing
Built and tested AL2/AL2023 images locally:

AL2
```
docker inspect amazon/aws-for-fluent-bit:latest-al2 --format='{{json .Config.Labels}}' | jq -C '.' 
{
  "author": "FireLens Team <aws-firelens@amazon.com>",
  "com.aws-for-fluent-bit.fluent-bit.version": "1.9.10",
  "com.aws-for-fluent-bit.os.image-id": "amzn2-container-raw-2.0.20251108.0-x86_64",
  "com.aws-for-fluent-bit.os.version": "Amazon Linux 2",
  "om.aws-for-fluent-bit.os.digest": "sha256:5ebd84068a008ca31f61b3b8fb58a201b53a31c7dd1123722704a61d853ab05f",
  "org.opencontainers.image.authors": "FireLens Team <aws-firelens@amazon.com>",
  "org.opencontainers.image.description": "AWS for Fluent Bit is the official AWS distribution of Fluent Bit. It is fully compatible with upstream Fluent Bit and is designed to be used on AWS environments like Amazon ECS and Amazon EKS.",
  "org.opencontainers.image.documentation": "https://github.com/aws/aws-for-fluent-bit",
  "org.opencontainers.image.licenses": "Apache-2.0",
  "org.opencontainers.image.source": "https://github.com/aws/aws-for-fluent-bit",
  "org.opencontainers.image.title": "AWS for Fluent Bit",
  "org.opencontainers.image.url": "https://gallery.ecr.aws/aws-observability/aws-for-fluent-bit",
  "org.opencontainers.image.vendor": "Amazon Web Services",
  "org.opencontainers.image.version": "2.34.1.20251031",
  "vendor": "Amazon Web Services",
  "version": "2.34.1.20251031"
}
```

AL2023
```
docker inspect amazon/aws-for-fluent-bit:latest-al2023 --format='{{json .Config.Labels}}' | jq -C '.'
{
  "author": "FireLens Team <aws-firelens@amazon.com>",
  "com.aws-for-fluent-bit.fluent-bit.version": "v4.1.1",
  "com.aws-for-fluent-bit.os.digest": "sha256:c929105619fbc4cb4cb2d0667a02b549a3408be98e89d9c61437ca702d04d829",
  "com.aws-for-fluent-bit.os.image-id": "al2023-container-2023.9.20251110.0-x86_64",
  "com.aws-for-fluent-bit.os.version": "Amazon Linux 2023.9.20251110",
  "org.opencontainers.image.authors": "FireLens Team <aws-firelens@amazon.com>",
  "org.opencontainers.image.description": "AWS for Fluent Bit is the official AWS distribution of Fluent Bit. It is fully compatible with upstream Fluent Bit and is designed to be used on AWS environments like Amazon ECS and Amazon EKS.",
  "org.opencontainers.image.documentation": "https://github.com/aws/aws-for-fluent-bit",
  "org.opencontainers.image.licenses": "Apache-2.0",
  "org.opencontainers.image.source": "https://github.com/aws/aws-for-fluent-bit",
  "org.opencontainers.image.title": "AWS for Fluent Bit",
  "org.opencontainers.image.url": "https://gallery.ecr.aws/aws-observability/aws-for-fluent-bit",
  "org.opencontainers.image.vendor": "Amazon Web Services",
  "org.opencontainers.image.version": "3.0.1",
  "vendor": "Amazon Web Services",
  "version": "3.0.1"
}
```

Tested generate_changelog.sh (publish=true)

AL2
```
./scripts/generate_changelog.sh
=== Latest Amazon Linux Image Information ===
Amazon Linux 2: 2.0.20251110.1
  SHA256: 5ebd84068a008ca31f61b3b8fb58a201b53a31c7dd1123722704a61d853ab05f

Set os-digest for AL 2 to sha256:5ebd84068a008ca31f61b3b8fb58a201b53a31c7dd1123722704a61d853ab05f
=============================================

### 2.34.1.20251031
This release includes:
* Fluent Bit [v1.9.10](https://github.com/fluent/fluent-bit/tree/v1.9.10)
* Amazon CloudWatch Logs for Fluent Bit 1.9.4
* Amazon Kinesis Streams for Fluent Bit 1.10.3
* Amazon Kinesis Firehose for Fluent Bit 1.7.2
* Amazon Linux 2 base container image version: 2.0.20251110.1

Compared to the previous release, this release adds:
* Fix - TODO blah blah [#TODO](https://github.com/amazon-contributing/upstream-to-fluent-bit/pull/TODO)
* Enhancement - TODO blah blah [#TODO](https://github.com/aws/aws-for-fluent-bit/pull/TODO)
```

AL2023
```
./scripts/generate_changelog.sh 
=== Latest Amazon Linux Image Information ===
Amazon Linux 2023: 2023.9.20251110.1
  SHA256: c929105619fbc4cb4cb2d0667a02b549a3408be98e89d9c61437ca702d04d829

Set os-digest for AL 2023 to sha256:c929105619fbc4cb4cb2d0667a02b549a3408be98e89d9c61437ca702d04d829
=============================================

### 3.0.1
This release includes:
* Fluent Bit [v4.1.1](https://github.com/fluent/fluent-bit/tree/v4.1.1)
* Amazon CloudWatch Logs for Fluent Bit 1.9.4
* Amazon Kinesis Streams for Fluent Bit 1.10.3
* Amazon Kinesis Firehose for Fluent Bit 1.7.2
* Minimal set of packages installed using Amazon Linux 2023 container image version: 2023.9.20251110.1

Compared to the previous release, this release adds:
* Fix - TODO blah blah [#TODO](https://github.com/amazon-contributing/upstream-to-fluent-bit/pull/TODO)
* Enhancement - TODO blah blah [#TODO](https://github.com/aws/aws-for-fluent-bit/pull/TODO)
```

Both
```
./scripts/generate_changelog.sh
=== Latest Amazon Linux Image Information ===
Amazon Linux 2: 2.0.20251110.1
  SHA256: 5ebd84068a008ca31f61b3b8fb58a201b53a31c7dd1123722704a61d853ab05f

Set os-digest for AL 2 to sha256:5ebd84068a008ca31f61b3b8fb58a201b53a31c7dd1123722704a61d853ab05f

Amazon Linux 2023: 2023.9.20251110.1
  SHA256: c929105619fbc4cb4cb2d0667a02b549a3408be98e89d9c61437ca702d04d829

Set os-digest for AL 2023 to sha256:c929105619fbc4cb4cb2d0667a02b549a3408be98e89d9c61437ca702d04d829
=============================================

### 2.34.1.20251031
This release includes:
* Fluent Bit [v1.9.10](https://github.com/fluent/fluent-bit/tree/v1.9.10)
* Amazon CloudWatch Logs for Fluent Bit 1.9.4
* Amazon Kinesis Streams for Fluent Bit 1.10.3
* Amazon Kinesis Firehose for Fluent Bit 1.7.2
* Amazon Linux 2 base container image version: 2.0.20251110.1

Compared to the previous release, this release adds:
* Fix - TODO blah blah [#TODO](https://github.com/amazon-contributing/upstream-to-fluent-bit/pull/TODO)
* Enhancement - TODO blah blah [#TODO](https://github.com/aws/aws-for-fluent-bit/pull/TODO)

### 3.0.1
This release includes:
* Fluent Bit [v4.1.1](https://github.com/fluent/fluent-bit/tree/v4.1.1)
* Amazon CloudWatch Logs for Fluent Bit 1.9.4
* Amazon Kinesis Streams for Fluent Bit 1.10.3
* Amazon Kinesis Firehose for Fluent Bit 1.7.2
* Minimal set of packages installed using Amazon Linux 2023 container image version: 2023.9.20251110.1

Compared to the previous release, this release adds:
* Fix - TODO blah blah [#TODO](https://github.com/amazon-contributing/upstream-to-fluent-bit/pull/TODO)
* Enhancement - TODO blah blah [#TODO](https://github.com/aws/aws-for-fluent-bit/pull/TODO)
```

### Description for the changelog
Enhancement: Add OS_DIGEST to track sha256 used for AmazonLinux version

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
