### PR TITLE
fix: Make unzip use -qq to control output

### DIFF
--- a/scripts/dockerfiles/runtime/Dockerfile.debug-common
+++ b/scripts/dockerfiles/runtime/Dockerfile.debug-common
@@ -12,7 +12,7 @@ RUN yum clean all \
 
 WORKDIR /var/tmp
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(arch).zip" -o "awscliv2.zip"
-RUN unzip -o awscliv2.zip
+RUN unzip -qq awscliv2.zip
 RUN ./aws/install
 RUN rm awscliv2.zip
 


### PR DESCRIPTION
### Summary
Reduce log bloat when Dockerfile.debug-common unzip's awscli.

### Testing
Built debug image and observed quieter output during Dockerfile.debug-common

```
#10 [ 6/12] RUN unzip -qq awscliv2.zip
#10 DONE 3.5s
```

### Description for the changelog
fix: Make unzip use -qq to control output

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
