### PR TITLE
Revert "Release 20260817 (#1193)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-### 3.5.0
-* enhancement: update fluent-bit version to 5.1.0 - [#1192](https://github.com/aws/aws-for-fluent-bit/pull/1192)
-
 ### 2.34.3.20260805
 * Minimal set of packages installed using Amazon Linux 2 container image version: 2.0.20260803.1
 

--- a/linux.version
+++ b/linux.version
@@ -14,17 +14,17 @@
       "al-tag": "2",
       "os-digest": "sha256:3ad6628ec681ddbac364a2c4ff87b81082982eb3d7f7031ced9e6268bfab6784",
       "flb-repository": "https://github.com/amazon-contributing/upstream-to-fluent-bit.git",
-      "publish": "false"
+      "publish": "true"
     }
   },
   {
     "linux": {
       "major-version": "3",
-      "version": "3.5.0",
-      "release-version": "3.5.0",
+      "version": "3.4.13",
+      "release-version": "3.4.13",
       "latest": "false",
       "build": "1",
-      "fluent-bit": "v5.1.0",
+      "fluent-bit": "v5.0.9",
       "release-fluent-bit": "v5.1.0",
       "kinesis-plugin": "v1.10.4",
       "firehose-plugin": "v1.7.3",

--- a/linux.version
+++ b/linux.version
@@ -25,7 +25,7 @@
       "latest": "false",
       "build": "1",
       "fluent-bit": "v5.0.9",
-      "release-fluent-bit": "v5.1.0",
+      "release-fluent-bit": "v5.0.9",
       "kinesis-plugin": "v1.10.4",
       "firehose-plugin": "v1.7.3",
       "cloudwatch-plugin": "v1.9.5",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/aws-for-fluent-bit/blob/mainline/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
This reverts commit 6ef0c09138ec1f64b618b279948223e954505dfd.

Fluent Bit v5.1.0 introduced a config-parse regression so reverting the bump. This commit sets the branch back to the state before #1192. Diff can be seen [here](https://github.com/aws/aws-for-fluent-bit/compare/4656228...revert-1193-fluentbit-v510).

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
