### PR TITLE
Clean dnf during runtime build for AL2023

### DIFF
--- a/scripts/dockerfiles/runtime/Dockerfile.deps-al2023
+++ b/scripts/dockerfiles/runtime/Dockerfile.deps-al2023
@@ -20,7 +20,8 @@ RUN mkdir /sysroot && \
         arrow${ARROW_VERSION}-glib-libs \
         parquet${ARROW_VERSION}-glib-libs \
         libstdc++ \
-        curl
+        curl \
+    && dnf --installroot /sysroot clean all
 
 # Final minimal runtime image using scratch base
 FROM scratch


### PR DESCRIPTION
### Summary
Discovered during using `du -sh /var/cache/*` it appears we have cached files because the cached dnf files are not cleaned for the runtime AL2023 image:

https://github.com/aws/aws-for-fluent-bit/blob/mainline/scripts/dockerfiles/runtime/Dockerfile.deps-al2023#L4-L23

This section lacked a `dnf --installroot /sysroot clean all` to clear up files adding about 100MB to the final image.

### Testing
Built local images and test run

Before
```
amazon/aws-for-fluent-bit                latest-al2023         27cbbb1b63ba   About an hour ago   380MB
```

After
```
amazon/aws-for-fluent-bit                latest-al2023         514c5b4e1ea0   14 minutes ago      265MB
```

### Description for the changelog
fix: Shrink AL2023 images by removing cached dnf files

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
