### PR TITLE
fix: Remove local image before verification

### DIFF
--- a/buildspec_publish_dockerhub.yml
+++ b/buildspec_publish_dockerhub.yml
@@ -16,6 +16,11 @@ phases:
       - BUILD_VERSION=2 ./scripts/publish.sh cicd-publish dockerhub
       - BUILD_VERSION=3 ./scripts/publish.sh cicd-publish dockerhub
 
+      # Clear locally cached images so verify pulls fresh from DockerHub.
+      # sync-test-images.sh retags ECR images as amazon/aws-for-fluent-bit:*,
+      # which contaminates docker inspect RepoDigests with ECR digests.
+      - docker image rm $(docker image ls -q amazon/aws-for-fluent-bit) 2>/dev/null || true
+
       # Pull the image from dockerhub and verify
       - BUILD_VERSION=2 ./scripts/publish.sh cicd-verify dockerhub
       - BUILD_VERSION=3 ./scripts/publish.sh cicd-verify dockerhub

--- a/buildspec_publish_public_ecr.yml
+++ b/buildspec_publish_public_ecr.yml
@@ -31,6 +31,11 @@ phases:
       - BUILD_VERSION=2 ./scripts/publish.sh cicd-publish public-ecr
       - BUILD_VERSION=3 ./scripts/publish.sh cicd-publish public-ecr
 
+      # Clear locally cached images so verify pulls fresh from DockerHub.
+      # sync-test-images.sh retags ECR images as amazon/aws-for-fluent-bit:*,
+      # which contaminates docker inspect RepoDigests with ECR digests.
+      - docker image rm $(docker image ls -q amazon/aws-for-fluent-bit) 2>/dev/null || true
+
       # Nullify the temporary credentials for the assumed role to publish
       - |
         if [ "${PUBLISH_ROLE_ARN_PUBLIC_ECR}" != "" ]; then


### PR DESCRIPTION

### Summary

#### Problem

The cicd-verify step was intermittently failing with a SHA mismatch error when verifying BUILD_VERSION=3 against DockerHub (and Public ECR). The root cause was a stale local image cache left behind by sync-test-images.sh.

sync-test-images.sh --tag pulls images from the internal ECR test repo and retags them locally as amazon/aws-for-fluent-bit:<tag>. Because these images were originally pulled from ECR, docker inspect --format='{{index .RepoDigests 0}}' returns an ECR-sourced digest (e.g. 906394416424.dkr.ecr.us-west-2.amazonaws.com/...@sha256:57f795...).

When cicd-verify subsequently runs for BUILD_VERSION=3 (PUBLISH_LATEST=false), it compares the stable tag (freshly pulled from DockerHub, returning a DockerHub digest) against the versioned tag (served from the local cache, returning an ECR digest). These digests are structurally different strings even when they represent the same image content, so verify_sha always fails.

#### Fix

Add a docker image rm step between the publish and verify phases in both buildspec_publish_dockerhub.yml and buildspec_publish_public_ecr.yml. This evicts all locally cached amazon/aws-for-fluent-bit:* images, ensuring the verify step pulls fresh from the target registry and compares digests from the same source.

*Issue #, if available:*

### Testing
Locally testing parts of the script and validated codebuild logs referenced local images and not dockerhub variants

### Description for the changelog
fix: Remove local image before verification

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
