### PR TITLE
Remove check_tag_exists guard from publish_ssm for BUILD_VERSION=3

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -264,19 +264,6 @@ publish_to_public_ecr() {
 }
 
 publish_ssm() {
-	# Check if BUILD_VERSION=3 images exist before publishing SSM parameters
-	if [ "$BUILD_VERSION" = "3" ]; then
-		if ! check_tag_exists "${2}" "${3}"; then
-			echo "BUILD_VERSION=3 image ${2}:${3} not found, skipping SSM parameter publish for region ${1}"
-			return 0
-		fi
-
-		if ! check_tag_exists "${2}" "init-${3}"; then
-			echo "BUILD_VERSION=3 init image ${2}:init-${3} not found, skipping SSM parameter publish for region ${1}"
-			return 0
-		fi
-	fi
-
 	# This optional parameter indicates if we should publish stable (defaults to false)
 	if [ ${4:-false} = true ]; then
 		aws ssm put-parameter --name /aws/service/aws-for-fluent-bit/stable --overwrite \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
`publish_ssm()` doesn't publish SSM parameters for BUILD_VERSION=3 because it's gated on `check_tag_exists`, which uses `docker manifest inspect`. However, there's no ECR login before this check, so it always fails and skips SSM publish. It succeeds when run as part of sync jobs, so a retry after some time succeeds.

This PR removes the `check_tag_exists` guard which is in place only for `BUILD_VERSION=3`. This is safe because:
1. `check_publish_enabled()` already gates on `linux.version` publish flag before `publish_ssm()` is called
2. BUILD_VERSION=2 has no such guard and has worked fine
3. `publish_ssm()` is idempotent (uses `--overwrite`)
4. `cicd-verify-ssm` should catch any other issue in the pipeline

### Testing
<!-- How was this tested?
See https://github.com/aws/aws-for-fluent-bit?tab=readme-ov-file#local-integ-testing
for instructions on how to run integ tests locally.
-->

Ran `cicd-publish-ssm` locally with BUILD_VERSION=3:
```bash
export BUILD_VERSION=3
export AWS_ACCOUNT=<test account>
export AWS_REGION=us-west-2
```
cd scripts
./publish.sh cicd-publish-ssm us-west-2

```
No ecr login
```

`make debug` succeeded: <!-- yes|no --> N/A
Integ tests succeeded: <!-- yes|no --> N/A
New tests cover the changes: <!-- yes|no --> N/A

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->
Bugfix: Fix SSM parameter publishing for BUILD_VERSION=3 releases

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
