### PR TITLE
enhancement: Change release frequency to every 15th and 28th of the month

### DIFF
--- a/.github/workflows/initiaterelease.yml
+++ b/.github/workflows/initiaterelease.yml
@@ -3,8 +3,8 @@ name: InitiateRelease
 on:
   workflow_dispatch:
   schedule:
-    # Run at 6PM UTC (10AM PST) M-F
-    - cron: 0 18 * * 1-5
+    # Run at 6PM UTC (10AM PST) on the 15th and 28th of each month
+    - cron: 0 18 15,28 * *
 
 jobs:
   GenerateConfig:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This PR changes the release kickoff frequency to every 15th and 28th of the month to be compliant with internal process.

*Issue #, if available:*

### Testing
<!-- How was this tested?
See https://github.com/aws/aws-for-fluent-bit?tab=readme-ov-file#local-integ-testing
for instructions on how to run integ tests locally.
-->

`make debug` succeeded: <!-- yes|no -->
Integ tests succeeded: <!-- yes|no -->
New tests cover the changes: <!-- yes|no -->

### Description for the changelog

enhancement: Change release frequency to every 15th and 28th of the month

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
