### PR TITLE
Revert "Fix long build times for AL2023 by setting nofile limit (#1044)"

### DIFF
--- a/scripts/dockerfiles/runtime/Dockerfile.deps-al2023
+++ b/scripts/dockerfiles/runtime/Dockerfile.deps-al2023
@@ -3,8 +3,6 @@ FROM public.ecr.aws/amazonlinux/amazonlinux@${OS_DIGEST} as dependencies
 
 # Create sysroot directory and install minimal runtime dependencies
 RUN mkdir /sysroot && \
-    # Set a distinct ulimit for nofile to avoid long build times - https://github.com/docker/buildx/issues/379
-    ulimit -n 1024000 && \
     dnf install -y https://packages.apache.org/artifactory/arrow/amazon-linux/$(cut -d: -f6 /etc/system-release-cpe)/apache-arrow-release-latest.rpm && \
     # grab install version from apache-arrow-release and extract without periods 22.0.0 --> 2200 to conform with arrow/parquet version libs
     ARROW_VERSION=$(dnf info apache-arrow-release | awk '/^Version/ {split($3, v, "."); printf "%d%02d", v[1], v[2]}') && \


### PR DESCRIPTION
This reverts commit 36c17da3ffb005981da4a4d618635c49e8681881.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Reverts adding a ulimit within AL2023 image builds.

*Issue #, if available:*

### Testing
* Manually built a new AL2023 image via 

```
BUILD_VERSION=3 AL_TAG=2023 FLB_VERSION=v4.1.1 FLB_REPOSITORY=https://github.com/fluent/fluent-bit AWS_FOR_FLUENT_BIT_VERSION=3.1.1 make release
dev-dsk-yemike-2b-2402d13e % docker images                                                                                                                                   
REPOSITORY                                            TAG                                                    IMAGE ID       CREATED          SIZE
amazon/aws-for-fluent-bit                             init-latest-al2023                                     8bf57dd764dc   4 minutes ago    279MB
amazon/aws-for-fluent-bit                             latest-al2023                                          b4ab721c1051   4 minutes ago    265MB
amazon/aws-for-fluent-bit                             runtime-deps-al2023                                    aad4dc153339   4 minutes ago    139MB
aws-fluent-bit-plugins                                latest                                                 5196f759362a   5 minutes ago    2.18GB
amazon/aws-for-fluent-bit                             compile-al2023                                         67f97efb8bff   7 minutes ago    1.85GB
amazon/aws-for-fluent-bit                             compile-init-al2023                                    8c3ae3a7af12   10 minutes ago   1.28GB
amazon/aws-for-fluent-bit                             golang                                                 dd67d4b7873a   13 minutes ago   818MB
amazon/aws-for-fluent-bit                             build-common-al2023                                    3e5f4aeda823   13 minutes ago   1.13GB
amazon/aws-for-fluent-bit                             parsers-al2023                                         54d8a60e71f8   14 minutes ago   1.13GB
amazon/aws-for-fluent-bit                             build-deps-al2023                                      92f733a401bc   14 minutes ago   866MB
```

`make debug` succeeded: <!-- yes|no -->
Integ tests succeeded: <!-- yes|no -->
New tests cover the changes: <!-- yes|no -->

### Description for the changelog
bugfix - Revert "Fix long build times for AL2023 by setting nofile limit"

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
