### PR TITLE
fix: use merge time for changelog release boundary

### DIFF
--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -60,8 +60,7 @@ get_changes_since_last_release() {
 		--limit 30 \
 		--json mergedAt,headRefName \
 		--jq '[.[]
-			| select(.headRefName | test("^release-"))
-			| select(.mergedAt != null)]
+			| select(.headRefName | test("^release-"))]
 			| sort_by(.mergedAt) | last | .mergedAt' 2>/dev/null || true)
 
 	if [ -z "$last_release_merged_at" ] || [ "$last_release_merged_at" = "null" ]; then

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -47,14 +47,22 @@ get_version_info() {
 # Get PR titles merged since the last "Release XXXX" commit via the GitHub CLI (gh) to query merged PRs by date
 get_changes_since_last_release() {
 	local last_release_merged_at
+	# Boundary = merge time of the most-recently-merged release PR.
+	# GitHub search cannot sort by merge time (no sort:merged), and sort:updated
+	# floats stale release PRs (old branches deleted/cross-referenced long after
+	# they merged) to the top, producing a far-too-early boundary. Fetch a window
+	# of release PRs and pick the max mergedAt client-side.
 	last_release_merged_at=$(gh pr list \
 		--repo "$REPO" \
 		--state merged \
 		--base mainline \
-		--search "head:release- sort:updated-desc" \
-		--limit 1 \
-		--json mergedAt \
-		--jq '.[0].mergedAt' 2>/dev/null || true)
+		--search "head:release-" \
+		--limit 30 \
+		--json mergedAt,headRefName \
+		--jq '[.[]
+			| select(.headRefName | test("^release-"))
+			| select(.mergedAt != null)]
+			| sort_by(.mergedAt) | last | .mergedAt' 2>/dev/null || true)
 
 	if [ -z "$last_release_merged_at" ] || [ "$last_release_merged_at" = "null" ]; then
 		echo "WARNING: Could not find last release PR merge timestamp" >&2
@@ -69,7 +77,7 @@ get_changes_since_last_release() {
 		--repo "$REPO" \
 		--base mainline \
 		--state merged \
-		--search "merged:>=${last_release_merged_at}" \
+		--search "merged:>${last_release_merged_at}" \
 		--json title,number,mergedAt \
 		--jq '.[] | select(.title | test("^(stable:|Release \\d)"; "i") | not) | "* \(.title) [#\(.number)](https://github.com/'"$REPO"'/pull/\(.number))"' \
 		2>/dev/null || true)

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -48,15 +48,17 @@ get_version_info() {
 get_changes_since_last_release() {
 	local last_release_merged_at
 	# Boundary = merge time of the most-recently-merged release PR.
-	# GitHub search cannot sort by merge time (no sort:merged), and sort:updated
-	# floats stale release PRs (old branches deleted/cross-referenced long after
-	# they merged) to the top, producing a far-too-early boundary. Fetch a window
-	# of release PRs and pick the max mergedAt client-side.
+	# GitHub search has no sort:merged, so we can't grab the latest-merged release
+	# PR directly with --limit 1 (sort:updated floats stale release PRs whose
+	# branches were deleted/cross-referenced long after merge to the top, giving a
+	# far-too-early boundary). Instead fetch a window of recent release PRs
+	# (sort:updated-desc keeps the window near the head) and pick max mergedAt
+	# client-side, which is correct regardless of GitHub's ordering within the window.
 	last_release_merged_at=$(gh pr list \
 		--repo "$REPO" \
 		--state merged \
 		--base mainline \
-		--search "head:release-" \
+		--search "head:release- sort:updated-desc" \
 		--limit 30 \
 		--json mergedAt,headRefName \
 		--jq '[.[]


### PR DESCRIPTION
## What

`get_changes_since_last_release` in `scripts/generate_changelog.sh` computed the "last release" boundary with:

```
--search "head:release- sort:updated-desc" --limit 1
```

`sort:updated-desc` orders by last-touched time, not merge time. An old release PR whose branch was later deleted or cross-referenced floats to the top and sets the boundary to its (stale) `mergedAt`. In the 20260720 release this selected PR #979 (merged 2025-08-13, updated 2026-07-13), pushing the boundary ~11 months too early and sweeping already-shipped PRs (#1107–#1173) into the new entry.

## Fix

GitHub search has no `sort:merged`, so fetch a window of release PRs with `sort:updated-desc` and pick the max `mergedAt` client-side. Also tighten `merged:>=` to `merged:>` so the boundary release PR itself is excluded.

## Testing

Ran the script against the 20260720 release state:
- Before: boundary `2025-08-13`, 3.4.9 entry had 19 bullets (#1107–#1176).
- After: boundary `2026-07-13T20:10:43Z` (#1175), 3.4.9 entry has 2 bullets (AL package line + #1176) — the only PR merged since the last release.

The corresponding CHANGELOG.md correction for the 20260720 release is in PR #1177.
