### PR TITLE
fix: Revert "Fix long build times for AL2023 by setting nofile limit (#1135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,10 @@
 ### 2.34.3.20260515
 * Minimal set of packages installed using Amazon Linux 2 container image version: 2.0.20260511.1
 * fix: handle unbound variable for stable parameter in verify_public_ecr and verify_dockerhub [#1138](https://github.com/aws/aws-for-fluent-bit/pull/1138)
-* enhancement: Fix long build times for AL2023 by setting nofile limit [#1135](https://github.com/aws/aws-for-fluent-bit/pull/1135)
 
 ### 3.3.2
 * Minimal set of packages installed using Amazon Linux 2023 container image version: 2023.11.20260511.1
 * fix: handle unbound variable for stable parameter in verify_public_ecr and verify_dockerhub [#1138](https://github.com/aws/aws-for-fluent-bit/pull/1138)
-* enhancement: Fix long build times for AL2023 by setting nofile limit [#1135](https://github.com/aws/aws-for-fluent-bit/pull/1135)
 
 ### 2.34.3.20260506
 * Minimal set of packages installed using Amazon Linux 2 container image version: 2.0.20260504.0

--- a/scripts/dockerfiles/runtime/Dockerfile.deps-al2023
+++ b/scripts/dockerfiles/runtime/Dockerfile.deps-al2023
@@ -3,8 +3,6 @@ FROM public.ecr.aws/amazonlinux/amazonlinux@${OS_DIGEST} as dependencies
 
 # Create sysroot directory and install minimal runtime dependencies
 RUN mkdir /sysroot && \
-    # Set a distinct ulimit for nofile to avoid long build times - https://github.com/docker/buildx/issues/379
-    ulimit -n 1024000 && \
     dnf install -y https://packages.apache.org/artifactory/arrow/amazon-linux/$(cut -d: -f6 /etc/system-release-cpe)/apache-arrow-release-latest.rpm && \
     # grab install version from apache-arrow-release and extract without periods 22.0.0 --> 2200 to conform with arrow/parquet version libs
     ARROW_VERSION=$(dnf info apache-arrow-release | awk '/^Version/ {split($3, v, "."); printf "%d%02d", v[1], v[2]}') && \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Revert "Fix long build times for AL2023 by setting nofile limit (#1135). The following error is seen on CodeBuild
```
ulimit: open files: cannot modify limit: Operation not permitted
```

*Issue #, if available:*

### Testing
<!-- How was this tested?
See https://github.com/aws/aws-for-fluent-bit?tab=readme-ov-file#local-integ-testing
for instructions on how to run integ tests locally.
-->

`make debug` succeeded: <!-- yes|no -->
Integ tests succeeded: <!-- yes|no -->
New tests cover the changes: <!-- yes|no -->

### Description for the changelog
fix: Revert "Fix long build times for AL2023 by setting nofile limit (#1135)

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
