### PR TITLE
fix: tighten file permissions in openFile from 0700 to 0600

### DIFF
--- a/init/fluent_bit_init_process.go
+++ b/init/fluent_bit_init_process.go
@@ -431,7 +431,7 @@ func createFile(filePath string, AutoClose bool) *os.File {
 }
 
 func openFile(filePath string) *os.File {
-	file, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, 0700)
+	file, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
 		logrus.Errorln(err)
 		logrus.Fatalf("[FluentBit Init Process] Unable to read %s\n", filePath)


### PR DESCRIPTION
### Summary
The perm argument in os.OpenFile is only applied when O_CREATE is set (https://man7.org/linux/man-pages/man2/open.2.html, https://pkg.go.dev/os#OpenFile) . Since we open with O_APPEND|O_WRONLY only, this is a no-op change, but 0600 is a more appropriate semantic value for a private file. Note that 0600 is still ignored, but this change is just for code hygiene.
  
### Testing
<!-- How was this tested?
See https://github.com/aws/aws-for-fluent-bit?tab=readme-ov-file#local-integ-testing
for instructions on how to run integ tests locally.
-->
  
`make debug` succeeded: yes
Integ tests succeeded: N/A (no behavioral change — perm is ignored without O_CREATE)
New tests cover the changes: no (existing tests pass; the parameter is a no-op)
  
  ### Description for the changelog
  <!--
  Write a short (one line) summary that describes the changes in this
  pull request for inclusion in the changelog.
  -->
  
fix: Tighten unused file permission in `openFile()` from 0700 to 0600.
  
### Licensing
  
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.