### PR TITLE
enhancement: Add signal handling for SIGCONT/stats dump to valgrind_uploader

### DIFF
--- a/docs/valgrind.md
+++ b/docs/valgrind.md
@@ -51,6 +51,23 @@ The entrypoint script ([`valgrind_uploader.sh`](../scripts/valgrind_uploader.sh)
 
 If valgrind exits on its own (e.g. Fluent Bit crashes), results are uploaded immediately.
 
+### Signal handling
+
+| Signal | Behavior |
+|--------|----------|
+| `SIGTERM` / `SIGINT` | Initiates shutdown: forwards SIGTERM to valgrind, waits for exit, uploads results |
+| `SIGCONT` | Forwarded to valgrind, which delivers it to Fluent Bit. Fluent Bit handles SIGCONT by [dumping internal stats](https://docs.fluentbit.io/manual/administration/troubleshooting#dump-internals-and-signal) (input status, storage layer, chunk counts) to stdout. Useful for getting a point-in-time snapshot of Fluent Bit's internal state |
+
+To trigger a stats dump from outside the container:
+
+```bash
+# Docker
+docker kill --signal=SIGCONT <container_id>
+
+# Kubernetes
+kubectl exec -n <namespace> <pod> -- kill -CONT 1
+```
+
 ### Modes
 
 Each mode runs a different valgrind tool and produces different output files:

--- a/scripts/valgrind_uploader.sh
+++ b/scripts/valgrind_uploader.sh
@@ -100,6 +100,13 @@ handle_signal() {
     CAUGHT_SIGNAL=1
 }
 
+# Forward SIGCONT to valgrind so fluent-bit dumps its internal stats.
+handle_sigcont() {
+    if [ -n "$VALGRIND_PID" ] && kill -0 "$VALGRIND_PID" 2>/dev/null; then
+        kill -CONT "$VALGRIND_PID" 2>/dev/null
+    fi
+}
+
 # Heap profiling over time. Diagnostics go to stderr (massif doesn't support --log-file).
 start_massif() {
     valgrind \
@@ -170,6 +177,7 @@ wait_for_shutdown() {
 # Entry point.
 main() {
     trap handle_signal SIGTERM SIGINT
+    trap handle_sigcont SIGCONT
 
     log "Starting in ${VALGRIND_MODE} mode (PID $$)"
 


### PR DESCRIPTION
### Summary
Update docs/uploader to support forwarding SIGCONT from script to valgrind to allow fluent-bit to dump stats - https://docs.fluentbit.io/manual/administration/troubleshooting#dump-internals-and-signal

### Testing
Built and tested AL2/AL2023

`BUILD_VERSION=2 make debug-valgrind`
`make debug-valgrind`

Sample run:
```
docker run amazon/aws-for-fluent-bit:debug-valgrind-al2
docker kill --signal=SIGCONT $(docker ps -q --filter ancestor=amazon/aws-for-fluent-bit:debug-valgrind-al2)
```

Sample output (no data as from local run/no-conf)
```
[2026/04/16 21:15:34] [engine] caught signal (SIGCONT)
[2026/04/16 21:15:34] Fluent Bit Dump

===== Input =====
forward.0 (forward)
│
├─ status
│  └─ overlimit     : no
│     ├─ mem size   : 0b (0 bytes)
│     └─ mem limit  : 0b (0 bytes)
│
├─ tasks
│  ├─ total tasks   : 0
│  ├─ new           : 0
│  ├─ running       : 0
│  └─ size          : 0b (0 bytes)
│
└─ chunks
   └─ total chunks  : 0
      ├─ up chunks  : 0
      ├─ down chunks: 0
      └─ busy chunks: 0
         ├─ size    : 0b (0 bytes)
         └─ size err: 0


===== Storage Layer =====
total chunks     : 0
├─ mem chunks    : 0
└─ fs chunks     : 0
   ├─ up         : 0
   └─ down       : 0
```

### Description for the changelog
enhancement: Add signal handling for SIGCONT/stats dump to valgrind_uploader

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
