### PR TITLE
bugfix: Match AWS fluent bit version with current and version to be released

### DIFF
--- a/linux.version
+++ b/linux.version
@@ -3,7 +3,7 @@
     "linux": {
       "major-version": "2",
       "version": "2.34.3.20260309",
-      "release-version": "2.34.3.20260209",
+      "release-version": "2.34.3.20260309",
       "latest": "true",
       "build": "1",
       "fluent-bit": "1.9.10",
@@ -21,7 +21,7 @@
     "linux": {
       "major-version": "3",
       "version": "3.2.4",
-      "release-version": "3.2.2",
+      "release-version": "3.2.4",
       "latest": "false",
       "build": "1",
       "fluent-bit": "v4.2.2",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR fixes the `release-version` for AWS Fluentbit 3.X to match with the current `version`. This is so it doesn't kick off the github action.

*Issue #, if available:*

### Testing
<!-- How was this tested?
See https://github.com/aws/aws-for-fluent-bit?tab=readme-ov-file#local-integ-testing
for instructions on how to run integ tests locally.
-->

`make debug` succeeded: <!-- yes|no -->
Integ tests succeeded: <!-- yes|no -->
New tests cover the changes: <!-- yes|no -->

### Description for the changelog
bugfix -  Match AWS fluent bit 3.X version with current and version to be released

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
