### PR TITLE
fix: Fixed the verify_dockerhub and verify_public_ecr functions to use the correct reference tag when verifying BUILD_VERSION=3 releases.

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -778,32 +778,30 @@ verify_dockerhub() {
 
 		verify_sha $sha1 $sha2
 	else
-		# Get the image SHA's
-		docker pull amazon/aws-for-fluent-bit:latest
-		sha1=$(docker inspect --format='{{index .RepoDigests 0}}' amazon/aws-for-fluent-bit:latest)
+		# Verify major version tag "3" for BUILD_VERSION=3
+		if [ "$BUILD_VERSION" = "3" ]; then
+			docker pull amazon/aws-for-fluent-bit:3
+			sha1=$(docker inspect --format='{{index .RepoDigests 0}}' amazon/aws-for-fluent-bit:3)
+
+			docker pull amazon/aws-for-fluent-bit:init-3
+			sha1_init=$(docker inspect --format='{{index .RepoDigests 0}}' amazon/aws-for-fluent-bit:init-3)
+		else
+			docker pull amazon/aws-for-fluent-bit:latest
+			sha1=$(docker inspect --format='{{index .RepoDigests 0}}' amazon/aws-for-fluent-bit:latest)
+
+			docker pull amazon/aws-for-fluent-bit:"$init"-latest
+			sha1_init=$(docker inspect --format='{{index .RepoDigests 0}}' amazon/aws-for-fluent-bit:"$init"-latest)
+		fi
+
+		# Get and compare the versioned image tag by SHA
 		docker pull amazon/aws-for-fluent-bit:${AWS_FOR_FLUENT_BIT_VERSION}
 		sha2=$(docker inspect --format='{{index .RepoDigests 0}}' amazon/aws-for-fluent-bit:${AWS_FOR_FLUENT_BIT_VERSION})
-
 		verify_sha $sha1 $sha2
 
-		docker pull amazon/aws-for-fluent-bit:"$init"-latest
-		sha1_init=$(docker inspect --format='{{index .RepoDigests 0}}' amazon/aws-for-fluent-bit:"$init"-latest)
+		# Get and compare the versioned init image tag by SHA
 		docker pull amazon/aws-for-fluent-bit:"$init"-${AWS_FOR_FLUENT_BIT_VERSION}
 		sha2_init=$(docker inspect --format='{{index .RepoDigests 0}}' amazon/aws-for-fluent-bit:"$init"-${AWS_FOR_FLUENT_BIT_VERSION})
 		verify_sha $sha1_init $sha2_init
-
-		# Verify major version tag "3" for BUILD_VERSION=3
-		if [ "$BUILD_VERSION" = "3" ]; then
-			if check_tag_exists "amazon/aws-for-fluent-bit" "3"; then
-				docker pull amazon/aws-for-fluent-bit:3
-				sha_major=$(docker inspect --format='{{index .RepoDigests 0}}' amazon/aws-for-fluent-bit:3)
-				verify_sha $sha2 $sha_major
-
-				docker pull amazon/aws-for-fluent-bit:init-3
-				sha_major_init=$(docker inspect --format='{{index .RepoDigests 0}}' amazon/aws-for-fluent-bit:init-3)
-				verify_sha $sha2_init $sha_major_init
-			fi
-		fi
 	fi
 }
 
@@ -822,33 +820,31 @@ verify_public_ecr() {
 
 		verify_sha $sha1 $sha2
 	else
-		# Get the image SHA's
-		docker pull public.ecr.aws/aws-observability/aws-for-fluent-bit:latest
-		sha1=$(docker inspect --format='{{index .RepoDigests 0}}' public.ecr.aws/aws-observability/aws-for-fluent-bit:latest)
-		docker pull public.ecr.aws/aws-observability/aws-for-fluent-bit:${AWS_FOR_FLUENT_BIT_VERSION}
-		sha2=$(docker inspect --format='{{index .RepoDigests 0}}' public.ecr.aws/aws-observability/aws-for-fluent-bit:${AWS_FOR_FLUENT_BIT_VERSION})
-
-		verify_sha $sha1 $sha2
-
-		docker pull public.ecr.aws/aws-observability/aws-for-fluent-bit:"$init"-latest
-		sha1_init=$(docker inspect --format='{{index .RepoDigests 0}}' public.ecr.aws/aws-observability/aws-for-fluent-bit:"$init"-latest)
-		docker pull public.ecr.aws/aws-observability/aws-for-fluent-bit:"$init"-${AWS_FOR_FLUENT_BIT_VERSION}
-		sha2_init=$(docker inspect --format='{{index .RepoDigests 0}}' public.ecr.aws/aws-observability/aws-for-fluent-bit:"$init"-${AWS_FOR_FLUENT_BIT_VERSION})
-
-		verify_sha $sha1_init $sha2_init
-
 		# Verify major version tag "3" for BUILD_VERSION=3
 		if [ "$BUILD_VERSION" = "3" ]; then
-			if check_tag_exists "public.ecr.aws/aws-observability/aws-for-fluent-bit" "3"; then
-				docker pull public.ecr.aws/aws-observability/aws-for-fluent-bit:3
-				sha_major=$(docker inspect --format='{{index .RepoDigests 0}}' public.ecr.aws/aws-observability/aws-for-fluent-bit:3)
-				verify_sha $sha2 $sha_major
+			docker pull public.ecr.aws/aws-observability/aws-for-fluent-bit:3
+			sha1=$(docker inspect --format='{{index .RepoDigests 0}}' public.ecr.aws/aws-observability/aws-for-fluent-bit:3)
 
-				docker pull public.ecr.aws/aws-observability/aws-for-fluent-bit:init-3
-				sha_major_init=$(docker inspect --format='{{index .RepoDigests 0}}' public.ecr.aws/aws-observability/aws-for-fluent-bit:init-3)
-				verify_sha $sha2_init $sha_major_init
-			fi
+			docker pull public.ecr.aws/aws-observability/aws-for-fluent-bit:init-3
+			sha1_init=$(docker inspect --format='{{index .RepoDigests 0}}' public.ecr.aws/aws-observability/aws-for-fluent-bit:init-3)
+		else
+			docker pull public.ecr.aws/aws-observability/aws-for-fluent-bit:latest
+			sha1=$(docker inspect --format='{{index .RepoDigests 0}}' public.ecr.aws/aws-observability/aws-for-fluent-bit:latest)
+
+			docker pull public.ecr.aws/aws-observability/aws-for-fluent-bit:"$init"-latest
+			sha1_init=$(docker inspect --format='{{index .RepoDigests 0}}' public.ecr.aws/aws-observability/aws-for-fluent-bit:"$init"-latest)
 		fi
+
+		# Get and compare the versioned image tag by SHA
+		docker pull public.ecr.aws/aws-observability/aws-for-fluent-bit:${AWS_FOR_FLUENT_BIT_VERSION}
+		sha2=$(docker inspect --format='{{index .RepoDigests 0}}' public.ecr.aws/aws-observability/aws-for-fluent-bit:${AWS_FOR_FLUENT_BIT_VERSION})
+		verify_sha $sha1 $sha2
+		
+		# Get and compare the versioned init image tag by SHA
+		docker pull public.ecr.aws/aws-observability/aws-for-fluent-bit:"$init"-${AWS_FOR_FLUENT_BIT_VERSION}
+		sha2_init=$(docker inspect --format='{{index .RepoDigests 0}}' public.ecr.aws/aws-observability/aws-for-fluent-bit:"$init"-${AWS_FOR_FLUENT_BIT_VERSION})
+		verify_sha $sha1_init $sha2_init
+
 	fi
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
For BUILD_VERSION=3, the pipeline publishes a :3 major version tag instead of :latest. However, the verification functions were always comparing against :latest, then doing a separate optional check against :3. This meant:
  
1. For BUILD_VERSION=3, comparing against :latest is wrong — that tag points to the BUILD_VERSION=2 image.
2. The :3 tag check was guarded by check_tag_exists, making it a soft/optional verification rather than a hard requirement.

This change will restructure both functions so the reference tag is selected based on BUILD_VERSION:
  
- BUILD_VERSION=3 → verifies against :3 and :init-3
- All others → verifies against :latest and :init-latest

The check_tag_exists guard was also removed, meaning the :3 tag is now expected to exist when verifying a BUILD_VERSION=3 release.

*Issue #, if available:*

### Testing

Manually tested via a separate bash script with the same logic

`make debug` succeeded: <!-- yes|no -->
Integ tests succeeded: <!-- yes|no -->
New tests cover the changes: <!-- yes|no -->

### Description for the changelog
fix: Fixed the verify_dockerhub and verify_public_ecr functions to use the correct reference tag when verifying BUILD_VERSION=3 releases.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
