### PR TITLE
fix: Fix verification for stable

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -765,10 +765,11 @@ verify_ecr_image_scan() {
 }
 
 verify_dockerhub() {
+	stable=${1}
 	docker_hub_login
 
 	# Verify the image with stable tag
-	if [ $# -eq 1 ] || [ "${PUBLISH_LATEST}" = "false" ]; then
+	if [ -n "$stable" ] && [ "${PUBLISH_LATEST}" = "true" ]; then
 		# Get the image SHA's
 		docker pull amazon/aws-for-fluent-bit:stable
 		sha1=$(docker inspect --format='{{index .RepoDigests 0}}' amazon/aws-for-fluent-bit:stable)
@@ -807,11 +808,12 @@ verify_dockerhub() {
 }
 
 verify_public_ecr() {
+	stable=${1}
 	sleep 60
 	aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/aws-observability || echo "0"
 
 	# Verify the image with stable tag
-	if [ $# -eq 1 ] || [ "${PUBLISH_LATEST}" = "false" ]; then
+	if [ -n "$stable" ] && [ "${PUBLISH_LATEST}" = "true" ]; then
 		# Get the image SHA's
 		docker pull public.ecr.aws/aws-observability/aws-for-fluent-bit:stable
 		sha1=$(docker inspect --format='{{index .RepoDigests 0}}' public.ecr.aws/aws-observability/aws-for-fluent-bit:stable)
@@ -1314,7 +1316,11 @@ if [ "${1}" = "cicd-verify" ]; then
 			verify_ecr ${region} ${classic_regions_account_id} true
 		done
 	elif [ "${2}" = "stable" ]; then
-		if [ "${3}" = "us-west-2" ]; then
+		if [ "${3}" = "dockerhub" ]; then
+			verify_dockerhub stable
+		elif [ "${3}" = "public-ecr" ]; then
+			verify_public_ecr stable
+		else
 			verify_dockerhub stable
 			verify_public_ecr stable
 		fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
  Fixes the verification logic for stable image tags in publish.sh. 

### Implementation
  - Fix stable verification condition — verify_dockerhub and verify_public_ecr previously used [ $# -eq 1 ] || [   
  "${PUBLISH_LATEST}" = "false" ] to decide whether to verify the stable tag. This incorrectly ran stable          
  verification even when the version being published wasn't the latest. Changed to [ -n "$stable" ] && [           
  "${PUBLISH_LATEST}" = "true" ] so stable is only verified when explicitly requested and the version is considered
  latest.                                                                                                          
  - Extract `stable` parameter into a named variable — replaced the fragile $# positional arg check with an        
  explicit stable=${1} variable for readability.                                                                   
  - Fix `cicd-verify stable` dispatch — the old code gated dockerhub/public-ecr verification behind [ "${3}" =     
  "us-west-2" ], which was region-specific and unnecessarily restrictive. Replaced with dispatch on ${3}           
  (dockerhub, public-ecr, or both by default), allowing targeted or combined verification. 

### Testing
<!-- How was this tested?
See https://github.com/aws/aws-for-fluent-bit?tab=readme-ov-file#local-integ-testing
for instructions on how to run integ tests locally.
-->

`make debug` succeeded: <!-- yes|no -->
Integ tests succeeded: <!-- yes|no -->
New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
