### PR TITLE
Create parse-json-healthcheck configuration file

### DIFF
--- a/configs/parse-json-healthcheck
+++ b/configs/parse-json-healthcheck
@@ -18,4 +18,3 @@
     Key_Name     log
     Parser       json
     Reserve_Data True
-    

--- a/configs/parse-json-healthcheck
+++ b/configs/parse-json-healthcheck
@@ -5,8 +5,9 @@
     HTTP_Server            On
     HTTP_Listen            0.0.0.0
     HTTP_Port              2020
-# https://docs.fluentbit.io/manual/administration/monitoring#health-check-for-fluent-bit
+    # https://docs.fluentbit.io/manual/administration/monitoring#health-check-for-fluent-bit
     Health_Check           On
+    # customize error and retry thresholds and evaluation period as desired
     HC_Errors_Count        5
     HC_Retry_Failure_Count 5
     HC_Period              5

--- a/configs/parse-json-healthcheck
+++ b/configs/parse-json-healthcheck
@@ -3,8 +3,9 @@
     Flush                  1
     Grace                  30
     HTTP_Server            On
-    HTTP_Listen            127.0.0.1
+    HTTP_Listen            0.0.0.0
     HTTP_Port              2020
+# https://docs.fluentbit.io/manual/administration/monitoring#health-check-for-fluent-bit
     Health_Check           On
     HC_Errors_Count        5
     HC_Retry_Failure_Count 5

--- a/configs/parse-json-healthcheck
+++ b/configs/parse-json-healthcheck
@@ -1,0 +1,19 @@
+[SERVICE]
+    Parsers_File           /fluent-bit/parsers/parsers.conf
+    Flush                  1
+    Grace                  30
+    HTTP_Server            On
+    HTTP_Listen            127.0.0.1
+    HTTP_Port              2020
+    Health_Check           On
+    HC_Errors_Count        5
+    HC_Retry_Failure_Count 5
+    HC_Period              5
+
+[FILTER]
+    Name         parser
+    Match        *
+    Key_Name     log
+    Parser       json
+    Reserve_Data True
+    

--- a/scripts/dockerfiles/build/Dockerfile.build-common
+++ b/scripts/dockerfiles/build/Dockerfile.build-common
@@ -27,6 +27,7 @@ ADD configs/output-metrics-healthcheck.conf /fluent-bit/configs/
 ADD configs/plugin-metrics-to-cloudwatch.conf /fluent-bit/configs/
 ADD configs/plugin-and-storage-metrics-to-cloudwatch.conf /fluent-bit/configs/
 ADD configs/plugin-metrics-parser.conf /fluent-bit/configs/
+ADD configs/parse-json-healthcheck /fluent-bit/configs/
 
 # Get Fluent Bit source code
 ARG FLB_VERSION=1.9.10


### PR DESCRIPTION
### Summary

Configuration for simultaneously allow:
- HTTP health check server on port 2020 (/api/v1/health)
- JSON log parsing via the built-in json parser

### Testing

Tested in our company as a custom configuration

`make debug` succeeded: <!-- yes|no -->
Integ tests succeeded: <!-- yes|no -->
New tests cover the changes: <!-- yes|no -->

### Description for the changelog

Configuration for both HTTP health check server and JSON log parsing

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
