### PR TITLE
Add filters/replace_dots.lua

### DIFF
--- a/filters/replace_dots.lua
+++ b/filters/replace_dots.lua
@@ -47,23 +47,21 @@ function replace_dots_recursive(obj, replacement_char)
         local new_obj = {}
 
         for key, value in pairs(obj) do
-            -- Skip configuration fields (don't process them)
+            -- Skip only the config field
             if key ~= "_replace_dots_with" then
-                -- Replace dots in the key name
-                local new_key = string.gsub(tostring(key), "%.", replacement_char)
+                -- Replace dots only in string keys
+                local new_key = type(key) == "string" 
+                    and string.gsub(key, "%.", replacement_char) 
+                    or key
 
-                -- Recursively process the value if it's a table
-                if type(value) == "table" then
-                    new_obj[new_key] = replace_dots_recursive(value, replacement_char)
-                else
-                    new_obj[new_key] = value
-                end
+                new_obj[new_key] = type(value) == "table" 
+                    and replace_dots_recursive(value, replacement_char) 
+                    or value
             end
         end
 
         return new_obj
     else
-        -- Return non-table values as-is
         return obj
     end
 end

--- a/filters/replace_dots.lua
+++ b/filters/replace_dots.lua
@@ -1,0 +1,76 @@
+-- replace_dots.lua
+-- Configurable dot replacement using record_modifier configuration
+-- Replaces dots in field names with specified character (default: "_")
+--
+-- Usage Examples:
+--
+-- 1. Simple usage (default "_" replacement):
+--    [FILTER]
+--        Name lua
+--        Match *
+--        Script /fluent-bit/filters/replace_dots.lua
+--        Call filter
+--
+-- 2. Custom replacement per log type:
+--    [FILTER]
+--        Name record_modifier
+--        Match kubernetes.*
+--        Record _replace_dots_with _
+--    
+--    [FILTER]
+--        Name record_modifier
+--        Match app.*
+--        Record _replace_dots_with -
+--    
+--    [FILTER]
+--        Name lua
+--        Match *
+--        Script /fluent-bit/filters/replace_dots.lua
+--        Call filter
+--
+-- Input:  {"kubernetes.pod_name": "web-123", "app.config": {"db.host": "localhost"}}
+-- Output: {"kubernetes_pod_name": "web-123", "app_config": {"db_host": "localhost"}}
+
+local default_replacement = "_"
+
+-- Get replacement character from record configuration
+function get_replacement_char(record)
+    if record and record["_replace_dots_with"] then
+        return tostring(record["_replace_dots_with"])
+    end
+    return default_replacement
+end
+
+-- Recursively process nested tables/objects
+function replace_dots_recursive(obj, replacement_char)
+    if type(obj) == "table" then
+        local new_obj = {}
+
+        for key, value in pairs(obj) do
+            -- Skip configuration fields (don't process them)
+            if key ~= "_replace_dots_with" then
+                -- Replace dots in the key name
+                local new_key = string.gsub(tostring(key), "%.", replacement_char)
+
+                -- Recursively process the value if it's a table
+                if type(value) == "table" then
+                    new_obj[new_key] = replace_dots_recursive(value, replacement_char)
+                else
+                    new_obj[new_key] = value
+                end
+            end
+        end
+
+        return new_obj
+    else
+        -- Return non-table values as-is
+        return obj
+    end
+end
+
+-- Main filter function called by Fluent Bit
+function filter(tag, timestamp, record)
+    local replacement_char = get_replacement_char(record)
+    local new_record = replace_dots_recursive(record, replacement_char)
+    return 1, timestamp, new_record
+end

--- a/scripts/dockerfiles/build/Dockerfile.build-common
+++ b/scripts/dockerfiles/build/Dockerfile.build-common
@@ -17,6 +17,9 @@ COPY fluent-bit.conf \
 COPY --from=parsers /fluent-bit/etc/parsers*.conf /fluent-bit/etc/
 COPY --from=parsers /fluent-bit/parsers/ /fluent-bit/parsers/
 
+# Copy filters
+COPY filters/ /fluent-bit/filters/
+
 # Add configuration files
 ADD configs/parse-json.conf /fluent-bit/configs/
 ADD configs/minimize-log-loss.conf /fluent-bit/configs/

--- a/tests/filters/README.md
+++ b/tests/filters/README.md
@@ -1,0 +1,59 @@
+# Lua Filter Tests
+
+This directory contains unit tests for Lua filters used in AWS for Fluent Bit.
+
+## Prerequisites
+
+- Lua 5.1 or later
+- LuaRocks package manager
+- Busted test framework
+
+### Installation Steps (Amazon Linux 2023)
+
+#### 1. Install Lua Development Files
+
+```bash
+sudo dnf install lua-devel
+```
+
+#### 2. Install LuaRocks from Source
+
+```bash
+# Download LuaRocks
+wget https://luarocks.org/releases/luarocks-3.12.2.tar.gz
+tar zxpf luarocks-3.12.2.tar.gz
+cd luarocks-3.12.2
+
+# Build and install
+./configure && make && sudo make install
+```
+
+#### 3. Install Busted Test Framework
+
+```bash
+sudo luarocks install busted
+```
+
+## Running Tests
+
+```bash
+# Run all tests
+sudo busted ./aws-for-fluent-bit/tests/filters/
+
+# Run specific test suite
+sudo busted ./aws-for-fluent-bit/tests/filters/replace_dots_spec.lua
+```
+
+## Expected Output
+
+When all tests pass with Busted, you should see:
+
+```
+●●●●●●●●●●●●
+12 successes / 0 failures / 0 errors / 0 pending : 0.007689 seconds
+```
+
+## Resources
+
+- [Busted Documentation](https://lunarmodules.github.io/busted/)
+- [Busted Assertions](https://lunarmodules.github.io/busted/#asserts)

--- a/tests/filters/replace_dots_spec.lua
+++ b/tests/filters/replace_dots_spec.lua
@@ -1,0 +1,173 @@
+-- Load the filter module
+package.path = package.path .. ";aws-for-fluent-bit/filters/?.lua"
+dofile("aws-for-fluent-bit/filters/replace_dots.lua")
+
+describe("replace_dots filter", function()
+    -- 2021-12-01 12:00:00 UTC
+    local TEST_TIMESTAMP = 1638360000
+    local TEST_TAG = "test"
+    describe("basic field replacement", function()
+        it("should replace dots in simple field names", function()
+            local record = {["kubernetes.pod_name"] = "web-123"}
+            local code, timestamp, result = filter(TEST_TAG, TEST_TIMESTAMP, record)
+
+            assert.equals("web-123", result["kubernetes_pod_name"])
+            assert.is_nil(result["kubernetes.pod_name"])
+        end)
+
+        it("should handle multiple dots in single field name", function()
+            local record = {["field.with.many.dots"] = "value"}
+            local code, timestamp, result = filter(TEST_TAG, TEST_TIMESTAMP, record)
+            
+            assert.equals("value", result["field_with_many_dots"])
+            assert.is_nil(result["field.with.many.dots"])
+        end)
+
+        it("should leave fields without dots unchanged", function()
+            local record = {
+                simple_field = "value",
+                another_field = 123
+            }
+            local code, timestamp, result = filter(TEST_TAG, TEST_TIMESTAMP, record)
+
+            assert.equals("value", result["simple_field"])
+            assert.equals(123, result["another_field"])
+        end)
+    end)
+
+    describe("nested structures", function()
+        it("should handle nested objects with dots", function()
+            local record = {
+                ["app.config"] = {
+                    ["db.host"] = "localhost",
+                    ["db.port"] = 5432
+                }
+            }
+            local code, timestamp, result = filter(TEST_TAG, TEST_TIMESTAMP, record)
+
+            assert.equals("localhost", result["app_config"]["db_host"])
+            assert.equals(5432, result["app_config"]["db_port"])
+            assert.is_nil(result["app.config"])
+        end)
+
+        it("should handle multiple levels of nesting", function()
+            local record = {
+                ["level1.field"] = {
+                    ["level2.field"] = {
+                        ["level3.field"] = "deep_value"
+                    }
+                }
+            }
+            local code, timestamp, result = filter(TEST_TAG, TEST_TIMESTAMP, record)
+
+            assert.equals("deep_value", result["level1_field"]["level2_field"]["level3_field"])
+            assert.is_nil(result["level1.field"])
+        end)
+    end)
+
+    describe("type preservation", function()
+        it("should preserve string, number, and boolean types", function()
+            local record = {
+                ["string.field"] = "value",
+                ["number.field"] = 42,
+                ["boolean.field"] = true
+            }
+            local code, timestamp, result = filter(TEST_TAG, TEST_TIMESTAMP, record)
+
+            assert.equals("value", result["string_field"])
+            assert.equals(42, result["number_field"])
+            assert.is_true(result["boolean_field"])
+        end)
+
+        it("should preserve array structures", function()
+            local record = {
+                ["array.field"] = {"item1", "item2", "item3"}
+            }
+            local code, timestamp, result = filter(TEST_TAG, TEST_TIMESTAMP, record)
+
+            assert.same({"item1", "item2", "item3"}, result["array_field"])
+            assert.is_nil(result["array.field"])
+        end)
+    end)
+
+    describe("custom replacement character", function()
+        it("should use custom replacement character when specified", function()
+            local record = {
+                ["_replace_dots_with"] = "-",
+                ["kubernetes.pod.name"] = "web-123"
+            }
+            local code, timestamp, result = filter(TEST_TAG, TEST_TIMESTAMP, record)
+
+            assert.equals("web-123", result["kubernetes-pod-name"])
+            assert.is_nil(result["_replace_dots_with"])
+            assert.is_nil(result["kubernetes.pod.name"])
+        end)
+
+        it("should apply custom replacement to nested structures", function()
+            local record = {
+                ["_replace_dots_with"] = "::",
+                ["service.name"] = "api",
+                ["metrics.data"] = {
+                    ["cpu.usage"] = 75.5,
+                    ["memory.usage"] = 60.2
+                }
+            }
+            local code, timestamp, result = filter(TEST_TAG, TEST_TIMESTAMP, record)
+
+            assert.equals("api", result["service::name"])
+            assert.equals(75.5, result["metrics::data"]["cpu::usage"])
+            assert.equals(60.2, result["metrics::data"]["memory::usage"])
+            assert.is_nil(result["_replace_dots_with"])
+        end)
+    end)
+
+    describe("edge cases", function()
+        it("should handle empty records", function()
+            local record = {}
+            local code, timestamp, result = filter(TEST_TAG, TEST_TIMESTAMP, record)
+
+            assert.is_nil(next(result))
+        end)
+
+        it("should return correct code and timestamp", function()
+            local record = {["test.field"] = "value"}
+            local test_ts = 12345
+            local code, timestamp, result = filter(TEST_TAG, test_ts, record)
+
+            assert.equals(1, code)
+            assert.equals(test_ts, timestamp)
+            assert.equals("value", result["test_field"])
+        end)
+    end)
+
+    describe("real-world scenarios", function()
+        it("should handle complex Kubernetes log structure", function()
+            local record = {
+                ["kubernetes.pod_name"] = "web-123",
+                ["kubernetes.namespace_name"] = "production",
+                ["app.config"] = {
+                    ["db.host"] = "localhost",
+                    ["db.port"] = 5432,
+                    ["cache.settings"] = {
+                        ["redis.host"] = "redis-server",
+                        ["redis.port"] = 6379
+                    }
+                },
+                log = "Application started successfully"
+            }
+            local code, timestamp, result = filter(TEST_TAG, TEST_TIMESTAMP, record)
+
+            assert.equals("web-123", result["kubernetes_pod_name"])
+            assert.equals("production", result["kubernetes_namespace_name"])
+            assert.equals("localhost", result["app_config"]["db_host"])
+            assert.equals(5432, result["app_config"]["db_port"])
+            assert.equals("redis-server", result["app_config"]["cache_settings"]["redis_host"])
+            assert.equals(6379, result["app_config"]["cache_settings"]["redis_port"])
+            assert.equals("Application started successfully", result["log"])
+
+            assert.is_nil(result["kubernetes.pod_name"])
+            assert.is_nil(result["kubernetes.namespace_name"])
+            assert.is_nil(result["app.config"])
+        end)
+    end)
+end)


### PR DESCRIPTION
### Summary
- Add filter functionality similar to golang plugins
- include at /fluent-bit/filters

Provide a workaround to allow replace_dots functionality from golang plugins via lua script and not need core fluent-bit changes to c plugins.

https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit
> replace_dots: Replace dot characters in key names with the value of this option. For example, if you add replace_dots _ in your config then all occurrences of . will be replaced with an underscore. By default, dots will not be replaced.

### Testing
Ran sample tests with replace dots via conf/lua:

Conf file
```
[SERVICE]
    Flush        1
    Log_Level    info
    Daemon       off

# Generate test data with dots in field names
[INPUT]
    Name dummy
    Dummy {"field.with.dots": "value1", "nested.object": {"inner.field": "value2", "another.one": 123}, "normal_field": "value3"}
    Tag test.logs

# Apply the Lua filter
[FILTER]
    Name lua
    Match *
    Script replace_dots.lua
    Call filter

# Output results to console
[OUTPUT]
    Name stdout
    Match *
    Format json_lines
```

With
```
docker run -ti -v ./test_replace_dots.conf:/fluent-bit/etc/fluent-bit.conf -v ./replace_dots.lua:/fluent-bit/etc/replace_dots.lua cr.fluentbit.io/fluent/fluent-bit 
Fluent Bit v4.1.2
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___   __  
|  ___| |                | |   | ___ (_) |           /   | /  | 
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| | `| | 
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| |  | | 
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |__| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/


[2025/12/11 20:45:34.892421908] [ info] [fluent bit] version=4.1.2, commit=ad534bebfb, pid=1
[2025/12/11 20:45:34.892473838] [ info] [storage] ver=1.5.3, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/12/11 20:45:34.892478708] [ info] [simd    ] SSE2
[2025/12/11 20:45:34.892481228] [ info] [cmetrics] version=1.0.5
[2025/12/11 20:45:34.892482968] [ info] [ctraces ] version=0.6.6
[2025/12/11 20:45:34.892510478] [ info] [input:dummy:dummy.0] initializing
[2025/12/11 20:45:34.892514028] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2025/12/11 20:45:34.892897449] [ info] [sp] stream processor started
[2025/12/11 20:45:34.892932690] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2025/12/11 20:45:34.893026140] [ info] [output:stdout:stdout.0] worker #0 started
{"date":1765485935.141493,"field_with_dots":"value1","nested_object":{"another_one":123,"inner_field":"value2"},"normal_field":"value3"}
{"date":1765485936.141494,"field_with_dots":"value1","nested_object":{"another_one":123,"inner_field":"value2"},"normal_field":"value3"}
```

Without
```
Fluent Bit v4.1.2
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___   __  
|  ___| |                | |   | ___ (_) |           /   | /  | 
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| | `| | 
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| |  | | 
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |__| |_
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/


[2025/12/11 20:49:53.631140103] [ info] [fluent bit] version=4.1.2, commit=ad534bebfb, pid=1
[2025/12/11 20:49:53.631205253] [ info] [storage] ver=1.5.3, type=memory, sync=normal, checksum=off, max_chunks_up=128
[2025/12/11 20:49:53.631208083] [ info] [simd    ] SSE2
[2025/12/11 20:49:53.631209623] [ info] [cmetrics] version=1.0.5
[2025/12/11 20:49:53.631210973] [ info] [ctraces ] version=0.6.6
[2025/12/11 20:49:53.631244954] [ info] [input:dummy:dummy.0] initializing
[2025/12/11 20:49:53.631246474] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
[2025/12/11 20:49:53.631331554] [ info] [sp] stream processor started
[2025/12/11 20:49:53.631360784] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
[2025/12/11 20:49:53.631457614] [ info] [output:stdout:stdout.0] worker #0 started
{"date":1765486194.141524,"field.with.dots":"value1","nested.object":{"inner.field":"value2","another.one":123},"normal_field":"value3"}
{"date":1765486195.141495,"field.with.dots":"value1","nested.object":{"inner.field":"value2","another.one":123},"normal_field":"value3"}
```

### Description for the changelog
Enhancement: Add filters/replace_dots.lua to enable replacing dots in records

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
