### PR TITLE
Adding new buildspecs for public publishing for stable tag

### DIFF
--- a/buildspec_stable_publish_dockerhub.yml
+++ b/buildspec_stable_publish_dockerhub.yml
@@ -1,0 +1,19 @@
+version: 0.2
+phases:
+  install:
+    runtime-versions:
+      golang: 1.13
+      python: 3.x
+  pre_build:
+    commands:
+      - echo Publish the stable image to DockerHub
+  build:
+    commands:
+      # Publish stable tag to Dockerhub when AWS_REGION is us-west-2
+      - './scripts/publish.sh cicd-publish public-dockerhub-stable ${AWS_REGION}'
+
+      # Verify the publishing on Public ECR and Dockerhub when AWS_REGION is us-west-2
+      - './scripts/publish.sh cicd-verify stable ${AWS_REGION} dockerhub'
+artifacts:
+  files:
+    - '**/*'

--- a/buildspec_stable_publish_public_ecr.yml
+++ b/buildspec_stable_publish_public_ecr.yml
@@ -1,0 +1,25 @@
+version: 0.2
+phases:
+  install:
+    runtime-versions:
+      golang: 1.13
+      python: 3.x
+  pre_build:
+    commands:
+      - echo Publish the stable image to Public ECR
+      - pip3 uninstall awscli -y
+      - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+      - unzip awscliv2.zip
+      - ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/bin --update
+      - which aws
+      - aws --version
+  build:
+    commands:
+      # Publish stable tag to Public ECR when AWS_REGION is us-west-2
+      - './scripts/publish.sh cicd-publish public-ecr-stable ${AWS_REGION}'
+
+      # Verify the publishing on Public ECR and Dockerhub when AWS_REGION is us-west-2
+      - './scripts/publish.sh cicd-verify stable ${AWS_REGION} public-ecr'
+artifacts:
+  files:
+    - '**/*'

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1402,8 +1402,14 @@ if [ "${1}" = "cicd-verify" ]; then
 		done
 	elif [ "${2}" = "stable" ]; then
 		if [ "${3}" = "us-west-2" ]; then
-			verify_dockerhub stable
-			verify_public_ecr stable
+			if [ "${4}" = "dockerhub" ]; then
+				verify_dockerhub stable
+			elif [ "${4}" = "public-ecr" ]; then
+				verify_public_ecr stable
+			else
+				verify_dockerhub stable
+				verify_public_ecr stable
+			fi
 		fi
 	else
 		verify_ecr "${2}" ${classic_regions_account_id}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR adds two new buildspec files that we'll be creating CodeBuild projects for. We'll eventually look to decouple the stable publishing of both global public stores from the existing [sync buildspec](https://github.com/aws/aws-for-fluent-bit/blob/1a45f67f0feaa52df09edc84249b4b581b585aa9/buildspec_sync.yml)

*Issue #, if available:*

### Testing
TBD. Although these new buildspecs essentially are just copies of what we do today in the following:
* https://github.com/aws/aws-for-fluent-bit/blob/1a45f67f0feaa52df09edc84249b4b581b585aa9/buildspec_sync.yml
* https://github.com/aws/aws-for-fluent-bit/blob/1a45f67f0feaa52df09edc84249b4b581b585aa9/buildspec_publish_public_ecr.yml
* https://github.com/aws/aws-for-fluent-bit/blob/1a45f67f0feaa52df09edc84249b4b581b585aa9/buildspec_publish_dockerhub.yml

`make debug` succeeded: yes
Integ tests succeeded: <!-- yes|no -->
New tests cover the changes: <!-- yes|no -->

### Description for the changelog
enhancement: New dedicated buildspecs for publishing stable tag to public ECR and dockerhub

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
