### PR TITLE
enhancement: Add vulnerability scanning for enhanced type

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,16 +6,6 @@ phases:
       python: 3.x
   pre_build:
     commands:
-      # Short term fix: ensure ECR basic scanning is enabled for the registry
-      # TODO: Remove this once we have a long term fix
-      - |
-        current_scan_type=$(aws ecr get-registry-scanning-configuration --region ${AWS_DEFAULT_REGION} --query 'scanningConfiguration.scanType' --output text 2>/dev/null || echo "UNKNOWN")
-        if [ "$current_scan_type" != "BASIC" ]; then
-          echo "Setting ECR scanning configuration to BASIC"
-          aws ecr put-registry-scanning-configuration --scan-type BASIC --region ${AWS_DEFAULT_REGION}
-        else
-          echo "ECR scanning configuration already set to BASIC, skipping"
-        fi
       - echo Building the AWS for Fluent Bit image
       # Check BUILD_VERSION environment variable and set default if not provided
       # TODO: Remove default once codepipeline and buildspec setup is complete end to end for new builds

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -710,14 +710,56 @@ verify_ecr_image_scan() {
 
 	tagCount=$(aws ecr list-images  --repository-name ${repo_uri} --region ${region} | jq -r '.imageIds[].imageTag' | grep -c ${tag} || echo "0")
 	if [ "$tagCount" = '1' ]; then
-		aws ecr start-image-scan --repository-name ${repo_uri} --image-id imageTag=${tag} --region ${region}
-		aws ecr wait image-scan-complete --repository-name ${repo_uri} --region ${region} --image-id imageTag=${tag}
-		highVulnerabilityCount=$(aws ecr describe-image-scan-findings --repository-name ${repo_uri} --region ${region} --image-id imageTag=${tag} | jq '.imageScanFindings.findingSeverityCounts.HIGH // 0')
-		criticalVulnerabilityCount=$(aws ecr describe-image-scan-findings --repository-name ${repo_uri} --region ${region} --image-id imageTag=${tag} | jq '.imageScanFindings.findingSeverityCounts.CRITICAL // 0')
-		if [ "$highVulnerabilityCount" -gt 0 ] || [ "$criticalVulnerabilityCount" -gt 0 ]; then
-			vulnerabilityCount=$((highVulnerabilityCount + criticalVulnerabilityCount))
-			echo "Uploaded image ${tag} has ${vulnerabilityCount} vulnerabilities (HIGH: ${highVulnerabilityCount}, CRITICAL: ${criticalVulnerabilityCount})."
-			exit 1
+		scan_type=$(aws ecr get-registry-scanning-configuration --region ${region} --query 'scanningConfiguration.scanType' --output text 2>/dev/null || echo "BASIC")
+		if [ "$scan_type" = "ENHANCED" ]; then
+			max_attempts=20
+			attempt=0
+
+			echo "Checking Inspector2 coverage for repo=${repo_uri} tag=${tag}..."
+			while [ $attempt -lt $max_attempts ]; do
+				# Note: list-coverage uses 'ecrRepositoryName' filter key
+				coverage_result=$(aws inspector2 list-coverage \
+					--filter-criteria '{"ecrRepositoryName":[{"comparison":"EQUALS","value":"'${repo_uri}'"}],"ecrImageTags":[{"comparison":"EQUALS","value":"'${tag}'"}]}' \
+					--region ${region})
+				status=$(echo "$coverage_result" | jq -r '.coveredResources[0].scanStatus.statusCode // "NOT_FOUND"')
+				if [ "$status" = "ACTIVE" ]; then
+					echo "Inspector2 scan complete for ${tag}"
+					break
+				fi
+				attempt=$((attempt + 1))
+				echo "Waiting for Inspector2 scan (status: ${status}, attempt ${attempt}/${max_attempts})..."
+				sleep 15
+			done
+			if [ $attempt -eq $max_attempts ]; then
+				echo "Error: Inspector2 scan did not complete for ${repo_uri}:${tag} after $((max_attempts * 15)) seconds"
+				exit 1
+			fi
+
+			# Continuously poll for any high/critical findings — findings may appear gradually after scan shows ACTIVE
+			echo "Waiting for findings to propagate..."
+			sleep 15
+			max_stability_attempts=10
+			stability_attempt=0
+			while [ $stability_attempt -lt $max_stability_attempts ]; do
+				findings=$(aws inspector2 list-findings --max-results 1 --filter-criteria '{"ecrImageRepositoryName":[{"comparison":"EQUALS","value":"'${repo_uri}'"}],"ecrImageTags":[{"comparison":"EQUALS","value":"'${tag}'"}],"severity":[{"comparison":"EQUALS","value":"HIGH"},{"comparison":"EQUALS","value":"CRITICAL"}]}' --region ${region})
+				vulnerability=$(echo "$findings" | jq '.findings | length')
+				if [ $vulnerability -gt 0 ]; then
+					echo "Uploaded image ${tag} has HIGH/CRITICAL vulnerabilities."
+					exit 1
+				fi
+				stability_attempt=$((stability_attempt + 1))
+				sleep 15
+			done
+		else
+			aws ecr start-image-scan --repository-name ${repo_uri} --image-id imageTag=${tag} --region ${region}
+			aws ecr wait image-scan-complete --repository-name ${repo_uri} --region ${region} --image-id imageTag=${tag}
+			highVulnerabilityCount=$(aws ecr describe-image-scan-findings --repository-name ${repo_uri} --region ${region} --image-id imageTag=${tag} | jq '.imageScanFindings.findingSeverityCounts.HIGH // 0')
+			criticalVulnerabilityCount=$(aws ecr describe-image-scan-findings --repository-name ${repo_uri} --region ${region} --image-id imageTag=${tag} | jq '.imageScanFindings.findingSeverityCounts.CRITICAL // 0')
+			if [ "$highVulnerabilityCount" -gt 0 ] || [ "$criticalVulnerabilityCount" -gt 0 ]; then
+				vulnerabilityCount=$((highVulnerabilityCount + criticalVulnerabilityCount))
+				echo "Uploaded image ${tag} has ${vulnerabilityCount} vulnerabilities (HIGH: ${highVulnerabilityCount}, CRITICAL: ${criticalVulnerabilityCount})."
+				exit 1
+			fi
 		fi
 	fi
 }


### PR DESCRIPTION
### Summary

Add enhanced ECR scanning support to `verify_ecr_image_scan()` so the CI build works with both basic and enhanced scanning modes. Previously, the build forced the registry to basic scanning (requiring `inspector2:Disable` permission the CodeBuild role lacks), causing `AccessDeniedException` failures.

The function now detects the scanning type at runtime:
- **Basic**: keeps existing `start-image-scan` + `describe-image-scan-findings` flow
- **Enhanced**: uses `inspector2 list-coverage` to poll for scan completion, then `inspector2 list-findings` to check for HIGH/CRITICAL vulnerabilities

Also removes the `put-registry-scanning-configuration --scan-type BASIC` block from `buildspec.yml` since it's no longer needed.

Requires adding `inspector2:ListFindings`, `inspector2:ListCoverage`, and `ecr:GetRegistryScanningConfiguration` permissions to the CodeBuild role.

*Issue #, if available:*

### Testing

Verified enhanced scanning path against a test ECR repo (`amazonlinux:2.0.20250915.0`) with known HIGH vulnerabilities — build correctly detects and fails. Verified clean images pass without false positives. Confirmed findings propagation delay after scan shows ACTIVE is handled by the polling loop. Basic scanning path is unchanged.

Manual test:
```
dev-dsk% ./scan-test.sh
Checking Inspector2 coverage for repo=amazonlinux tag=2.0.20250808.1...
Waiting for Inspector2 scan (status: NOT_FOUND, attempt 1/20)...
Waiting for Inspector2 scan (status: INACTIVE, attempt 2/20)...
Inspector2 scan complete for 2.0.20250808.1
Waiting for findings to propagate...
Uploaded image 2.0.20250808.1 has HIGH/CRITICAL vulnerabilities.
```

`make debug` succeeded: no (CI-only change, no image build changes)
Integ tests succeeded: no (CI-only change, not applicable)
New tests cover the changes: no (shell script changes in CI pipeline, tested manually against live ECR/Inspector2)

### Description for the changelog

enhancement: Add support for ECR enhanced scanning (Amazon Inspector) in image vulnerability checks, removing the requirement to force basic scanning mode.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
