### PR TITLE
fix: clean up changelog entry generation and only run github actions in official repo

### DIFF
--- a/.github/workflows/initiaterelease.yml
+++ b/.github/workflows/initiaterelease.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   GenerateConfig:
+    if: github.repository == 'aws/aws-for-fluent-bit'
     runs-on: ubuntu-latest
     outputs:
       stage_exit_code: ${{ steps.stage.outputs.stage_exit_code }}
@@ -59,7 +60,7 @@ jobs:
           echo "pr_exit_code=$?" >> "$GITHUB_OUTPUT"
   MetricPublish:
     needs: GenerateConfig
-    if: success() || failure()
+    if: (success() || failure()) && github.repository == 'aws/aws-for-fluent-bit'
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/postkickoff.yml
+++ b/.github/workflows/postkickoff.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ResetReleaseMetric:
-    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release-')
+    if: github.repository == 'aws/aws-for-fluent-bit' && github.event.pull_request.merged == true && startsWith(github.head_ref, 'release-')
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: github.event.pull_request.user.login != 'github-actions[bot]'
+    if: github.repository == 'aws/aws-for-fluent-bit' && github.event.pull_request.user.login != 'github-actions[bot]'
     steps:
       - uses: amannn/action-semantic-pull-request@v6
         env:

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -87,34 +87,18 @@ generate_entry() {
 	local commits="$3"
 	local entry_file="$4"
 
-	local version fluent_bit cw_plugin kinesis_plugin firehose_plugin al_tag
+	local version al_tag
 	version=$(get_version_info "$major_version" "version")
-	fluent_bit=$(get_version_info "$major_version" "fluent-bit")
-	cw_plugin=$(get_version_info "$major_version" "cloudwatch-plugin")
-	kinesis_plugin=$(get_version_info "$major_version" "kinesis-plugin")
-	firehose_plugin=$(get_version_info "$major_version" "firehose-plugin")
 	al_tag=$(get_version_info "$major_version" "al-tag")
-
-	local al_description
-	if [[ "$al_tag" == "2023" ]]; then
-		al_description="Minimal set of packages installed using Amazon Linux 2023 container image version: $al_version"
-	else
-		al_description="Amazon Linux $al_tag base container image version: $al_version"
-	fi
 
 	cat >>"$entry_file" <<EOF
 ### $version
-This release includes:
-* Fluent Bit [v${fluent_bit#v}](https://github.com/fluent/fluent-bit/tree/v${fluent_bit#v})
-* Amazon CloudWatch Logs for Fluent Bit ${cw_plugin#v}
-* Amazon Kinesis Streams for Fluent Bit ${kinesis_plugin#v}
-* Amazon Kinesis Firehose for Fluent Bit ${firehose_plugin#v}
-* $al_description
-
-Compared to the previous release, this release adds:
-$commits
-
+* Minimal set of packages installed using Amazon Linux $al_tag container image version: $al_version
 EOF
+	if [[ -n "$commits" ]]; then
+		echo "$commits" >>"$entry_file"
+	fi
+	echo "" >>"$entry_file"
 }
 
 prepend_to_changelog() {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Clean up changelog generation script and restrict GitHub Actions workflows to only run in the original `aws/aws-for-fluent-bit` repository.

- Fix extra blank line in generated changelog entries when there are no new commits since the last release
- Remove unused variables (`fluent_bit`, `cw_plugin`, `kinesis_plugin`, `firehose_plugin`) from `generate_entry()` in `generate_changelog.sh`
- Add `github.repository == 'aws/aws-for-fluent-bit'` guard to `InitiateRelease`, `Post-release merge action`, and `Lint PR` workflows so they don't run in forks

*Issue #, if available:* N/A

### Testing

Manually ran the script locally via `bash scripts/generate_changelog.sh`

Changelog entries:
```
### 2.34.3.20260407
* Minimal set of packages installed using Amazon Linux 2 container image version: 2.0.20260413.0

### 3.2.6
* Minimal set of packages installed using Amazon Linux 2023 container image version: 2023.11.20260413.0
```

`make debug` succeeded: N/A (no build artifacts affected)
Integ tests succeeded: N/A
New tests cover the changes: no

Verified by running `scripts/generate_changelog.sh` manually with no new commits and confirming the extra blank line is no longer present. Workflow YAML changes are syntactically valid.

### Description for the changelog

fix: Clean up changelog generation and restrict GitHub Actions to original repo only

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
