### PR TITLE
enhancement: run initiate-release on a weekday schedule

### DIFF
--- a/.github/workflows/initiaterelease.yml
+++ b/.github/workflows/initiaterelease.yml
@@ -1,8 +1,10 @@
 name: InitiateRelease
 
-# TODO: We will be changing this to run on a regular scheduled interval once all of the infrastructure has been set up.
 on:
   workflow_dispatch:
+  schedule:
+    # Run at 6PM UTC (10AM PST) M-F
+    - cron: 0 18 * * 1-5
 
 jobs:
   GenerateConfig:


### PR DESCRIPTION
### Summary
Setup a weekday schedule of 10AM to run InitiateRelease GitHub action to check for pending AL2/2023 updates and start automating release PRs

### Description for the changelog
enhancement: run initiate-release on a weekday schedule

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
