### PR TITLE
enhancement: Rework valgrind image to offer additional options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,14 @@ all: release
 
 # Execute set-cache to turn docker cache back on for faster development.
 DOCKER_BUILD_FLAGS := "--no-cache"
-# Amazon Linux Tag to use for images, will use value if not set
-AL_TAG ?= "2"
-# Fluent Bit version (branch or tag) to checkout, will use value if not set 
-FLB_VERSION ?= "1.9.10"
-# Fluent Bit repository to checkout, will use value if not set
-FLB_REPOSITORY ?= "https://github.com/amazon-contributing/upstream-to-fluent-bit.git"
 # Build Version
-BUILD_VERSION ?= 2
+BUILD_VERSION ?= 3
+# Amazon Linux Tag to use for images, derived from linux.version if not set
+AL_TAG ?= $(shell ./scripts/get_linux_version.sh ${BUILD_VERSION} al-tag)
+# Fluent Bit version (branch or tag) to checkout, derived from linux.version if not set
+FLB_VERSION ?= $(shell ./scripts/get_linux_version.sh ${BUILD_VERSION} fluent-bit)
+# Fluent Bit repository to checkout, derived from linux.version if not set
+FLB_REPOSITORY ?= $(shell ./scripts/get_linux_version.sh ${BUILD_VERSION} flb-repository)
 # AWS for Fluent Bit Version
 AWS_FOR_FLUENT_BIT_VERSION ?= $(shell ./scripts/get_linux_version.sh ${BUILD_VERSION} version)
 # sha256 digest for the OS image

--- a/README.md
+++ b/README.md
@@ -369,35 +369,32 @@ AWS for Fluent Bit can be built locally using the following commands:
 
 You can customize which Amazon Linux base image version is used in the Docker builds. This is useful for testing with different Amazon Linux versions or when you need to match a specific base image version.
 
-The default value is:
-
-- `AL_TAG`: "2" (Amazon Linux 2)
+The default value is derived from `linux.version` based on `BUILD_VERSION` (default: `3`), which resolves to the corresponding `al-tag` (e.g. `2023` for Amazon Linux 2023).
 
 There are two ways to customize this value:
 
-**Method 1: Using environment variables**
+**Method 1: Using environment variables (preferred)**
 
 Set the environment variable when running the make command:
 
 ```bash
-# Use a specific Amazon Linux 2 version
-AL_TAG="2.0.20250623.0" make release
+# Use a specific Amazon Linux version
+AL_TAG="2023.7.20260401" make release
+
+# Build with Amazon Linux 2 (BUILD_VERSION=2)
+BUILD_VERSION=2 make release
 
 # For development builds
-AL_TAG="2.0.20250623.0" make dev
+AL_TAG="2023.7.20260401" make dev
 ```
 
-**Method 2: Updating the Makefile directly**
+**Method 2: Updating `linux.version` directly**
 
-You can also modify the default value in the Makefile:
+To change the default persistently, edit the `linux.version` file at the root of the repository:
 
-1. Open the Makefile in your editor
-2. Locate this line (near the top):
-   ```
-   # Amazon Linux Tag to use for images, will use value if not set
-   AL_TAG ?= "2"
-   ```
-3. Update the value as needed (e.g., change `"2"` to `"2.0.20250623.0"`)
+1. Open `linux.version` in your editor
+2. Locate the entry matching your target `major-version` (e.g. `"3"`)
+3. Update the `al-tag` field as needed
 4. Save the file and run `make release` or `make dev`
 
 The `AL_TAG` variable affects all Docker builds in the Makefile, including:
@@ -411,20 +408,20 @@ The `AL_TAG` variable affects all Docker builds in the Makefile, including:
 
 ##### Customizing Fluent Bit Version and Repository
 
-You can customize which version of Fluent Bit is built and which repository it's sourced from. The default values are:
+You can customize which version of Fluent Bit is built and which repository it's sourced from. The default values are derived from `linux.version` based on `BUILD_VERSION` (default: `3`):
 
-- `FLB_VERSION`: "1.9.10" (can be either a branch name or tag name within the repository)
-- `FLB_REPOSITORY`: "https://github.com/amazon-contributing/upstream-to-fluent-bit.git"
+- `FLB_VERSION`: Resolved from `linux.version` (e.g. `v4.2.2`; can be either a branch name or tag name within the repository)
+- `FLB_REPOSITORY`: Resolved from `linux.version` (e.g. `https://github.com/fluent/fluent-bit.git`)
 
 There are two ways to customize these values:
 
-**Method 1: Using environment variables**
+**Method 1: Using environment variables (preferred)**
 
 Set the environment variables when running the make command:
 
 ```bash
 # Build with a specific Fluent Bit version tag
-FLB_VERSION="2.0.8" make release
+FLB_VERSION="v4.3.0" make release
 
 # Build with a specific branch name
 FLB_VERSION="feature-branch" make release
@@ -432,23 +429,20 @@ FLB_VERSION="feature-branch" make release
 # Build from a different repository
 FLB_VERSION="your-branch" FLB_REPOSITORY="https://github.com/your-username/fluent-bit.git" make release
 
+# Build the v2 configuration (Fluent Bit 1.9.10 on AL2)
+BUILD_VERSION=2 make release
+
 # Combine with dev mode for faster builds with caching
 FLB_VERSION="your-branch" FLB_REPOSITORY="https://github.com/your-username/fluent-bit.git" make dev
 ```
 
-**Method 2: Updating the Makefile directly**
+**Method 2: Updating `linux.version` directly**
 
-You can also modify the default values in the Makefile:
+To change the defaults persistently, edit the `linux.version` file at the root of the repository:
 
-1. Open the Makefile in your editor
-2. Locate these lines (near the compile stage):
-   ```
-   # Fluent Bit version (branch or tag) to checkout, will use value if not set
-   FLB_VERSION ?= "1.9.10"
-   # Fluent Bit repository to checkout, will use value if not set
-   FLB_REPOSITORY ?= "https://github.com/amazon-contributing/upstream-to-fluent-bit.git"
-   ```
-3. Update the values as needed
+1. Open `linux.version` in your editor
+2. Locate the entry matching your target `major-version` (e.g. `"3"`)
+3. Update the `fluent-bit` and/or `flb-repository` fields as needed
 4. Save the file and run `make release` or `make dev`
 
 #### Local integ testing

--- a/docs/valgrind.md
+++ b/docs/valgrind.md
@@ -1,0 +1,82 @@
+# Valgrind Debugging
+
+The `debug-valgrind` image runs Fluent Bit under [Valgrind](https://valgrind.org/) for memory debugging. It supports three modes and optional S3 upload of results.
+
+## Building
+
+```bash
+make debug-valgrind
+```
+
+Defaults are derived from `linux.version` based on `BUILD_VERSION`:
+
+| Variable | Default |
+|----------|---------|
+| `BUILD_VERSION` | `3` |
+| `AL_TAG` | Resolved from `linux.version` (e.g. `2023`) |
+| `FLB_VERSION` | Resolved from `linux.version` (e.g. `v4.2.2`) |
+| `FLB_REPOSITORY` | Resolved from `linux.version` (e.g. `https://github.com/fluent/fluent-bit.git`) |
+
+This produces `amazon/aws-for-fluent-bit:debug-valgrind-al2023`.
+
+To build against Amazon Linux 2 and Fluent Bit 1.9.10:
+
+```bash
+BUILD_VERSION=2 make debug-valgrind
+```
+
+This produces `amazon/aws-for-fluent-bit:debug-valgrind-al2`.
+
+## Configuration
+
+All configuration is via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VALGRIND_MODE` | `memcheck` | `memcheck`, `massif`, or `dhat` |
+| `S3_BUCKET` | *(none)* | S3 bucket for uploading results. If unset, results stay local only |
+| `S3_KEY_PREFIX` | `valgrind-results` | Folder prefix within the bucket |
+| `HOST_NAME` | System hostname | Used in the S3 key path to identify the source pod/container |
+| `SHUTDOWN_TIMEOUT` | `60` | Seconds to wait for valgrind to exit after SIGTERM before SIGKILL |
+
+## How it works
+
+The entrypoint script ([`valgrind_uploader.sh`](../scripts/valgrind_uploader.sh)) launches Fluent Bit under valgrind and waits for a SIGTERM or SIGINT (e.g. container shutdown, pod termination). On signal:
+
+1. Forwards SIGTERM to valgrind so it can write its output
+2. Waits up to `SHUTDOWN_TIMEOUT` seconds for a clean exit
+3. Falls back to SIGKILL if valgrind doesn't exit in time
+4. Logs which output files are available locally
+5. Uploads output files to S3 (if `S3_BUCKET` is set)
+
+If valgrind exits on its own (e.g. Fluent Bit crashes), results are uploaded immediately.
+
+### Modes
+
+Each mode runs a different valgrind tool and produces different output files:
+
+**memcheck** (default) — Leak detection at exit. Tracks every allocation and reports leaks when Fluent Bit shuts down. Writes a detailed report to `/tmp/valgrind.log` including "definitely lost", "possibly lost", and "still reachable" summaries.
+
+**massif** — Heap profiling over time. Takes periodic snapshots of heap usage to show how memory grows. Writes profiling data to `/tmp/massif.out`. Valgrind diagnostics go to stderr (container logs) since massif doesn't support `--log-file`.
+
+**dhat** — Allocation lifetime tracking. Records every allocation's size, lifetime, and call stack to identify short-lived allocations (churn) vs long-lived ones (potential leaks). Writes allocation data to `/tmp/dhat.out` and valgrind diagnostics to `/tmp/valgrind.log`.
+
+## S3 upload path
+
+Results are uploaded to:
+
+```
+s3://{S3_BUCKET}/{S3_KEY_PREFIX}/{HOST_NAME}/{filename}-{YYYYMMDD-HHMMSS}
+```
+
+With defaults, this looks like:
+
+```
+s3://{S3_BUCKET}/valgrind-results/{hostname}/valgrind.log-20260415-031500
+```
+
+## Reading results
+
+- **memcheck**: Review `/tmp/valgrind.log` for leak summaries. Look for "definitely lost" and "possibly lost" blocks.
+- **massif**: Use `ms_print /tmp/massif.out` to visualize heap usage over time, or load into [massif-visualizer](https://github.com/KDE/massif-visualizer).
+- **dhat**: Open `/tmp/dhat.out` in the [DHAT viewer](https://valgrind.org/docs/manual/dh-manual.html#dh-manual.viewer) (bundled with valgrind source) to analyze allocation lifetimes.

--- a/scripts/dockerfiles/runtime/Dockerfile.debug-valgrind
+++ b/scripts/dockerfiles/runtime/Dockerfile.debug-valgrind
@@ -1,5 +1,7 @@
 ARG RUNTIME_IMAGE
 FROM ${RUNTIME_IMAGE}
 
-# Run under valgrind
-CMD valgrind --leak-check=full --error-limit=no /fluent-bit/bin/fluent-bit -e /fluent-bit/firehose.so -e /fluent-bit/cloudwatch.so -e /fluent-bit/kinesis.so -c /fluent-bit/etc/fluent-bit.conf
+COPY ./scripts/valgrind_uploader.sh /usr/local/bin/valgrind_uploader.sh
+RUN chmod +x /usr/local/bin/valgrind_uploader.sh
+
+CMD ["/usr/local/bin/valgrind_uploader.sh"]

--- a/scripts/valgrind_uploader.sh
+++ b/scripts/valgrind_uploader.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# Runs fluent-bit under valgrind (massif, memcheck, or dhat) and uploads results to S3.
+#
+# The script waits for an external SIGTERM/SIGINT (e.g. container shutdown),
+# forwards it to valgrind, waits for valgrind to write its output, then uploads.
+#
+# Env vars:
+#   VALGRIND_MODE      - "memcheck" (default), "massif", or "dhat"
+#   S3_BUCKET          - required for upload
+#   S3_KEY_PREFIX      - S3 folder prefix (default: valgrind-results)
+#   HOST_NAME          - optional, defaults to hostname
+#   SHUTDOWN_TIMEOUT   - max wait for valgrind exit after SIGTERM (default 60)
+
+VALGRIND_MODE="${VALGRIND_MODE:-memcheck}"
+S3_BUCKET="${S3_BUCKET:-}"
+S3_KEY_PREFIX="${S3_KEY_PREFIX:-valgrind-results}"
+HOST_NAME="${HOST_NAME:-$(cat /proc/sys/kernel/hostname)}"
+SHUTDOWN_TIMEOUT="${SHUTDOWN_TIMEOUT:-60}"
+
+VALGRIND_PID=""
+UPLOADED=0
+CAUGHT_SIGNAL=0
+
+OUTPUT_FILES=(/tmp/massif.out /tmp/valgrind.log /tmp/dhat.out)
+FLB_CMD="/fluent-bit/bin/fluent-bit \
+    -e /fluent-bit/firehose.so \
+    -e /fluent-bit/cloudwatch.so \
+    -e /fluent-bit/kinesis.so \
+    -c /fluent-bit/etc/fluent-bit.conf"
+
+# Log with prefix.
+log() {
+    echo "[valgrind_uploader] $*"
+}
+
+# Lists valgrind output files in /tmp.
+print_local_files() {
+    log "Output files available locally:"
+    for f in "${OUTPUT_FILES[@]}"; do
+        [ -f "$f" ] && echo -e "[valgrind_uploader]\t$f"
+    done
+}
+
+# Upload output files to S3. Idempotent.
+upload() {
+    if [ "$UPLOADED" -eq 1 ]; then
+        return
+    fi
+    UPLOADED=1
+
+    print_local_files
+
+    if [ -z "$S3_BUCKET" ]; then
+        log "S3_BUCKET not set, skipping upload"
+        return
+    fi
+
+    local dest="s3://${S3_BUCKET}/${S3_KEY_PREFIX}/${HOST_NAME}"
+    local ts=$(date +%Y%m%d-%H%M%S)
+
+    for f in "${OUTPUT_FILES[@]}"; do
+        if [ -f "$f" ]; then
+            local base=$(basename "$f")
+            log "Uploading $f -> ${dest}/${base}-${ts}"
+            aws s3 cp "$f" "${dest}/${base}-${ts}" --quiet 2>/dev/null && \
+                log "Upload succeeded: ${base}-${ts}" || \
+                log "Upload failed: ${base}-${ts}"
+        fi
+    done
+}
+
+# SIGTERM valgrind, wait up to SHUTDOWN_TIMEOUT, then SIGKILL.
+stop_valgrind() {
+    if [ -z "$VALGRIND_PID" ] || ! kill -0 "$VALGRIND_PID" 2>/dev/null; then
+        return
+    fi
+
+    log "Sending SIGTERM to valgrind (PID $VALGRIND_PID)"
+    kill -TERM "$VALGRIND_PID" 2>/dev/null
+
+    local elapsed=0
+    while kill -0 "$VALGRIND_PID" 2>/dev/null && [ "$elapsed" -lt "$SHUTDOWN_TIMEOUT" ]; do
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+
+    if kill -0 "$VALGRIND_PID" 2>/dev/null; then
+        log "Valgrind did not exit after ${SHUTDOWN_TIMEOUT}s, sending SIGKILL"
+        kill -KILL "$VALGRIND_PID" 2>/dev/null
+        wait "$VALGRIND_PID" 2>/dev/null
+    else
+        wait "$VALGRIND_PID" 2>/dev/null
+        log "Valgrind exited cleanly"
+    fi
+}
+
+# Deferred signal handler — sets flag for the wait loop to act on.
+handle_signal() {
+    log "Caught signal"
+    CAUGHT_SIGNAL=1
+}
+
+# Heap profiling over time. Diagnostics go to stderr (massif doesn't support --log-file).
+start_massif() {
+    valgrind \
+        --tool=massif \
+        --massif-out-file=/tmp/massif.out \
+        --time-unit=ms \
+        --detailed-freq=20 \
+        --max-snapshots=200 \
+        --threshold=0.5 \
+        --stacks=no \
+        --alloc-fn=flb_malloc \
+        --alloc-fn=flb_calloc \
+        --alloc-fn=flb_realloc \
+        --log-fd=2 \
+        `# --pages-as-heap=yes tracks mmap/brk instead of malloc` \
+        $FLB_CMD &
+}
+
+# Allocation lifetime tracking.
+start_dhat() {
+    valgrind \
+        --tool=dhat \
+        --dhat-out-file=/tmp/dhat.out \
+        --num-callers=20 \
+        --log-file=/tmp/valgrind.log \
+        $FLB_CMD &
+}
+
+# Leak detection at exit.
+start_memcheck() {
+    valgrind \
+        --leak-check=full \
+        --show-leak-kinds=definite,possible \
+        --error-limit=no \
+        --track-origins=yes \
+        --verbose \
+        --log-file=/tmp/valgrind.log \
+        --num-callers=30 \
+        --keep-debuginfo=yes \
+        --leak-resolution=high \
+        --freelist-vol=100000000 \
+        $FLB_CMD &
+}
+
+# Block until valgrind exits or a signal arrives.
+# Polls with short sleeps so trapped signals are delivered between iterations.
+wait_for_shutdown() {
+    log "Valgrind running (PID $VALGRIND_PID), waiting for shutdown signal"
+
+    while kill -0 "$VALGRIND_PID" 2>/dev/null; do
+        # Interruptible sleep allows signal delivery between iterations.
+        sleep 1
+
+        if [ "$CAUGHT_SIGNAL" -eq 1 ]; then
+            log "Signal received, initiating shutdown"
+            trap '' SIGTERM SIGINT
+            stop_valgrind
+            upload
+            exit 0
+        fi
+    done
+
+    wait "$VALGRIND_PID" 2>/dev/null
+    log "Valgrind exited on its own (exit code: $?)"
+    upload
+}
+
+# Entry point.
+main() {
+    trap handle_signal SIGTERM SIGINT
+
+    log "Starting in ${VALGRIND_MODE} mode (PID $$)"
+
+    case "$VALGRIND_MODE" in
+        massif)   start_massif ;;
+        dhat)     start_dhat ;;
+        *)        start_memcheck ;;
+    esac
+
+    VALGRIND_PID=$!
+    wait_for_shutdown
+}
+
+main "$@"

--- a/troubleshooting/debugging.md
+++ b/troubleshooting/debugging.md
@@ -747,46 +747,14 @@ Check out the FireLens example for preventing/reducing out of memory exceptions:
 
 #### Testing for real memory leaks using Valgrind
 
-If you do think the cause of your high memory usage is a bug in the code, you can optionally help us out by attempting to profile Fluent Bit for the source of the leak. To do this, use the [Valgrind](https://valgrind.org/) tool.
-
-There are some caveats when using Valgrind. Its a debugging tool, and so it significantly reduces the performance of Fluent Bit. It will consume more memory and CPU and generally be slower when debugging. Therefore, Valgrind images may not be safe to deploy to prod. 
-
-##### Option 1: Build from prod release (Easier but less robust)
-
-Use the Dockerfile below to create a new container image that will invoke your Fluent Bit version using Valgrind. Replace the "builder" image with whatever AWS for Fluent Bit release you are using, in this case, we are testing the latest image. The Dockerfile here will copy the original binary into a new image with Valgrind. Valgrind is a little bit like a mini-VM that will run the Fluent Bit binary and inspect the code at runtime. When you terminate the container, Valgrind will output diagnostic information on shutdown, with summary of memory leaks it detected. This output will allow us to determine which part of the code caused the leak. Valgrind can also be used to find the source of segmentation faults
-
-```
-FROM public.ecr.aws/aws-observability/aws-for-fluent-bit:latest as builder
-
-FROM public.ecr.aws/amazonlinux/amazonlinux@${OS_DIGEST}
-RUN yum upgrade -y \
-    && yum install -y openssl11-devel \
-          cyrus-sasl-devel \
-          pkgconfig \
-          systemd-devel \
-          zlib-devel \
-          libyaml \
-          valgrind \
-          nc && rm -fr /var/cache/yum
-
-COPY --from=builder /fluent-bit /fluent-bit
-CMD valgrind --leak-check=full --error-limit=no /fluent-bit/bin/fluent-bit -c /fluent-bit/etc/fluent-bit.conf
-```
-
-##### Option 2: Debug Build (More robust)
-
-The best option, which is most likely to catch any leak or segfault is to create a fresh build of the image using the `make debug-valgrind` target. This will create a fresh build with debug mode and valgrind support enabled, which gives the highest chance that Valgrind will be able to produce useful diagnostic information about the issue.
-
-1. Check out the git tag for the version that saw the problem
-2. Make sure the `FLB_VERSION` at the top of the `Makefile` is set to the same version as the main Dockerfile for that tag.
-3. Build this dockerfile with the `make debug-valgrind` target. The image will be tagged with the `amazon/aws-for-fluent-bit:debug-valgrind` tag.
+See [docs/valgrind.md](../docs/valgrind.md) for full details on building, configuring, and reading results from the valgrind debug image.
 
 ##### Other Options: Other Debug Builds
 Several debug targets can be built via `make <target-name>`
 Here's a list of debug targets and what they do:
 - `debug` and `debug-s3`: these debug targets upload crash symbols, such as a compressed core dump, stack traces, and crashed Fluent Bit executable to an S3 bucket of your choosing. Symbols are also stored in the `/cores` directory. You can access this via a mounted volume. Stack trace is also printed out on crash. More information on how to use the debug image can be found in: [Tutorial: Debugging Fluent Bit with GDB](tutorials/remote-core-dump/README.md).
 - `debug-fs`: this is a light weight debug target that simply outputs the coredump crash file to the `/cores` directory which can be mounted to by a Docker volume. This image does not upload crash symbols to S3, and does not process stack traces.
-- `debug-valgrind`: this is an image that runs Fluent Bit with valrind to catch leaks and segfaults.
+- `debug-valgrind`: runs Fluent Bit under valgrind. See [docs/valgrind.md](../docs/valgrind.md) for details.
 - `init-debug` and `init-debug-s3`: same as `debug` and `debug-s3` images but with the init process
 - `init-debug-fs`: same as `debug-fs` but with the init process.
 - `main-debug-all`: builds `debug-s3`, `debug-fs`, and `debug-valgrind` efficiently without rebuilding dependencies.


### PR DESCRIPTION
### Summary
The current valgrind image offered limited options for memory debugging. This PR adds a valgrind_uploader script that offers:
- memcheck (default) - leak detection at exit
- dhat - dynamic heap analysis tool, allocation lifetime tracking
- massif - heap profiling over time

These files are written inside the fluent-bit container to the /tmp directory (ie: /tmp/dhat.out)

If S3_BUCKET is provided and the container has access to permissions it will attempt to upload the results to S3 for later review.

This change also updates the notes in debugging.md about valgrind image and creates a new valgrind.md in a docs folder (to try to slim down existing documentation).

### Testing

Custom images running in all 3 modes and validating valgrind output is generated and uploaded to s3.

memcheck
```
[valgrind_uploader] Starting in memcheck mode (PID 1)
[valgrind_uploader] Valgrind running (PID 8), waiting for shutdown signal
...
[valgrind_uploader] Valgrind exited cleanly
[valgrind_uploader] Output files available locally:
[valgrind_uploader]	/tmp/valgrind.log
[valgrind_uploader] Uploading /tmp/valgrind.log -> s3://shared-logs-XXX-us-west-2/valgrind2-eks-cluster/test/valgrind.log-20260415-041105
[valgrind_uploader] Upload succeeded: valgrind.log-20260415-041105
```

dhat
```
[valgrind_uploader] Starting in dhat mode (PID 1)
[valgrind_uploader] Valgrind running (PID 7), waiting for shutdown signal
...
[valgrind_uploader] Valgrind exited cleanly
[valgrind_uploader] Output files available locally:
[valgrind_uploader]	/tmp/valgrind.log
[valgrind_uploader]	/tmp/dhat.out
[valgrind_uploader] Uploading /tmp/valgrind.log -> s3://shared-logs-XXX-us-west-2/valgrind3-eks-cluster/test/valgrind.log-20260415-041412
[valgrind_uploader] Upload succeeded: valgrind.log-20260415-041412
[valgrind_uploader] Uploading /tmp/dhat.out -> s3://shared-logs-XXX-us-west-2/valgrind3-eks-cluster/test/dhat.out-20260415-041412
[valgrind_uploader] Upload succeeded: dhat.out-20260415-041412
```

massif
```
[valgrind_uploader] Starting in massif mode (PID 1)
[valgrind_uploader] Valgrind running (PID 7), waiting for shutdown signal
==7== Massif, a heap profiler
...
==7== 
[valgrind_uploader] Valgrind exited cleanly
[valgrind_uploader] Output files available locally:
[valgrind_uploader]	/tmp/massif.out
[valgrind_uploader] Uploading /tmp/massif.out -> s3://shared-logs-XXX-us-west-2/valgrind1-eks-cluster/test/massif.out-20260415-040807
[valgrind_uploader] Upload succeeded: massif.out-20260415-040807
```

### Description for the changelog
enhancement: Rework valgrind image to offer additional options

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
