### PR TITLE
fix: Suppress AL2 EOL critical finding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,9 @@
 
 ### 2.34.3.20260702
 * Minimal set of packages installed using Amazon Linux 2 container image version: 2.0.20260629.0
-* fix: Clean up unnecessary post kickoff github workflow [#1169](https://github.com/aws/aws-for-fluent-bit/pull/1169)
 
 ### 3.4.6
 * Minimal set of packages installed using Amazon Linux 2023 container image version: 2023.12.20260629.0
-* fix: Clean up unnecessary post kickoff github workflow [#1169](https://github.com/aws/aws-for-fluent-bit/pull/1169)
 
 ### 2.34.3.20260629
 * Minimal set of packages installed using Amazon Linux 2 container image version: 2.0.20260622.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ### 2.34.3.20260702
 * Minimal set of packages installed using Amazon Linux 2 container image version: 2.0.20260629.0
+* fix: Clean up unnecessary post kickoff github workflow [#1169](https://github.com/aws/aws-for-fluent-bit/pull/1169)
 
 ### 3.4.6
 * Minimal set of packages installed using Amazon Linux 2023 container image version: 2023.12.20260629.0
+* fix: Clean up unnecessary post kickoff github workflow [#1169](https://github.com/aws/aws-for-fluent-bit/pull/1169)
 
 ### 2.34.3.20260629
 * Minimal set of packages installed using Amazon Linux 2 container image version: 2.0.20260622.1

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -741,7 +741,7 @@ verify_ecr_image_scan() {
 			max_stability_attempts=10
 			stability_attempt=0
 			while [ $stability_attempt -lt $max_stability_attempts ]; do
-				findings=$(aws inspector2 list-findings --max-results 1 --filter-criteria '{"ecrImageRepositoryName":[{"comparison":"EQUALS","value":"'${repo_uri}'"}],"ecrImageTags":[{"comparison":"EQUALS","value":"'${tag}'"}],"severity":[{"comparison":"EQUALS","value":"HIGH"},{"comparison":"EQUALS","value":"CRITICAL"}]}' --region ${region})
+				findings=$(aws inspector2 list-findings --max-results 1 --filter-criteria '{"ecrImageRepositoryName":[{"comparison":"EQUALS","value":"'${repo_uri}'"}],"ecrImageTags":[{"comparison":"EQUALS","value":"'${tag}'"}],"severity":[{"comparison":"EQUALS","value":"HIGH"},{"comparison":"EQUALS","value":"CRITICAL"}],"vulnerabilityId":[{"comparison":"NOT_EQUALS","value":"IN-DISCONTINUED-001"}]}' --region ${region})
 				vulnerability=$(echo "$findings" | jq '.findings | length')
 				if [ $vulnerability -gt 0 ]; then
 					echo "Uploaded image ${tag} has HIGH/CRITICAL vulnerabilities."


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
AL2 is EOL and this is generating a critical finding - `IN-DISCONTINUED-001 — Platform End Of Life`

This breaks the image build and CI/CD workflow, as this critical finding stops the builds from going through to testing stage.

Suppressing this finding in inspector.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->
Fix: Suppress AL2 EOL critical finding

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
