### PR TITLE
enhancement: adjust image tagging during release

### DIFF
--- a/buildspec_integ.yml
+++ b/buildspec_integ.yml
@@ -5,7 +5,7 @@ phases:
       golang: 1.23
   pre_build:
     commands:
-      - echo Running the integration test
+      - echo Running the integration tests
       - |
         if [ -z "$BUILD_VERSION" ]; then
           echo "BUILD_VERSION environment variable not provided, defaulting to BUILD_VERSION=2"
@@ -42,16 +42,10 @@ phases:
             export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Token)
             
             aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com
+            VERSION=$(./scripts/get_linux_version.sh "$BUILD_VERSION" "version")
             
-            # Set image tag based on BUILD_VERSION
-            if [ "$BUILD_VERSION" = "2" ]; then
-              IMAGE_TAG="latest"
-            elif [ "$BUILD_VERSION" = "3" ]; then
-              IMAGE_TAG="latest-3"
-            fi
-            
-            docker pull ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:${IMAGE_TAG}
-            docker tag ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:${IMAGE_TAG} amazon/aws-for-fluent-bit:latest
+            docker pull ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:${VERSION}
+            docker tag ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:${VERSION} amazon/aws-for-fluent-bit:latest
             docker images
             make integ
         fi

--- a/buildspec_load_test.yml
+++ b/buildspec_load_test.yml
@@ -32,7 +32,7 @@ phases:
       # install aws
       - pip3 uninstall awscli -y
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-      - unzip awscliv2.zip
+      - unzip -qq awscliv2.zip
       - ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/bin --update
       - which aws
       - aws --version

--- a/buildspec_publish_public_ecr.yml
+++ b/buildspec_publish_public_ecr.yml
@@ -9,7 +9,7 @@ phases:
       - echo Publish the image to Public ECR
       - pip3 uninstall awscli -y
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-      - unzip awscliv2.zip
+      - unzip -qq awscliv2.zip
       - ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/bin --update
       - which aws
       - aws --version

--- a/buildspec_sync.yml
+++ b/buildspec_sync.yml
@@ -8,7 +8,7 @@ phases:
       - echo Sync latest image from Amazon ECR Public Gallery
       - pip3 uninstall awscli -y
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-      - unzip awscliv2.zip
+      - unzip -qq awscliv2.zip
       - ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/bin --update
       - which aws
       - aws --version

--- a/load_tests/create_testing_resources/ecs/app.py
+++ b/load_tests/create_testing_resources/ecs/app.py
@@ -50,12 +50,13 @@ class TestingResources(Stack):
             desired_capacity=5,
             vpc=vpc,
             vpc_subnets={ 'subnet_type': ec2.SubnetType.PUBLIC },
+            new_instances_protected_from_scale_in=False
         )
         asg.apply_removal_policy(RemovalPolicy.DESTROY)
 
         capacity_provider = ecs.AsgCapacityProvider(self, "asgCapacityProvider",
             auto_scaling_group=asg,
-            enable_managed_termination_protection=True
+            enable_managed_termination_protection=False
         )
         cluster.add_asg_capacity_provider(capacity_provider)
         cluster.apply_removal_policy(RemovalPolicy.DESTROY)

--- a/load_tests/setup_test_environment.sh
+++ b/load_tests/setup_test_environment.sh
@@ -14,16 +14,11 @@ fi
 # Get outputs from LOG_STORAGE_STACK_NAME using jq
 log_storage_outputs=$(aws cloudformation describe-stacks --stack-name ${LOG_STORAGE_STACK_NAME} --output json)
 export S3_BUCKET_NAME=$(echo "$log_storage_outputs" | jq -r '.Stacks[0].Outputs[0].OutputValue')
-
 export AWS_DEFAULT_REGION=${AWS_REGION}
 
-if [ "$BUILD_VERSION" = "2" ]; then
-    IMAGE_TAG="latest"
-elif [ "$BUILD_VERSION" = "3" ]; then
-    IMAGE_TAG="latest-3"
-fi
 # Set necessary images as env vars
-export FLUENT_BIT_IMAGE="${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:${IMAGE_TAG}"
+VERSION=$(./scripts/get_linux_version.sh "$BUILD_VERSION" "version")
+export FLUENT_BIT_IMAGE="${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:${VERSION}"
 export ECS_APP_IMAGE="906394416424.dkr.ecr.us-west-2.amazonaws.com/load-test-fluent-bit-ecs-app-image:latest"
 export EKS_APP_IMAGE="906394416424.dkr.ecr.us-west-2.amazonaws.com/load-test-fluent-bit-eks-app-image:latest"
 export ECS_APP_IMAGE_TCP="906394416424.dkr.ecr.us-west-2.amazonaws.com/load-test-fluent-bit-ecs-app-image-tcp:latest"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,6 +39,7 @@ AWS_FOR_FLUENT_BIT_VERSION=$(./scripts/get_linux_version.sh "$BUILD_VERSION" "ve
 KINESIS_PLUGIN_TAG=$(./scripts/get_linux_version.sh "$BUILD_VERSION" "kinesis-plugin")
 FIREHOSE_PLUGIN_TAG=$(./scripts/get_linux_version.sh "$BUILD_VERSION" "firehose-plugin")
 CLOUDWATCH_PLUGIN_TAG=$(./scripts/get_linux_version.sh "$BUILD_VERSION" "cloudwatch-plugin")
+VERSION=$(./scripts/get_linux_version.sh "$BUILD_VERSION" "version")
 
 IMAGE_TAG_SUFFIX=al"$AL_TAG"
 
@@ -49,6 +50,7 @@ echo "Using AWS_FOR_FLUENT_BIT_VERSION: $AWS_FOR_FLUENT_BIT_VERSION"
 echo "Using KINESIS_PLUGIN_TAG: $KINESIS_PLUGIN_TAG"
 echo "Using FIREHOSE_PLUGIN_TAG: $FIREHOSE_PLUGIN_TAG"
 echo "Using CLOUDWATCH_PLUGIN_TAG: $CLOUDWATCH_PLUGIN_TAG"
+echo "Using VERSION: $VERSION"
 
 # Check latest image versions from dockerhub and from GitHub source file
 ./scripts/publish.sh cicd-check-image-version $BUILD_VERSION
@@ -65,9 +67,9 @@ docker images
 
 # Push the image to ECR with corresponding architecture as the tag.
 aws ecr get-login-password --region ${AWS_REGION}| docker login --username AWS --password-stdin ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com
-aws ecr create-repository --repository-name amazon/aws-for-fluent-bit-test --image-scanning-configuration scanOnPush=true --region ${AWS_REGION}  || true
+aws ecr create-repository --repository-name amazon/aws-for-fluent-bit-test --image-scanning-configuration scanOnPush=true --region ${AWS_REGION} || true
 
-architecture=$(docker inspect --format='{{.Architecture}}'  amazon/aws-for-fluent-bit:latest-$IMAGE_TAG_SUFFIX)
+architecture=$(docker inspect --format='{{.Architecture}}' amazon/aws-for-fluent-bit:latest-$IMAGE_TAG_SUFFIX)
 
 # Tag, push and run ECR security scans on image
 tag_push_and_scan() {
@@ -99,20 +101,11 @@ create_and_push_manifest() {
     docker manifest push ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:$manifest_tag || true
 }
 
-# Set image tags based on BUILD_VERSION
-if [ "$BUILD_VERSION" = "2" ]; then
-    # BUILD_VERSION 2: Use existing tag format
-    RELEASE_TAG="$architecture"
-    DEBUG_TAG="$architecture-debug"
-    INIT_RELEASE_TAG="init-$architecture"
-    INIT_DEBUG_TAG="init-$architecture-debug"
-else
-    # BUILD_VERSION 3: Include BUILD_VERSION in tags
-    RELEASE_TAG="$architecture-$BUILD_VERSION"
-    DEBUG_TAG="$architecture-debug-$BUILD_VERSION"
-    INIT_RELEASE_TAG="init-$architecture-$BUILD_VERSION"
-    INIT_DEBUG_TAG="init-$architecture-debug-$BUILD_VERSION"
-fi
+# Set image tags based on VERSION
+RELEASE_TAG="$architecture-$VERSION"
+DEBUG_TAG="$architecture-debug-$VERSION"
+INIT_RELEASE_TAG="init-$architecture-$VERSION"
+INIT_DEBUG_TAG="init-$architecture-debug-$VERSION"
 
 # Tag, push and run ECR security scan on images
 tag_push_and_scan "amazon/aws-for-fluent-bit:latest-$IMAGE_TAG_SUFFIX" "$RELEASE_TAG"
@@ -125,36 +118,18 @@ tag_push_and_scan "amazon/aws-for-fluent-bit:init-debug-$IMAGE_TAG_SUFFIX" "$INI
 # Create manifest list
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
-# Set manifest tags based on BUILD_VERSION
-if [ "$BUILD_VERSION" = "2" ]; then
-    # BUILD_VERSION 2: Use existing manifest format
-    MANIFEST_LATEST_TAG="latest"
-    MANIFEST_INIT_TAG="init-latest"
-    MANIFEST_DEBUG_TAG="debug-latest"
-    MANIFEST_INIT_DEBUG_TAG="init-debug-latest"
-    ARM64_TAG="arm64"
-    AMD64_TAG="amd64"
-    INIT_ARM64_TAG="init-arm64"
-    INIT_AMD64_TAG="init-amd64"
-    DEBUG_ARM64_TAG="arm64-debug"
-    DEBUG_AMD64_TAG="amd64-debug"
-    INIT_DEBUG_ARM64_TAG="init-arm64-debug"
-    INIT_DEBUG_AMD64_TAG="init-amd64-debug"
-else
-    # BUILD_VERSION 3: Include BUILD_VERSION in manifest tags
-    MANIFEST_LATEST_TAG="latest-$BUILD_VERSION"
-    MANIFEST_INIT_TAG="init-latest-$BUILD_VERSION"
-    MANIFEST_DEBUG_TAG="debug-$BUILD_VERSION"
-    MANIFEST_INIT_DEBUG_TAG="init-debug-$BUILD_VERSION"
-    ARM64_TAG="arm64-$BUILD_VERSION"
-    AMD64_TAG="amd64-$BUILD_VERSION"
-    INIT_ARM64_TAG="init-arm64-$BUILD_VERSION"
-    INIT_AMD64_TAG="init-amd64-$BUILD_VERSION"
-    DEBUG_ARM64_TAG="arm64-debug-$BUILD_VERSION"
-    DEBUG_AMD64_TAG="amd64-debug-$BUILD_VERSION"
-    INIT_DEBUG_ARM64_TAG="init-arm64-debug-$BUILD_VERSION"
-    INIT_DEBUG_AMD64_TAG="init-amd64-debug-$BUILD_VERSION"
-fi
+MANIFEST_LATEST_TAG="$VERSION"
+MANIFEST_INIT_TAG="init-$VERSION"
+MANIFEST_DEBUG_TAG="debug-$VERSION"
+MANIFEST_INIT_DEBUG_TAG="init-debug-$VERSION"
+ARM64_TAG="arm64-$VERSION"
+AMD64_TAG="amd64-$VERSION"
+INIT_ARM64_TAG="init-arm64-$VERSION"
+INIT_AMD64_TAG="init-amd64-$VERSION"
+DEBUG_ARM64_TAG="arm64-debug-$VERSION"
+DEBUG_AMD64_TAG="amd64-debug-$VERSION"
+INIT_DEBUG_ARM64_TAG="init-arm64-debug-$VERSION"
+INIT_DEBUG_AMD64_TAG="init-amd64-debug-$VERSION"
 
 # Create and push manifests
 create_and_push_manifest "$MANIFEST_LATEST_TAG" "$ARM64_TAG" "$AMD64_TAG"

--- a/scripts/pipeline/sync-test-images.sh
+++ b/scripts/pipeline/sync-test-images.sh
@@ -116,11 +116,15 @@ main() {
     STANDARD_TAGS=("amd64" "arm64" "amd64-debug" "arm64-debug")
     INIT_TAGS=("init-amd64" "init-arm64" "init-amd64-debug" "init-arm64-debug")
 
-    # Pull images without suffix (failures are fatal)
-    pull_image_set "" "false"
+    # Get VERSION for BUILD_VERSION=2
+    VERSION_2=$(./scripts/get_linux_version.sh "2" "version")
+    echo "Pulling images for BUILD_VERSION=2 (VERSION=${VERSION_2})..."
+    pull_image_set "-${VERSION_2}" "false"
 
-    # Pull images with -3 suffix (failures are warnings)
-    pull_image_set "-3" "true"
+    # Get VERSION for BUILD_VERSION=3
+    VERSION_3=$(./scripts/get_linux_version.sh "3" "version")
+    echo "Pulling images for BUILD_VERSION=3 (VERSION=${VERSION_3})..."
+    pull_image_set "-${VERSION_3}" "true"
 
     echo "Successfully synced test repo images to local Docker"
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -639,31 +639,18 @@ publish_ecr() {
 	aws ecr get-login-password --region ${region}| docker login --username AWS --password-stdin ${account_id}.dkr.ecr.${region}.amazonaws.com
 	aws ecr create-repository --repository-name aws-for-fluent-bit --image-scanning-configuration scanOnPush=true --region ${region} || true
 
-	source_suffix=""
-	# Add image suffix for BUILD_VERSION=3
-	if [ "$BUILD_VERSION" = "3" ]; then
-		source_suffix="-3"
-
-		# Verify all images exist before proceeding
-		if ! verify_images "-3"; then
-			echo "BUILD_VERSION=3 images not available yet, skipping publish to avoid pipeline failure"
-			# Zero exit to avoid pipeline failures until images exist
-			exit 0
-		fi
-	fi
-
 	for arch in "${ARCHITECTURES[@]}"
 	do
-		push_image_ecr ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:"$arch"${source_suffix} \
+		push_image_ecr ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:"$arch"-${AWS_FOR_FLUENT_BIT_VERSION} \
 			${account_id}.dkr.ecr.${region}.amazonaws.com/aws-for-fluent-bit:"$arch"-${AWS_FOR_FLUENT_BIT_VERSION}
 
-		push_image_ecr ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:"$arch"-"debug"${source_suffix} \
+		push_image_ecr ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:"$arch"-"debug"-${AWS_FOR_FLUENT_BIT_VERSION} \
 			${account_id}.dkr.ecr.${region}.amazonaws.com/aws-for-fluent-bit:"$arch"-"debug"-${AWS_FOR_FLUENT_BIT_VERSION}
 
-		push_image_ecr ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:"$init"-"$arch"${source_suffix} \
+		push_image_ecr ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:"$init"-"$arch"-${AWS_FOR_FLUENT_BIT_VERSION} \
 			${account_id}.dkr.ecr.${region}.amazonaws.com/aws-for-fluent-bit:"$init"-"$arch"-${AWS_FOR_FLUENT_BIT_VERSION}
 
-		push_image_ecr ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:"$init"-"$arch"-"debug"${source_suffix} \
+		push_image_ecr ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/amazon/aws-for-fluent-bit-test:"$init"-"$arch"-"debug"-${AWS_FOR_FLUENT_BIT_VERSION} \
 			${account_id}.dkr.ecr.${region}.amazonaws.com/aws-for-fluent-bit:"$init"-"$arch"-"debug"-${AWS_FOR_FLUENT_BIT_VERSION}
 	done
 
@@ -810,10 +797,11 @@ verify_ecr_image_scan() {
 	if [ "$tagCount" = '1' ]; then
 		aws ecr start-image-scan --repository-name ${repo_uri} --image-id imageTag=${tag} --region ${region}
 		aws ecr wait image-scan-complete --repository-name ${repo_uri} --region ${region} --image-id imageTag=${tag}
-		highVulnerabilityCount=$(aws ecr describe-image-scan-findings --repository-name ${repo_uri} --region ${region} --image-id imageTag=${tag} | jq '.imageScanFindings.findingSeverityCounts.HIGH')
-		criticalVulnerabilityCount=$(aws ecr describe-image-scan-findings --repository-name ${repo_uri} --region ${region} --image-id imageTag=${tag} | jq '.imageScanFindings.findingSeverityCounts.CRITICAL')
-		if [ "$highVulnerabilityCount" != null ] || [ "$criticalVulnerabilityCount" != null ]; then
-			echo "Uploaded image ${tag} has ${vulnerabilityCount} vulnerabilities."
+		highVulnerabilityCount=$(aws ecr describe-image-scan-findings --repository-name ${repo_uri} --region ${region} --image-id imageTag=${tag} | jq '.imageScanFindings.findingSeverityCounts.HIGH // 0')
+		criticalVulnerabilityCount=$(aws ecr describe-image-scan-findings --repository-name ${repo_uri} --region ${region} --image-id imageTag=${tag} | jq '.imageScanFindings.findingSeverityCounts.CRITICAL // 0')
+		if [ "$highVulnerabilityCount" -gt 0 ] || [ "$criticalVulnerabilityCount" -gt 0 ]; then
+			vulnerabilityCount=$((highVulnerabilityCount + criticalVulnerabilityCount))
+			echo "Uploaded image ${tag} has ${vulnerabilityCount} vulnerabilities (HIGH: ${highVulnerabilityCount}, CRITICAL: ${criticalVulnerabilityCount})."
 			exit 1
 		fi
 	fi


### PR DESCRIPTION
### Summary
- Use version field from linux.version to tag v2/v3 images in -test ECR repository
- adjust tagging in scripts/buildspecs
- Add -qq to unzip commands to remove thousands of log lines
- Remove scale-in/termination protection on load test resources as it sometimes fails cleanup

### Testing
Local testing with personal codebuild pipeline up to image release. The image retagging to specific versions is working for integ/load tests and should also work for ECR/DockerHub

### Description for the changelog
enhancement: adjust image tagging during release

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
