### PR TITLE
enhancement: temporarily check and change scanning type to BASIC before building new images

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,6 +6,16 @@ phases:
       python: 3.x
   pre_build:
     commands:
+      # Short term fix: ensure ECR basic scanning is enabled for the registry
+      # TODO: Remove this once we have a long term fix
+      - |
+        current_scan_type=$(aws ecr get-registry-scanning-configuration --region ${AWS_DEFAULT_REGION} --query 'scanningConfiguration.scanType' --output text 2>/dev/null || echo "UNKNOWN")
+        if [ "$current_scan_type" != "BASIC" ]; then
+          echo "Setting ECR scanning configuration to BASIC"
+          aws ecr put-registry-scanning-configuration --scan-type BASIC --region ${AWS_DEFAULT_REGION}
+        else
+          echo "ECR scanning configuration already set to BASIC, skipping"
+        fi
       - echo Building the AWS for Fluent Bit image
       # Check BUILD_VERSION environment variable and set default if not provided
       # TODO: Remove default once codepipeline and buildspec setup is complete end to end for new builds


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR first checks if the scanning type of our ECR repos are `BASIC` and if it is then we change the typing. This is a short term workaround as our image builder script isn't compatible with `ENHANCED` typing.

*Issue #, if available:*

### Testing
<!-- How was this tested?
See https://github.com/aws/aws-for-fluent-bit?tab=readme-ov-file#local-integ-testing
for instructions on how to run integ tests locally.
-->

`make debug` succeeded: <!-- yes|no -->
Integ tests succeeded: <!-- yes|no -->
New tests cover the changes: <!-- yes|no -->

### Description for the changelog
* enhancement: temporarily check and change scanning type to BASIC before building new images

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
