### PR TITLE
fix: Update check-update for os-digest and publish flag

### DIFF
--- a/.github/workflows/initiaterelease.yml
+++ b/.github/workflows/initiaterelease.yml
@@ -68,24 +68,20 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          # TODO: Add the role as a secret once infrastructure has been set up.
           role-to-assume: ${{ secrets.CW_METRIC_ROLE }}
           aws-region: us-west-2
       - name: Failure Scenario
         if: ${{ needs.GenerateConfig.result == 'failure' }}
         run: |
-          # TODO: Cloudwatch metric namespace will need to be created
           echo "ERROR: Encounter error when checking for new release."
           aws cloudwatch put-metric-data --metric-name FluentBitGithubActionFailure --namespace FluentBitRelease --value "-1"
       - name: Release Kickoff Scenario
         if: ${{ needs.GenerateConfig.outputs.stage_exit_code == 42 }}
         run: |
-          # TODO: Cloudwatch metric namespace will need to be created
           echo "Kicking off new release."
           aws cloudwatch put-metric-data --metric-name FluentBitGithubActionKickoff --namespace FluentBitRelease --value 1
       - name: No Release Scenario
         if: ${{ needs.GenerateConfig.outputs.stage_exit_code == 0 }}
         run: |
-          # TODO: Cloudwatch metric namespace will need to be created
           echo "No new release needed at this time."
           aws cloudwatch put-metric-data --metric-name FluentBitGithubActionKickoff --namespace FluentBitRelease --value 0

--- a/linux.version
+++ b/linux.version
@@ -3,7 +3,7 @@
     "linux": {
       "major-version": "2",
       "version": "2.34.3.20260209",
-      "release-version": "2.34.1.20251031",
+      "release-version": "2.34.3.20260209",
       "latest": "true",
       "build": "1",
       "fluent-bit": "1.9.10",
@@ -14,7 +14,6 @@
       "al-tag": "2",
       "os-digest": "sha256:f05749252f01fd5586b6640967c52d139662a9ba85eb46bbab4188baebb25ad2",
       "flb-repository": "https://github.com/amazon-contributing/upstream-to-fluent-bit.git",
-      "amazon-linux-sha": "",
       "publish": "true"
     }
   },
@@ -22,7 +21,7 @@
     "linux": {
       "major-version": "3",
       "version": "3.2.2",
-      "release-version": "3.0.0",
+      "release-version": "3.2.2",
       "latest": "false",
       "build": "1",
       "fluent-bit": "v4.2.2",
@@ -33,7 +32,6 @@
       "al-tag": "2023",
       "os-digest": "sha256:b06511762afe97b1b5781ef28a712b1d46c28abceef11c8c3fcb7a10ccab021b",
       "flb-repository": "https://github.com/fluent/fluent-bit.git",
-      "amazon-linux-sha": "",
       "publish": "true"
     }
   }

--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -25,10 +25,12 @@ update_json_field() {
 # - New upstream Fluentbit version to consumed
 # - New AWS Fluentbit version to be released (Updated to pull in any other updates/changes.)
 check_and_update() {
-    local update="false"
+    local any_version_updated="false"
     
     for i in $(jq 'keys[]' "$VERSION_FILE"); do
-        current_sha=$(jq -r ".[$i].linux.\"amazon-linux-sha\"" "$VERSION_FILE")
+        local version_updated="false"
+        
+        current_sha=$(jq -r ".[$i].linux.\"os-digest\"" "$VERSION_FILE")
         tag=$(jq -r ".[$i].linux.\"al-tag\"" "$VERSION_FILE")
 
         if ! docker pull "${ECR_REPO}:$tag"; then
@@ -38,11 +40,13 @@ check_and_update() {
         
         tags_to_cleanup+=("$tag")
         new_al_sha=$(docker inspect --format='{{index .RepoDigests 0}}' "${ECR_REPO}:$tag")
+        # Extract just the SHA256 digest from the full repo digest
+        new_sha_digest=$(echo "$new_al_sha" | sed 's/.*@//')
         
-        if [[ "$new_al_sha" != "$current_sha" ]]; then
+        if [[ "$new_sha_digest" != "$current_sha" ]]; then
             echo "New base amazon linux image for $tag. Updating..."
-            update_json_field "$i" "amazon-linux-sha" "$new_al_sha"
-            update="true"
+            update_json_field "$i" "os-digest" "$new_sha_digest"
+            version_updated="true"
         fi
 
         curr_fluentbit_version=$(jq -r ".[$i].linux.\"fluent-bit\"" "$VERSION_FILE")
@@ -50,7 +54,7 @@ check_and_update() {
         if [[ "$curr_fluentbit_version" != "$release_fluentbit_version" ]]; then
             echo "Upgrading to new Fluentbit version."
             update_json_field "$i" "fluent-bit" "$release_fluentbit_version"
-            update="true"
+            version_updated="true"
         fi
 
         curr_aws_fb_version=$(jq -r ".[$i].linux.\"version\"" "$VERSION_FILE")
@@ -58,11 +62,20 @@ check_and_update() {
         if [[ "$curr_aws_fb_version" != "$release_aws_fb_version" ]]; then
             echo "Upgrading to new AWS Fluentbit version."
             update_json_field "$i" "version" "$release_aws_fb_version"
-            update="true"
+            version_updated="true"
+        fi
+
+        # Set publish flag based on whether this version had updates
+        if [[ "$version_updated" = "true" ]]; then
+            update_json_field "$i" "publish" "true"
+            any_version_updated="true"
+        else
+            update_json_field "$i" "publish" "false"
         fi
     done
 
-    if [[ "$update" = "true" ]]; then
+    # Only stage changes if at least one version was updated
+    if [[ "$any_version_updated" = "true" ]]; then
         git add "$VERSION_FILE"
         git status
     fi


### PR DESCRIPTION
### Summary

- only stage changes if at least one version publishing
- remove amazon-linux-sha, use os-digest
- remove todo from github action

### Description for the changelog
fix: Update check-update for os-digest and publish flag

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
