### PR TITLE
Add changelog for 3.2.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 3.2.5
+* Minimal set of packages installed using Amazon Linux 2023 container image version: 2023.10.20260325.0
+
 ### 2.34.3.20260309
 * Minimal set of packages installed using Amazon Linux 2 base container image version: 2.0.20260302.0
 

--- a/linux.version
+++ b/linux.version
@@ -20,7 +20,7 @@
   {
     "linux": {
       "major-version": "3",
-      "version": "3.2.4",
+      "version": "3.2.5",
       "release-version": "3.2.4",
       "latest": "false",
       "build": "1",

--- a/linux.version
+++ b/linux.version
@@ -21,7 +21,7 @@
     "linux": {
       "major-version": "3",
       "version": "3.2.5",
-      "release-version": "3.2.4",
+      "release-version": "3.2.5",
       "latest": "false",
       "build": "1",
       "fluent-bit": "v4.2.2",


### PR DESCRIPTION
### Summary
Add changelog entry for 3.2.5 release.

### 3.2.5
* Minimal set of packages installed using Amazon Linux 2023 container image version: 2023.10.20260325.0

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.