### PR TITLE
fix: handle unbound variable for stable parameter in verify_public_ecr and verify_dockerhub

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -765,7 +765,7 @@ verify_ecr_image_scan() {
 }
 
 verify_dockerhub() {
-	stable=${1}
+	stable=${1:-}
 	docker_hub_login
 
 	# Verify the image with stable tag
@@ -808,7 +808,7 @@ verify_dockerhub() {
 }
 
 verify_public_ecr() {
-	stable=${1}
+	stable=${1:-}
 	sleep 60
 	aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/aws-observability || echo "0"
 


### PR DESCRIPTION
### Summary
`publish.sh` runs with `set -euo pipefail`. The `-u` flag causes bash to treat any reference to an unset variable as an error and immediately exit the script.

`verify_public_ecr` and `verify_dockerhub` both assigned their first positional parameter with `stable=${1}`. When either function is called without an argument, `$1` is unset and bash aborts the script with `unbound variable` before the verification logic runs.

Changed `stable=${1}` to `stable=${1:-}` in both functions. The ` :-` default value syntax tells bash to use an empty string if `$1` is unset, satisfying `-u` without changing behavior when the argument is provided.




### Testing
A snippet to test the behavior
```
#!/bin/bash
set -euo pipefail

echo "=== BEFORE fix: stable=\${1} ==="
( set -euo pipefail; stable=${1}; echo "stable=${stable}" ) && echo "OK" || echo "FAILED: unbound variable"

echo ""
echo "=== AFTER fix: stable=\${1:-} ==="
( set -euo pipefail; stable=${1:-}; echo "stable=${stable}" ) && echo "OK: stable is empty string, no error"
```
Output:
```
./snippet.sh            
=== BEFORE fix: stable=${1} ===
./test.sh: line 5: 1: unbound variable
FAILED: unbound variable

=== AFTER fix: stable=${1:-} ===
stable=
OK: stable is empty string, no error
```


### Description for the changelog
fix: handle unbound variable for `stable` parameter in `verify_public_ecr` and `verify_dockerhub`

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
