### PR TITLE
enhancement: update fluent-bit version to 5.1.0

### DIFF
--- a/linux.version
+++ b/linux.version
@@ -25,7 +25,7 @@
       "latest": "false",
       "build": "1",
       "fluent-bit": "v5.0.9",
-      "release-fluent-bit": "v5.0.9",
+      "release-fluent-bit": "v5.1.0",
       "kinesis-plugin": "v1.10.4",
       "firehose-plugin": "v1.7.3",
       "cloudwatch-plugin": "v1.9.5",


### PR DESCRIPTION
### Summary

Update `release-fluent-bit` version to `v5.1.0` in `linux.version` for the v3 image.

Upstream diff (current consumed version -> new version): [fluent/fluent-bit@v5.0.9...v5.1.0](https://github.com/fluent/fluent-bit/compare/v5.0.9...v5.1.0)

Release notes:
- 5.1.0: https://fluentbit.io/announcements/v5.1.0/ , https://github.com/fluent/fluent-bit/releases/tag/v5.1.0

Qualified via ECS FireLens stability tests (6-day run): 285/285 tasks survived, memory flat, disk growth identical to the previously-qualified v5.0.9 baseline. v5.1.0 also fixes memory leaks reported against the v5.0 series ([fluent/fluent-bit#11846](https://github.com/fluent/fluent-bit/issues/11846)).

### Key changes

AWS output plugins:
- out_s3: add columnar `format=arrow` / `format=parquet` output, plus a new columnar compression API for arrow/parquet
- out_s3: require exact match for `log_key` (:warning: behavior change for configs relying on loose matching)
- out_kafka: resolve remote Avro schema from a schema registry
- signv4: plug memory leak on exception paths
- FIPS: new FIPS mode (engine/config/CLI verification); out_s3 safe guard and out_azure_blob blocks MD5 when FIPS is enabled

Stability / crash fixes:
- filter_kubernetes: plug memory leaks on exceptions and fix SEGV on pod-association enablement
- in_kubernetes_events: fix OOB reads from non-NUL-terminated msgpack strings; tighten timestamp/uint64 parsing
- oauth2: fix request body ownership on allocation failure
- coro: increase default stack headroom and fix an uninitialized coro stack
- networking: per-connection I/O state with downstream event coroutines (in_forward TLS and plain TCP migrated)

Other changes:
- new out_gcs output plugin
- out_file: file rotation support
- engine: adaptive flushing intervals
- plugin aliases across input/output/filter/processor
- DTLS support (out_syslog) and HTTPS proxy (TLS-in-TLS) support
- pause/resume callbacks for in_http, in_opentelemetry, in_elasticsearch, in_splunk, in_prometheus_remote_write

### Description for the changelog

enhancement: update fluent-bit version to 5.1.0

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
