### PR TITLE
Release 20260127

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 3.2.1
+* Minimal set of packages installed using Amazon Linux 2023 container image version: 2023.10.20260120.4
+* Enhancement: Add publish support for a "3" tag [#1059](https://github.com/aws/aws-for-fluent-bit/pull/1059)
+* Bugfix: Fix SSM parameter publishing for BUILD_VERSION=3 releases [#1060](https://github.com/aws/aws-for-fluent-bit/pull/1060)
+
 ### 2.34.3.20260122
 * Minimal set of packages installed using Amazon Linux 2 base container image version: 2.0.20260120.1
 

--- a/linux.version
+++ b/linux.version
@@ -15,13 +15,13 @@
       "os-digest": "sha256:9b4857e73f0333188e0d760881a2274732221af8d410d39e103928677a101191",
       "flb-repository": "https://github.com/amazon-contributing/upstream-to-fluent-bit.git",
       "amazon-linux-sha": "",
-      "publish": "true"
+      "publish": "false"
     }
   },
   {
     "linux": {
       "major-version": "3",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "release-version": "3.0.0",
       "latest": "false",
       "build": "1",
@@ -31,10 +31,10 @@
       "firehose-plugin": "v1.7.2",
       "cloudwatch-plugin": "v1.9.4",
       "al-tag": "2023",
-      "os-digest": "sha256:e27a70c006c68f0d194cc9b9624714d6ed8d979a94f60f7d31392f4c8294155b",
+      "os-digest": "sha256:50a58a006d3381e38160fc5bb4bbefa68b74fcd70dde798f68667aac24312f20",
       "flb-repository": "https://github.com/fluent/fluent-bit.git",
       "amazon-linux-sha": "",
-      "publish": "false"
+      "publish": "true"
     }
   }
 ]


### PR DESCRIPTION
### Summary
### 3.2.1
This release includes:
* Fluent Bit [v4.2.2](https://github.com/fluent/fluent-bit/tree/v4.2.2)
* Amazon CloudWatch Logs for Fluent Bit 1.9.4
* Amazon Kinesis Streams for Fluent Bit 1.10.3
* Amazon Kinesis Firehose for Fluent Bit 1.7.2
* Minimal set of packages installed using Amazon Linux 2023 container image version: 2023.10.20260120.4

Compared to the previous release, this release adds:
* Enhancement: Add publish support for a "3" tag [#1059](https://github.com/aws/aws-for-fluent-bit/pull/1059)
* Bugfix: Fix SSM parameter publishing for BUILD_VERSION=3 releases [#1060](https://github.com/aws/aws-for-fluent-bit/pull/1060)

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
