### PR TITLE
enhancement: Add new autogeneration github actions

### DIFF
--- a/.github/workflows/initiaterelease.yml
+++ b/.github/workflows/initiaterelease.yml
@@ -55,7 +55,7 @@ jobs:
         if: ${{ steps.stage.outputs.stage_exit_code == 42 && steps.push.outputs.push_exit_code == 0 }}
         run: |
           date=$(date '+%Y%m%d')
-          gh pr create --base mainline --head release-${date} --title "Release ${date}" --body "Dummy Release PR"
+          gh pr create --base mainline --head release-${date} --title "Release ${date}" --body "AWS Fluentbit Release Kickoff"
           echo "pr_exit_code=$?" >> "$GITHUB_OUTPUT"
   MetricPublish:
     needs: GenerateConfig

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,29 @@
+name: 'Lint PR'
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - edited
+
+jobs:
+  ValidatePRTitle:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: github.event.pull_request.user.login != 'github-actions[bot]'
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |-
+            feat
+            enhancement
+            fix
+          requireScope: false

--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -3,86 +3,174 @@ set -euo pipefail
 
 readonly VERSION_FILE="linux.version"
 readonly ECR_REPO="public.ecr.aws/amazonlinux/amazonlinux"
+readonly STABLE_VERSION_FILE="AWS_FOR_FLUENT_BIT_STABLE_VERSION"
 
 # List of docker tags that we want to clean up after
 tags_to_cleanup=()
 
 # Cleanup function that removes the pulled AL docker images
 cleanup() {
-    for i in "${tags_to_cleanup[@]}"; do
-        docker rmi "${ECR_REPO}:$i" || true
-    done
+	for i in "${tags_to_cleanup[@]}"; do
+		docker rmi "${ECR_REPO}:$i" || true
+	done
 }
 
 # Helper function to update the specific JSON key/field within the release config file
 update_json_field() {
-    local key="$1" field="$2" value="$3"
-    jq ".[$key].linux.\"$field\" = \"$value\"" "$VERSION_FILE" > tmp.json && mv tmp.json "$VERSION_FILE"
+	local key="$1" field="$2" value="$3"
+	jq ".[$key].linux.\"$field\" = \"$value\"" "$VERSION_FILE" >tmp.json && mv tmp.json "$VERSION_FILE"
+}
+
+# Compute the next AWS for Fluent Bit version based on the type of change.
+#
+# Versioning rules (from the release runbook):
+#   MAJOR.MINOR.PATCH       — used by 3.x (AL2023)
+#   MAJOR.MINOR.PATCH.BUILD — used by 2.x (AL2)
+#
+# - Base-image-only change (os_updated, no fluentbit bump):
+#     2.x → bump BUILD to today's date (YYYYMMDD)
+#     3.x → bump PATCH
+# - Fluent Bit minor version bump (e.g., 4.2.x → 4.3.x):
+#     Both → bump MINOR, reset PATCH to 0
+# - Fluent Bit patch version bump (e.g., 4.2.2 → 4.2.3):
+#     Both → bump PATCH
+compute_new_version() {
+	local current_version="$1"
+	local major_version="$2"
+	local os_updated="$3"
+	local fluentbit_updated="$4"
+	local old_fluentbit="${5:-}"
+	local new_fluentbit="${6:-}"
+
+	# Parse current version components
+	local major minor patch build
+	IFS='.' read -r major minor patch build <<<"$current_version"
+
+	if [[ "$fluentbit_updated" == "true" ]]; then
+		# Determine whether the Fluent Bit change is a minor or patch bump
+		# by comparing the minor component of the old and new Fluent Bit versions.
+		local old_fb_minor new_fb_minor
+		old_fb_minor=$(echo "${old_fluentbit#v}" | cut -d. -f2)
+		new_fb_minor=$(echo "${new_fluentbit#v}" | cut -d. -f2)
+
+		if [[ "$new_fb_minor" != "$old_fb_minor" ]]; then
+			# Fluent Bit minor bump → AWS FB minor bump
+			minor=$((minor + 1))
+			patch=0
+		else
+			# Fluent Bit patch bump → AWS FB patch bump
+			patch=$((patch + 1))
+		fi
+		echo "${major}.${minor}.${patch}"
+	elif [[ "$os_updated" == "true" ]]; then
+		if [[ "$major_version" == "2" ]]; then
+			# 2.x base-image-only → set BUILD to today's date (YYYYMMDD)
+			local today
+			today=$(date '+%Y%m%d')
+			echo "${major}.${minor}.${patch}.${today}"
+		else
+			# 3.x base-image-only → bump PATCH
+			patch=$((patch + 1))
+			echo "${major}.${minor}.${patch}"
+		fi
+	else
+		# No change — return current version unchanged
+		echo "$current_version"
+	fi
 }
 
 # Function that checks and updates the release config file for any of the following:
 # - New Amazon Linux docker image (tracked by image SHA)
-# - New upstream Fluentbit version to consumed
-# - New AWS Fluentbit version to be released (Updated to pull in any other updates/changes.)
+# - New upstream Fluentbit version to be consumed
+# - New AWS Fluentbit version to be released (auto-computed from the above)
 check_and_update() {
-    local any_version_updated="false"
-    
-    for i in $(jq 'keys[]' "$VERSION_FILE"); do
-        local version_updated="false"
-        
-        current_sha=$(jq -r ".[$i].linux.\"os-digest\"" "$VERSION_FILE")
-        tag=$(jq -r ".[$i].linux.\"al-tag\"" "$VERSION_FILE")
+	local any_version_updated="false"
 
-        if ! docker pull "${ECR_REPO}:$tag"; then
-            echo "Warning: Failed to pull ${ECR_REPO}:$tag" >&2
-            continue
-        fi
-        
-        tags_to_cleanup+=("$tag")
-        new_al_sha=$(docker inspect --format='{{index .RepoDigests 0}}' "${ECR_REPO}:$tag")
-        # Extract just the SHA256 digest from the full repo digest
-        new_sha_digest=$(echo "$new_al_sha" | sed 's/.*@//')
-        
-        if [[ "$new_sha_digest" != "$current_sha" ]]; then
-            echo "New base amazon linux image for $tag. Updating..."
-            update_json_field "$i" "os-digest" "$new_sha_digest"
-            version_updated="true"
-        fi
+	for i in $(jq 'keys[]' "$VERSION_FILE"); do
+		local os_updated="false"
+		local fluentbit_updated="false"
 
-        curr_fluentbit_version=$(jq -r ".[$i].linux.\"fluent-bit\"" "$VERSION_FILE")
-        release_fluentbit_version=$(jq -r ".[$i].linux.\"release-fluent-bit\"" "$VERSION_FILE")
-        if [[ "$curr_fluentbit_version" != "$release_fluentbit_version" ]]; then
-            echo "Upgrading to new Fluentbit version."
-            update_json_field "$i" "fluent-bit" "$release_fluentbit_version"
-            version_updated="true"
-        fi
+		current_sha=$(jq -r ".[$i].linux.\"os-digest\"" "$VERSION_FILE")
+		tag=$(jq -r ".[$i].linux.\"al-tag\"" "$VERSION_FILE")
+		major_version=$(jq -r ".[$i].linux.\"major-version\"" "$VERSION_FILE")
+		latest=$(jq -r ".[$i].linux.\"latest\"" "$VERSION_FILE")
 
-        curr_aws_fb_version=$(jq -r ".[$i].linux.\"version\"" "$VERSION_FILE")
-        release_aws_fb_version=$(jq -r ".[$i].linux.\"release-version\"" "$VERSION_FILE")
-        if [[ "$curr_aws_fb_version" != "$release_aws_fb_version" ]]; then
-            echo "Upgrading to new AWS Fluentbit version."
-            update_json_field "$i" "version" "$release_aws_fb_version"
-            version_updated="true"
-        fi
+		if ! docker pull "${ECR_REPO}:$tag"; then
+			echo "Warning: Failed to pull ${ECR_REPO}:$tag" >&2
+			continue
+		fi
 
-        # Set publish flag based on whether this version had updates
-        if [[ "$version_updated" = "true" ]]; then
-            update_json_field "$i" "publish" "true"
-            any_version_updated="true"
-        else
-            update_json_field "$i" "publish" "false"
-        fi
-    done
+		tags_to_cleanup+=("$tag")
+		new_al_sha=$(docker inspect --format='{{index .RepoDigests 0}}' "${ECR_REPO}:$tag")
+		# Extract just the SHA256 digest from the full repo digest
+		new_sha_digest=$(echo "$new_al_sha" | sed 's/.*@//')
 
-    # Only stage changes if at least one version was updated
-    if [[ "$any_version_updated" = "true" ]]; then
-        git add "$VERSION_FILE"
-        git status
-    fi
+		if [[ "$new_sha_digest" != "$current_sha" ]]; then
+			echo "New base amazon linux image for $tag. Updating..."
+			update_json_field "$i" "os-digest" "$new_sha_digest"
+			os_updated="true"
+		fi
+
+		curr_fluentbit_version=$(jq -r ".[$i].linux.\"fluent-bit\"" "$VERSION_FILE")
+		release_fluentbit_version=$(jq -r ".[$i].linux.\"release-fluent-bit\"" "$VERSION_FILE")
+		if [[ "$curr_fluentbit_version" != "$release_fluentbit_version" ]]; then
+			echo "Upgrading to new Fluentbit version."
+			update_json_field "$i" "fluent-bit" "$release_fluentbit_version"
+			fluentbit_updated="true"
+		fi
+
+		# Determine the new AWS for Fluent Bit version.
+		# A manually set release-version (differs from version) takes priority
+		# over auto-computation from upstream changes.
+		curr_aws_fb_version=$(jq -r ".[$i].linux.\"version\"" "$VERSION_FILE")
+		release_aws_fb_version=$(jq -r ".[$i].linux.\"release-version\"" "$VERSION_FILE")
+
+		if [[ "$curr_aws_fb_version" != "$release_aws_fb_version" ]]; then
+			# Manual release: someone updated release-version directly
+			echo "Manual version override detected: $curr_aws_fb_version -> $release_aws_fb_version"
+			update_json_field "$i" "version" "$release_aws_fb_version"
+			update_json_field "$i" "publish" "true"
+			any_version_updated="true"
+
+			# Update the stable version to the new version if latest has been updated
+			if [[ "$latest" = "true" ]]; then
+				echo "Updating stable version to $release_aws_fb_version"
+				echo "$release_aws_fb_version" >"$STABLE_VERSION_FILE"
+			fi
+
+		elif [[ "$os_updated" == "true" || "$fluentbit_updated" == "true" ]]; then
+			# Auto-compute version from upstream changes
+			new_aws_fb_version=$(compute_new_version "$curr_aws_fb_version" "$major_version" "$os_updated" "$fluentbit_updated" "$curr_fluentbit_version" "$release_fluentbit_version")
+			echo "Bumping AWS for Fluent Bit version: $curr_aws_fb_version -> $new_aws_fb_version"
+			update_json_field "$i" "version" "$new_aws_fb_version"
+			update_json_field "$i" "release-version" "$new_aws_fb_version"
+			update_json_field "$i" "publish" "true"
+			any_version_updated="true"
+
+			# Update the stable version to the new version if latest has been updated
+			if [[ "$latest" = "true" ]]; then
+				echo "Updating stable version to $new_aws_fb_version"
+				echo "$new_aws_fb_version" >"$STABLE_VERSION_FILE"
+			fi
+		else
+			update_json_field "$i" "publish" "false"
+		fi
+	done
+
+	# Only stage changes if at least one version was updated
+	if [[ "$any_version_updated" = "true" ]]; then
+		git add "$VERSION_FILE" "$STABLE_VERSION_FILE"
+
+		# Generate and prepend new changelog entries
+		SCRIPTS_DIR="$(dirname "${BASH_SOURCE[0]}")"
+		"${SCRIPTS_DIR}/generate_changelog.sh"
+
+		git status
+	fi
 }
 
 main() {
-    check_and_update
+	check_and_update
 }
 
 trap cleanup EXIT

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -1,24 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
+
+readonly VERSION_FILE="linux.version"
+readonly CHANGELOG_FILE="CHANGELOG.md"
+readonly REPO="aws/aws-for-fluent-bit"
+
+WORK_DIR="$(mktemp -d)"
+trap "rm -rf ${WORK_DIR}" EXIT
 
 # Function to fetch all Amazon Linux image data from Public ECR API
 # Returns the full JSON response
 fetch_all_al_images() {
-    curl -sSL \
-        --header "Content-Type: application/json" \
-        --request POST \
-        --data '{"registryAliasName":"amazonlinux","repositoryName":"amazonlinux","maxResults":1000}' \
-        https://api.us-east-1.gallery.ecr.aws/describeImageTags
+	curl -sSL \
+		--header "Content-Type: application/json" \
+		--request POST \
+		--data '{"registryAliasName":"amazonlinux","repositoryName":"amazonlinux","maxResults":1000}' \
+		https://api.us-east-1.gallery.ecr.aws/describeImageTags
 }
 
 # Function to get the latest version and SHA256 for a specific AL version from cached response
 # Returns: "version sha256" (space-separated)
 get_latest_al_version_and_sha_from_response() {
-    local response="$1"
-    local version_prefix="$2"
-    
-    # Use jq to filter by prefix, exclude variants, sort by version, and get the latest with its SHA256
-    echo "$response" | jq -r --arg prefix "$version_prefix" '
+	local response="$1"
+	local version_prefix="$2"
+
+	# Use jq to filter by prefix, exclude variants, sort by version, and get the latest with its SHA256
+	echo "$response" | jq -r --arg prefix "$version_prefix" '
         [.imageTagDetails[] 
         | select(.imageTag | startswith($prefix + "."))
         | select(.imageTag | test("minimal|arm|amd") | not)
@@ -31,170 +38,159 @@ get_latest_al_version_and_sha_from_response() {
 
 # Function to extract version info from linux.version file
 get_version_info() {
-    local major_version="$1"
-    local field="$2"
-    local json_file="linux.version"
+	local major_version="$1"
+	local field="$2"
 
-    jq -r ".[] | select(.linux.\"major-version\" == \"$major_version\") | .linux.\"$field\"" "$json_file"
+	jq -r ".[] | select(.linux.\"major-version\" == \"$major_version\") | .linux.\"$field\"" "$VERSION_FILE"
 }
 
-# Function to update os-digest in linux.version file
-update_os_digest() {
-    local al_tag="$1"
-    local sha256="$2"
-    local json_file="linux.version"
+# Get PR titles merged since the last "Release XXXX" commit via the GitHub CLI (gh) to query merged PRs by date
+get_changes_since_last_release() {
+	local last_release_merged_at
+	last_release_merged_at=$(gh pr list \
+		--repo "$REPO" \
+		--state merged \
+		--base mainline \
+		--search "head:release- sort:updated-desc" \
+		--limit 1 \
+		--json mergedAt \
+		--jq '.[0].mergedAt' 2>/dev/null || true)
 
-    # Create a temporary file
-    local temp_file=$(mktemp)
+	if [ -z "$last_release_merged_at" ] || [ "$last_release_merged_at" = "null" ]; then
+		echo "WARNING: Could not find last release PR merge timestamp" >&2
+		return
+	fi
 
-    # Update the os-digest field for the matching al-tag
-    jq --arg tag "$al_tag" --arg digest "sha256:$sha256" '
-        map(
-            if .linux."al-tag" == $tag then
-                .linux."os-digest" = $digest
-            else
-                .
-            end
-        )
-    ' "$json_file" > "$temp_file"
+	echo "Fetching merged PRs since last release PR (merged at ${last_release_merged_at})..." >&2
 
-    # Replace the original file with the updated one
-    mv "$temp_file" "$json_file"
+	# Use GitHub CLI if available to get merged PR titles
+	local pr_titles
+	pr_titles=$(gh pr list \
+		--repo "$REPO" \
+		--base mainline \
+		--state merged \
+		--search "merged:>=${last_release_merged_at}" \
+		--json title,number,mergedAt \
+		--jq '.[] | select(.title | test("^(stable:|Release \\d)"; "i") | not) | "* \(.title) [#\(.number)](https://github.com/'"$REPO"'/pull/\(.number))"' \
+		2>/dev/null || true)
 
-    echo "Set os-digest for AL $al_tag to sha256:$sha256" >&2
+	if [[ -n "$pr_titles" ]]; then
+		echo "$pr_titles"
+		return
+	fi
 }
 
-# Function to extract all version information for a major version
-extract_version_data() {
-    local major_version="$1"
+# Generate a single changelog entry for a major version and append to an entry file
+generate_entry() {
+	local major_version="$1"
+	local al_version="$2"
+	local commits="$3"
+	local entry_file="$4"
 
-    # Create associative array to store version data
-    declare -A version_data
-    version_data[version]=$(get_version_info "$major_version" "version")
-    version_data[fluent_bit]=$(get_version_info "$major_version" "fluent-bit")
-    version_data[cloudwatch_plugin]=$(get_version_info "$major_version" "cloudwatch-plugin")
-    version_data[kinesis_plugin]=$(get_version_info "$major_version" "kinesis-plugin")
-    version_data[firehose_plugin]=$(get_version_info "$major_version" "firehose-plugin")
-    version_data[latest]=$(get_version_info "$major_version" "latest")
+	local version fluent_bit cw_plugin kinesis_plugin firehose_plugin al_tag
+	version=$(get_version_info "$major_version" "version")
+	fluent_bit=$(get_version_info "$major_version" "fluent-bit")
+	cw_plugin=$(get_version_info "$major_version" "cloudwatch-plugin")
+	kinesis_plugin=$(get_version_info "$major_version" "kinesis-plugin")
+	firehose_plugin=$(get_version_info "$major_version" "firehose-plugin")
+	al_tag=$(get_version_info "$major_version" "al-tag")
 
-    # Return the data (we'll use the latest version for the changelog)
-    if [[ "${version_data[latest]}" == "true" ]]; then
-        echo "${version_data[version]} ${version_data[fluent_bit]} ${version_data[cloudwatch_plugin]} ${version_data[kinesis_plugin]} ${version_data[firehose_plugin]}"
-    fi
-}
+	local al_description
+	if [[ "$al_tag" == "2023" ]]; then
+		al_description="Minimal set of packages installed using Amazon Linux 2023 container image version: $al_version"
+	else
+		al_description="Amazon Linux $al_tag base container image version: $al_version"
+	fi
 
-# Function to generate changelog section for a specific version
-generate_version_section() {
-    local major_version="$1"
-    local al_tag="$2"
-    local most_recent_al_version="$3"
-
-    local version=$(get_version_info "$major_version" "version")
-    local fluent_bit_version=$(get_version_info "$major_version" "fluent-bit")
-    local cloudwatch_plugin_version=$(get_version_info "$major_version" "cloudwatch-plugin")
-    local kinesis_plugin_version=$(get_version_info "$major_version" "kinesis-plugin")
-    local firehose_plugin_version=$(get_version_info "$major_version" "firehose-plugin")
-    local publish=$(get_version_info "$major_version" "publish")
-
-    # Only generate section if this version should be published
-    if [[ "$publish" == "true" ]]; then
-        local al_name
-        al_name="Amazon Linux $al_tag"
-
-        if [[ "$al_tag" == "2023" ]]; then
-            cat << EOF
+	cat >>"$entry_file" <<EOF
 ### $version
 This release includes:
-* Fluent Bit [$fluent_bit_version](https://github.com/fluent/fluent-bit/tree/v${fluent_bit_version#v})
-* Amazon CloudWatch Logs for Fluent Bit ${cloudwatch_plugin_version#v}
-* Amazon Kinesis Streams for Fluent Bit ${kinesis_plugin_version#v}
-* Amazon Kinesis Firehose for Fluent Bit ${firehose_plugin_version#v}
-* Minimal set of packages installed using Amazon Linux 2023 container image version: $most_recent_al_version
+* Fluent Bit [v${fluent_bit#v}](https://github.com/fluent/fluent-bit/tree/v${fluent_bit#v})
+* Amazon CloudWatch Logs for Fluent Bit ${cw_plugin#v}
+* Amazon Kinesis Streams for Fluent Bit ${kinesis_plugin#v}
+* Amazon Kinesis Firehose for Fluent Bit ${firehose_plugin#v}
+* $al_description
 
 Compared to the previous release, this release adds:
-* Fix - TODO blah blah [#TODO](https://github.com/amazon-contributing/upstream-to-fluent-bit/pull/TODO)
-* Enhancement - TODO blah blah [#TODO](https://github.com/aws/aws-for-fluent-bit/pull/TODO)
+$commits
 
 EOF
-        else
-            cat << EOF
-### $version
-This release includes:
-* Fluent Bit [v$fluent_bit_version](https://github.com/fluent/fluent-bit/tree/v${fluent_bit_version#v})
-* Amazon CloudWatch Logs for Fluent Bit ${cloudwatch_plugin_version#v}
-* Amazon Kinesis Streams for Fluent Bit ${kinesis_plugin_version#v}
-* Amazon Kinesis Firehose for Fluent Bit ${firehose_plugin_version#v}
-* $al_name base container image version: $most_recent_al_version
-
-Compared to the previous release, this release adds:
-* Fix - TODO blah blah [#TODO](https://github.com/amazon-contributing/upstream-to-fluent-bit/pull/TODO)
-* Enhancement - TODO blah blah [#TODO](https://github.com/aws/aws-for-fluent-bit/pull/TODO)
-
-EOF
-        fi
-    fi
 }
 
-# Main function to orchestrate changelog generation
+prepend_to_changelog() {
+	local entry_file="$1"
+
+	local first_release_line
+	first_release_line=$(grep -n '^### [0-9]' "$CHANGELOG_FILE" | head -1 | cut -d: -f1)
+
+	if [ -z "$first_release_line" ]; then
+		echo "ERROR: Could not find any release entry in CHANGELOG.md" >&2
+		exit 1
+	fi
+
+	# Build new changelog: header + new entry + blank line + existing entries
+	local tmpfile
+	tmpfile=$(mktemp)
+	head -n $((first_release_line - 1)) "$CHANGELOG_FILE" >"$tmpfile"
+	cat "$entry_file" >>"$tmpfile"
+	tail -n +${first_release_line} "$CHANGELOG_FILE" >>"$tmpfile"
+	mv "$tmpfile" "$CHANGELOG_FILE"
+}
+
 main() {
-    # Get list of al-tags that have publish=true
-    local publish_al_tags=$(jq -r '.[] | select(.linux.publish == "true") | .linux."al-tag"' linux.version)
+	# Collect major versions that have publish=true
+	local publish_versions
+	publish_versions=$(jq -r '.[] | select(.linux.publish == "true") | .linux."major-version"' "$VERSION_FILE")
 
-    # Check if we have any versions to publish
-    if [[ -n "$publish_al_tags" ]]; then
-        echo "=== Latest Amazon Linux Image Information ===" >&2
+	if [[ -z "$publish_versions" ]]; then
+		echo "No versions to publish. Skipping changelog generation." >&2
+		return 0
+	fi
 
-        # Declare associative arrays to store version and SHA data
-        declare -A al_versions
-        declare -A al_shas
+	echo "Fetching Amazon Linux image data for changelog..." >&2
+	local al_images_response
+	al_images_response=$(fetch_all_al_images)
 
-        # Fetch all AL image data once
-        local al_images_response=$(fetch_all_al_images)
+	# Get merged PR titles since the last release (shared across all entries)
+	local commits
+	commits=$(get_changes_since_last_release)
+	echo "Changes since last release:" >&2
+	echo "$commits" >&2
 
-        # Process data for each AL version that is being published
-        local count=0
-        local total=$(echo "$publish_al_tags" | wc -w)
-        
-        for al_tag in $publish_al_tags; do
-            count=$((count + 1))
-            local al_data=$(get_latest_al_version_and_sha_from_response "$al_images_response" "$al_tag")
-            al_versions[$al_tag]=$(echo "$al_data" | cut -d' ' -f1)
-            al_shas[$al_tag]=$(echo "$al_data" | cut -d' ' -f2)
+	# Generate a temporary file to hold new changelog entries
+	local entry_file=$(mktemp -p "$WORK_DIR")
 
-            # Print the information
-            echo "Amazon Linux $al_tag: ${al_versions[$al_tag]}" >&2
-            echo "  SHA256: ${al_shas[$al_tag]}" >&2
-            echo "" >&2
+	# Declare associative arrays to store version and SHA data
+	declare -A al_versions
+	declare -A al_shas
 
-            # Update os-digest in linux.version file
-            update_os_digest "$al_tag" "${al_shas[$al_tag]}"
-            
-            # Add spacing after os-digest update (except for the last one)
-            if [[ $count -lt $total ]]; then
-                echo "" >&2
-            fi
-        done
+	for major_version in $publish_versions; do
+		local al_tag
+		al_tag=$(get_version_info "$major_version" "al-tag")
 
-        echo "=============================================" >&2
-        echo "" >&2
-    fi
+		local al_data
+		al_data=$(get_latest_al_version_and_sha_from_response "$al_images_response" "$al_tag")
 
-    # Get all major versions from linux.version file
-    local major_versions=$(jq -r '.[].linux."major-version"' linux.version)
+		al_versions[$al_tag]=$(echo "$al_data" | cut -d' ' -f1)
+		al_shas[$al_tag]=$(echo "$al_data" | cut -d' ' -f2)
 
-    # Generate changelog sections for each version
-    for major_version in $major_versions; do
-        local al_tag=$(get_version_info "$major_version" "al-tag")
-        local most_recent_al_version=""
+		# Print the Amazon linux image information
+		printf "Amazon Linux %s: %s\n\tSHA256: %s\n" "$al_tag" "${al_versions[$al_tag]}" "${al_shas[$al_tag]}" >&2
 
-        # Get the AL version if it was fetched (i.e., if this version is being published)
-        if [[ -n "${al_versions[$al_tag]:-}" ]]; then
-            most_recent_al_version="${al_versions[$al_tag]}"
-        fi
+		local most_recent_al_version=""
+		# Get the AL version if it was fetched (i.e., if this version is being published)
+		if [[ -n "${al_versions[$al_tag]:-}" ]]; then
+			most_recent_al_version="${al_versions[$al_tag]}"
+		fi
 
-        generate_version_section "$major_version" "$al_tag" "$most_recent_al_version"
-    done
+		echo "Generating changelog entry for major version $major_version (AL $al_tag: $most_recent_al_version)" >&2
+		generate_entry "$major_version" "$most_recent_al_version" "$commits" "$entry_file"
+	done
+
+	echo "New changelog entries generated:"
+	cat "$entry_file"
+	prepend_to_changelog "$entry_file"
+	git add "$CHANGELOG_FILE"
 }
 
-# Execute main function
 main "$@"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR modifies the github action workflows so that:
* Lint the PR titles so that future PRs will need to follow a "feat/enhancement/fix" prefix. This will be used to generate new changelog entries when a new release PR comes in
* Generate new changelog entries for new AWS Fluentbit versions with the following template:
```
### $version
This release includes:
* Fluent Bit [v$fluent_bit_version](https://github.com/fluent/fluent-bit/tree/v${fluent_bit_version#v})
* Amazon CloudWatch Logs for Fluent Bit ${cloudwatch_plugin_version#v}
* Amazon Kinesis Streams for Fluent Bit ${kinesis_plugin_version#v}
* Amazon Kinesis Firehose for Fluent Bit ${firehose_plugin_version#v}
* $al_name base container image version: $most_recent_al_version

Compared to the previous release, this release adds:
* Fix - TODO blah blah [#TODO](https://github.com/amazon-contributing/upstream-to-fluent-bit/pull/TODO)
* Enhancement - TODO blah blah [#TODO](https://github.com/aws/aws-for-fluent-bit/pull/TODO)
```

*Issue #, if available:*

### Testing
Manual testing in: https://github.com/mye956/aws-for-fluent-bit/pull/27/changes and https://github.com/mye956/aws-for-fluent-bit/pull/24

Github action: https://github.com/mye956/aws-for-fluent-bit/actions/runs/23820992458/job/69432944644

### Description for the changelog
enhancement: add new autogeneration github actions

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
